### PR TITLE
Use CSS variables as single color source

### DIFF
--- a/src/colors.ts
+++ b/src/colors.ts
@@ -1,32 +1,31 @@
-// Auto-generiert: Farbcodes aus dem Projekt
-// Benennung nach Vorkommen und Zweck
+// Automatisch generierte Farbcodes – Werte werden ausschließlich in colors.css gepflegt
+// und hier als CSS-Variablen referenziert, damit die Farbdefinition nur einmal existiert.
 
-export const COLOR_DARK_BG = '#333333';
-export const COLOR_PANEL_BG = '#23272b';
-export const COLOR_WHITE = '#fff';
-export const COLOR_BLACK = '#111';
-export const COLOR_ACCENT = '#ffa726';
-//export const COLOR_ACCENT = '#ffa726';
-export const COLOR_BREW_BG = '#404040';
-export const COLOR_LIGHT_TEXT = '#eeeeee';
-export const COLOR_INPUT_BG = '#ffffff';
-export const COLOR_INPUT_BORDER = '#404040';
-export const COLOR_INPUT_BG2 = '#f0f0f0';
-export const COLOR_INPUT_BG3 = '#ccc6c6';
+export const COLOR_DARK_BG = 'var(--color-dark-bg)';
+export const COLOR_PANEL_BG = 'var(--color-panel-bg)';
+export const COLOR_WHITE = 'var(--color-white)';
+export const COLOR_BLACK = 'var(--color-black)';
+export const COLOR_ACCENT = 'var(--color-accent)';
+export const COLOR_BREW_BG = 'var(--color-brew-bg)';
+export const COLOR_LIGHT_TEXT = 'var(--color-light-text)';
+export const COLOR_INPUT_BG = 'var(--color-input-bg)';
+export const COLOR_INPUT_BORDER = 'var(--color-input-border)';
+export const COLOR_INPUT_BG2 = 'var(--color-input-bg2)';
+export const COLOR_INPUT_BG3 = 'var(--color-input-bg3)';
 
-export const SHADOW_PRIMARY = 'rgba(0,0,0,0.04)';
-export const SHADOW_SECONDARY = 'rgba(0,0,0,0.10)';
-export const SHADOW_PANEL = 'rgba(25, 118, 210, 0.18)';
-export const SHADOW_PANEL2 = 'rgba(0,0,0,0.18)';
-export const SHADOW_GOLD = 'rgba(184,134,11,0.08)';
-export const SHADOW_GOLD_LIGHT = 'rgba(184,134,11,0.06)';
-export const SHADOW_ORANGE = 'rgba(255,140,0,0.4)';
-export const BG_TRANSPARENT_BLACK = 'rgba(0, 0, 0, 0.25)';
-export const BG_TRANSPARENT_ORANGE = 'rgba(255, 165, 0, 0.25)';
-export const BG_TRANSPARENT_RED = 'rgba(255, 0, 0, 0.25)';
-export const BORDER_TRANSPARENT = 'rgba(0, 0, 0, 0.12)';
-export const SHADOW_WATER = 'rgba(0, 0, 0, 0.5)';
-export const SHADOW_KNOB_BLUE = 'rgba(0, 0, 255, 0.7)';
-export const SHADOW_KNOB_RED = 'rgba(255, 0, 0, 0.7)';
-export const SHADOW_KNOB_BLACK = 'rgba(0, 0, 0, 0.7)';
+export const SHADOW_PRIMARY = 'var(--shadow-primary)';
+export const SHADOW_SECONDARY = 'var(--shadow-secondary)';
+export const SHADOW_PANEL = 'var(--shadow-panel)';
+export const SHADOW_PANEL2 = 'var(--shadow-panel2)';
+export const SHADOW_GOLD = 'var(--shadow-gold)';
+export const SHADOW_GOLD_LIGHT = 'var(--shadow-gold-light)';
+export const SHADOW_ORANGE = 'var(--shadow-orange)';
+export const BG_TRANSPARENT_BLACK = 'var(--bg-transparent-black)';
+export const BG_TRANSPARENT_ORANGE = 'var(--bg-transparent-orange)';
+export const BG_TRANSPARENT_RED = 'var(--bg-transparent-red)';
+export const BORDER_TRANSPARENT = 'var(--border-transparent)';
+export const SHADOW_WATER = 'var(--shadow-water)';
+export const SHADOW_KNOB_BLUE = 'var(--shadow-knob-blue)';
+export const SHADOW_KNOB_RED = 'var(--shadow-knob-red)';
+export const SHADOW_KNOB_BLACK = 'var(--shadow-knob-black)';
 


### PR DESCRIPTION
## Summary
- reference color tokens via CSS variables so values live in one place
- keep colors.ts exports aligned with colors.css definitions

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69392d8c5ea8832fbb879151552afb3c)