### PR TITLE
Initialize theme on startup

### DIFF
--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -10,6 +10,7 @@ import {WaterStatus} from "../components/Controlls/WaterControll/WaterControl";
 import {FinishedBrew} from "../model/FinishedBrew";
 import {BackendAvailable} from "../reducers/productionReducer";
 import {scalingValues} from "../utils/BeerScaler/ScalingBeerRecipe";
+import { ThemeName, setTheme as applyAndStoreTheme } from "../utils/theme";
 
 export namespace BeerActions {
 
@@ -411,6 +412,7 @@ export namespace ApplicationActions {
         OPEN_ERROR_DIALOG = 'ApplicationActions.OPEN_ERROR_DIALOG',
         SET_MESSAGE = 'ApplicationActions.SET_MESSAGE',
         REMOVE_MESSAGE = 'ApplicationActions.REMOVE_MESSAGE',
+        SET_THEME = 'ApplicationActions.SET_THEME',
     }
 
     export interface SetView {
@@ -438,12 +440,18 @@ export namespace ApplicationActions {
         readonly type: ActionTypes.REMOVE_MESSAGE
     }
 
+    export interface SetTheme {
+        readonly type: ActionTypes.SET_THEME
+        payload: { theme: ThemeName }
+    }
+
     export type AllApplicationActions =
 
         SetView |
         OpenDialog |
         SetMessage |
-        RemoveMessage;
+        RemoveMessage |
+        SetTheme;
 
     export function setViewState(aView: Views): SetView {
         return {
@@ -470,6 +478,15 @@ export namespace ApplicationActions {
         return {
             type: ActionTypes.REMOVE_MESSAGE
         }
+    }
+
+    export function setTheme(theme: ThemeName): SetTheme {
+        applyAndStoreTheme(theme);
+
+        return {
+            type: ActionTypes.SET_THEME,
+            payload: { theme },
+        };
     }
 }
 export namespace ProductionActions {

--- a/src/colors.css
+++ b/src/colors.css
@@ -29,3 +29,35 @@
   --shadow-knob-black: rgba(0, 0, 0, 0.7);
 }
 
+/* Alternative Dark-Mode-Palette */
+:root.theme-dark-alt,
+:root[data-theme="dark-alt"] {
+  --color-dark-bg: #0f1724;
+  --color-panel-bg: #131b2a;
+  --color-white: #e8edf5;
+  --color-black: #05070d;
+  --color-accent: #8ab4f8;
+  --color-brew-bg: #0b1220;
+  --color-light-text: #d6def0;
+  --color-input-bg: #1f2a3d;
+  --color-input-border: #3c4a64;
+  --color-input-bg2: #23314a;
+  --color-input-bg3: #2e3c59;
+
+  --shadow-primary: rgba(4, 12, 26, 0.24);
+  --shadow-secondary: rgba(4, 12, 26, 0.36);
+  --shadow-panel: rgba(138, 180, 248, 0.22);
+  --shadow-panel2: rgba(0, 0, 0, 0.3);
+  --shadow-gold: rgba(255, 214, 102, 0.12);
+  --shadow-gold-light: rgba(255, 214, 102, 0.1);
+  --shadow-orange: rgba(255, 180, 112, 0.38);
+  --bg-transparent-black: rgba(5, 7, 13, 0.55);
+  --bg-transparent-orange: rgba(255, 180, 112, 0.28);
+  --bg-transparent-red: rgba(255, 121, 121, 0.28);
+  --border-transparent: rgba(255, 255, 255, 0.08);
+  --shadow-water: rgba(122, 183, 255, 0.5);
+  --shadow-knob-blue: rgba(138, 180, 248, 0.7);
+  --shadow-knob-red: rgba(255, 121, 121, 0.7);
+  --shadow-knob-black: rgba(5, 7, 13, 0.7);
+}
+

--- a/src/containers/MainView/Header/Header.css
+++ b/src/containers/MainView/Header/Header.css
@@ -14,6 +14,29 @@
   margin-right: auto;
 }
 
+.theme-toggle {
+  margin-left: 1rem;
+  padding: 0.5rem 0.75rem;
+  border-radius: 0.75rem;
+  border: 1px solid var(--color-input-border);
+  background: var(--color-input-bg2);
+  color: var(--color-black);
+  font-weight: 600;
+  cursor: pointer;
+  box-shadow: 0 1px 2px var(--shadow-primary);
+  transition: transform 0.1s ease, box-shadow 0.1s ease;
+}
+
+.theme-toggle:hover {
+  box-shadow: 0 3px 8px var(--shadow-secondary);
+  transform: translateY(-1px);
+}
+
+.theme-toggle:active {
+  transform: translateY(0);
+  box-shadow: 0 1px 2px var(--shadow-secondary) inset;
+}
+
 .header-status {
   display: flex;
   flex-direction: row;

--- a/src/containers/MainView/Header/Header.tsx
+++ b/src/containers/MainView/Header/Header.tsx
@@ -5,6 +5,7 @@ import {Views} from "../../../enums/eViews";
 import {ApplicationActions, BeerActions} from "../../../actions/actions";
 import setViewState = ApplicationActions.setViewState;
 import StatusDisplay from './StatusDisplay';
+import { getActiveTheme, setTheme, ThemeName } from '../../../utils/theme';
 
 
 
@@ -19,6 +20,7 @@ interface HeaderProps {
 interface HeaderState {
     currentTime: string;
     currentDate: string;
+    theme: ThemeName;
 }
 
 class Header extends React.Component<HeaderProps, HeaderState> {
@@ -26,10 +28,11 @@ class Header extends React.Component<HeaderProps, HeaderState> {
 
     constructor(props: HeaderProps) {
         super(props);
-        this.state = {
-            currentTime: this.getCurrentTimeString(),
-            currentDate: this.getCurrentDateString(),
-        };
+            this.state = {
+                currentTime: this.getCurrentTimeString(),
+                currentDate: this.getCurrentDateString(),
+                theme: getActiveTheme(),
+            };
     }
 
     componentDidMount() {
@@ -65,14 +68,24 @@ class Header extends React.Component<HeaderProps, HeaderState> {
         return `icon ${this.props.currentView === view ? 'active' : ''}`;
     }
 
+    toggleTheme = () => {
+        const nextTheme: ThemeName = this.state.theme === 'dark-alt' ? 'default' : 'dark-alt';
+        setTheme(nextTheme);
+        this.setState({ theme: nextTheme });
+    }
+
     render() {
        const { messages = [] , removeAllMessages, backendStatus} = this.props; // Default-Wert für messages ist ein leeres Array
+       const { theme } = this.state;
 
         return (
             <div className="Header">
                 <div className="header-left">
                   <h1>Brauhaus</h1>
                 </div>
+                <button className="theme-toggle" onClick={this.toggleTheme} type="button">
+                  {theme === 'dark-alt' ? 'Helles Theme' : 'Dunkles Theme'}
+                </button>
                 <div className="icons-container">
                     <img
                         src="beer.png"

--- a/src/containers/MainView/Header/Header.tsx
+++ b/src/containers/MainView/Header/Header.tsx
@@ -5,7 +5,7 @@ import {Views} from "../../../enums/eViews";
 import {ApplicationActions, BeerActions} from "../../../actions/actions";
 import setViewState = ApplicationActions.setViewState;
 import StatusDisplay from './StatusDisplay';
-import { getActiveTheme, setTheme, ThemeName } from '../../../utils/theme';
+import { ThemeName } from '../../../utils/theme';
 
 
 
@@ -15,12 +15,13 @@ interface HeaderProps {
     messages?: string[];
     removeAllMessages: () => void;
     backendStatus: boolean;
+    theme: ThemeName;
+    setTheme: (theme: ThemeName) => void;
 }
 
 interface HeaderState {
     currentTime: string;
     currentDate: string;
-    theme: ThemeName;
 }
 
 class Header extends React.Component<HeaderProps, HeaderState> {
@@ -31,7 +32,6 @@ class Header extends React.Component<HeaderProps, HeaderState> {
             this.state = {
                 currentTime: this.getCurrentTimeString(),
                 currentDate: this.getCurrentDateString(),
-                theme: getActiveTheme(),
             };
     }
 
@@ -69,14 +69,12 @@ class Header extends React.Component<HeaderProps, HeaderState> {
     }
 
     toggleTheme = () => {
-        const nextTheme: ThemeName = this.state.theme === 'dark-alt' ? 'default' : 'dark-alt';
-        setTheme(nextTheme);
-        this.setState({ theme: nextTheme });
+        const nextTheme: ThemeName = this.props.theme === 'dark-alt' ? 'default' : 'dark-alt';
+        this.props.setTheme(nextTheme);
     }
 
     render() {
-       const { messages = [] , removeAllMessages, backendStatus} = this.props; // Default-Wert für messages ist ein leeres Array
-       const { theme } = this.state;
+       const { messages = [] , removeAllMessages, backendStatus, theme} = this.props; // Default-Wert für messages ist ein leeres Array
 
         return (
             <div className="Header">
@@ -150,11 +148,13 @@ const mapStateToProps = (state: any) => ({
     currentView: state.applicationReducer.view,
     messages: state.applicationReducer.message,
     backendStatus: state.productionReducer.isBackenAvailable,
+    theme: state.applicationReducer.theme,
 });
 
 const mapDispatchToProps = (dispatch: any) => ({
     setViewState: (viewState: Views) => dispatch(setViewState(viewState)),
     removeAllMessages: () => dispatch(ApplicationActions.removeMessage()),
+    setTheme: (theme: ThemeName) => dispatch(ApplicationActions.setTheme(theme)),
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(Header);

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,10 +4,10 @@ import ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';
 import store from './store';
 import App from './containers/App';
-import { applyTheme, ThemeName } from './utils/theme';
+import { applyTheme, getStoredTheme, ThemeName } from './utils/theme';
 
 const setInitialTheme = (): void => {
-    const storedTheme = (localStorage.getItem('theme') as ThemeName | null);
+    const storedTheme = getStoredTheme();
 
     if (storedTheme) {
         applyTheme(storedTheme);

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,6 +4,21 @@ import ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';
 import store from './store';
 import App from './containers/App';
+import { applyTheme, ThemeName } from './utils/theme';
+
+const setInitialTheme = (): void => {
+    const storedTheme = (localStorage.getItem('theme') as ThemeName | null);
+
+    if (storedTheme) {
+        applyTheme(storedTheme);
+        return;
+    }
+
+    const prefersDarkAlt = window.matchMedia?.('(prefers-color-scheme: dark)').matches;
+    applyTheme(prefersDarkAlt ? 'dark-alt' : 'default');
+};
+
+setInitialTheme();
 
 ReactDOM.render(
     <Provider store={store}>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,21 +4,10 @@ import ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';
 import store from './store';
 import App from './containers/App';
-import { applyTheme, getStoredTheme, ThemeName } from './utils/theme';
+import { resolveInitialTheme } from './utils/theme';
+import { ApplicationActions } from './actions/actions';
 
-const setInitialTheme = (): void => {
-    const storedTheme = getStoredTheme();
-
-    if (storedTheme) {
-        applyTheme(storedTheme);
-        return;
-    }
-
-    const prefersDarkAlt = window.matchMedia?.('(prefers-color-scheme: dark)').matches;
-    applyTheme(prefersDarkAlt ? 'dark-alt' : 'default');
-};
-
-setInitialTheme();
+store.dispatch(ApplicationActions.setTheme(resolveInitialTheme()));
 
 ReactDOM.render(
     <Provider store={store}>

--- a/src/reducers/applicationReducer.ts
+++ b/src/reducers/applicationReducer.ts
@@ -1,5 +1,6 @@
 import {ApplicationActions} from '../actions/actions';
 import {Views} from '../enums/eViews';
+import { ThemeName, resolveInitialTheme } from '../utils/theme';
 import AllApplicationActions = ApplicationActions.AllApplicationActions;
 import ActionTypes = ApplicationActions.ActionTypes;
 
@@ -9,6 +10,7 @@ export interface ApplicationReducerState {
     errorDialogMessage: string;
     errorDialogOpen: boolean;
     message?: string[];
+    theme: ThemeName;
 }
 
 export const initialApplicationState: ApplicationReducerState = {
@@ -17,6 +19,7 @@ export const initialApplicationState: ApplicationReducerState = {
     errorDialogMessage: '',
     errorDialogOpen: false,
     message: [], // Default ist jetzt ein leeres Array
+    theme: resolveInitialTheme(),
 };
 
 const applicationReducer = (
@@ -46,6 +49,12 @@ const applicationReducer = (
             return {
                 ...aState,
                 message: [],
+            };
+        }
+        case ApplicationActions.ActionTypes.SET_THEME: {
+            return {
+                ...aState,
+                theme: aAction.payload.theme,
             };
         }
         default:

--- a/src/utils/theme.ts
+++ b/src/utils/theme.ts
@@ -1,5 +1,7 @@
 export type ThemeName = 'default' | 'dark-alt';
 
+const THEME_STORAGE_KEY = 'theme';
+
 /**
  * Aktiviert die gewünschte Farbpalette, indem die passende Theme-Klasse
  * bzw. das data-Attribut am Root-Element gesetzt wird. Alle Komponenten
@@ -17,4 +19,20 @@ export const applyTheme = (theme: ThemeName): void => {
 
   root.classList.remove('theme-dark-alt');
   root.removeAttribute('data-theme');
+};
+
+export const setTheme = (theme: ThemeName): void => {
+  applyTheme(theme);
+  localStorage.setItem(THEME_STORAGE_KEY, theme);
+};
+
+export const getStoredTheme = (): ThemeName | null => {
+  const stored = localStorage.getItem(THEME_STORAGE_KEY);
+  return stored === 'dark-alt' || stored === 'default' ? stored : null;
+};
+
+export const getActiveTheme = (): ThemeName => {
+  return document.documentElement.getAttribute('data-theme') === 'dark-alt'
+    ? 'dark-alt'
+    : 'default';
 };

--- a/src/utils/theme.ts
+++ b/src/utils/theme.ts
@@ -1,0 +1,20 @@
+export type ThemeName = 'default' | 'dark-alt';
+
+/**
+ * Aktiviert die gewünschte Farbpalette, indem die passende Theme-Klasse
+ * bzw. das data-Attribut am Root-Element gesetzt wird. Alle Komponenten
+ * beziehen Farben über CSS-Variablen, deshalb reicht das Umschalten der
+ * Klasse, um die Palette zu wechseln.
+ */
+export const applyTheme = (theme: ThemeName): void => {
+  const root = document.documentElement;
+
+  if (theme === 'dark-alt') {
+    root.classList.add('theme-dark-alt');
+    root.setAttribute('data-theme', 'dark-alt');
+    return;
+  }
+
+  root.classList.remove('theme-dark-alt');
+  root.removeAttribute('data-theme');
+};

--- a/src/utils/theme.ts
+++ b/src/utils/theme.ts
@@ -31,8 +31,13 @@ export const getStoredTheme = (): ThemeName | null => {
   return stored === 'dark-alt' || stored === 'default' ? stored : null;
 };
 
-export const getActiveTheme = (): ThemeName => {
-  return document.documentElement.getAttribute('data-theme') === 'dark-alt'
-    ? 'dark-alt'
-    : 'default';
+export const resolveInitialTheme = (): ThemeName => {
+  const storedTheme = getStoredTheme();
+
+  if (storedTheme) {
+    return storedTheme;
+  }
+
+  const prefersDarkAlt = window.matchMedia?.('(prefers-color-scheme: dark)').matches;
+  return prefersDarkAlt ? 'dark-alt' : 'default';
 };


### PR DESCRIPTION
## Summary
- call the theme helper on startup using a stored preference when available
- default to the alternative dark palette when the user prefers a dark color scheme

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69393047923c832f89448f6d7ff1d3ec)