### PR TITLE
Add settings view with navigation entry

### DIFF
--- a/src/containers/MainView/Header/Header.css
+++ b/src/containers/MainView/Header/Header.css
@@ -110,6 +110,12 @@ h1 {
   color: #b26a00;
 }
 
+.icon svg {
+  width: 1.5rem;
+  height: 1.5rem;
+  color: inherit;
+}
+
 .icon:last-child {
   margin-right: 0;
 }

--- a/src/containers/MainView/Header/Header.tsx
+++ b/src/containers/MainView/Header/Header.tsx
@@ -2,12 +2,9 @@ import React from 'react';
 import { connect } from 'react-redux';
 import './Header.css';
 import {Views} from "../../../enums/eViews";
-import {ApplicationActions, BeerActions} from "../../../actions/actions";
+import {ApplicationActions} from "../../../actions/actions";
 import setViewState = ApplicationActions.setViewState;
 import StatusDisplay from './StatusDisplay';
-import { ThemeName } from '../../../utils/theme';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faGear } from '@fortawesome/free-solid-svg-icons';
 
 
 
@@ -17,8 +14,6 @@ interface HeaderProps {
     messages?: string[];
     removeAllMessages: () => void;
     backendStatus: boolean;
-    theme: ThemeName;
-    setTheme: (theme: ThemeName) => void;
 }
 
 interface HeaderState {
@@ -70,22 +65,14 @@ class Header extends React.Component<HeaderProps, HeaderState> {
         return `icon ${this.props.currentView === view ? 'active' : ''}`;
     }
 
-    toggleTheme = () => {
-        const nextTheme: ThemeName = this.props.theme === 'dark-alt' ? 'default' : 'dark-alt';
-        this.props.setTheme(nextTheme);
-    }
-
     render() {
-       const { messages = [] , removeAllMessages, backendStatus, theme} = this.props; // Default-Wert für messages ist ein leeres Array
+       const { messages = [] , removeAllMessages, backendStatus } = this.props; // Default-Wert für messages ist ein leeres Array
 
         return (
             <div className="Header">
                 <div className="header-left">
                   <h1>Brauhaus</h1>
                 </div>
-                <button className="theme-toggle" onClick={this.toggleTheme} type="button">
-                  {theme === 'dark-alt' ? 'Helles Theme' : 'Dunkles Theme'}
-                </button>
                 <div className="icons-container">
                     <img
                         src="beer.png"
@@ -129,15 +116,15 @@ class Header extends React.Component<HeaderProps, HeaderState> {
                         onClick={() => this.handleIconClick(Views.INGREDIENTS)}
                         title="Zutaten verwalten"
                     />
-                    <div
+                    <img
+                        src="brewery.png"
+                        alt="Einstellungen"
                         className={this.getTabClassName(Views.SETTINGS)}
                         onClick={() => this.handleIconClick(Views.SETTINGS)}
                         title="Einstellungen"
                         role="button"
                         aria-label="Einstellungen"
-                    >
-                        <FontAwesomeIcon icon={faGear} size="lg" />
-                    </div>
+                    />
                 </div>
                 <div className="header-status">
                   <div className="status-display-wrapper">
@@ -155,17 +142,14 @@ class Header extends React.Component<HeaderProps, HeaderState> {
 }
 
 const mapStateToProps = (state: any) => ({
-    currentTime: state.applicationReducer.currentTime,
     currentView: state.applicationReducer.view,
     messages: state.applicationReducer.message,
     backendStatus: state.productionReducer.isBackenAvailable,
-    theme: state.applicationReducer.theme,
 });
 
 const mapDispatchToProps = (dispatch: any) => ({
     setViewState: (viewState: Views) => dispatch(setViewState(viewState)),
     removeAllMessages: () => dispatch(ApplicationActions.removeMessage()),
-    setTheme: (theme: ThemeName) => dispatch(ApplicationActions.setTheme(theme)),
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(Header);

--- a/src/containers/MainView/Header/Header.tsx
+++ b/src/containers/MainView/Header/Header.tsx
@@ -6,6 +6,8 @@ import {ApplicationActions, BeerActions} from "../../../actions/actions";
 import setViewState = ApplicationActions.setViewState;
 import StatusDisplay from './StatusDisplay';
 import { ThemeName } from '../../../utils/theme';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faGear } from '@fortawesome/free-solid-svg-icons';
 
 
 
@@ -127,6 +129,15 @@ class Header extends React.Component<HeaderProps, HeaderState> {
                         onClick={() => this.handleIconClick(Views.INGREDIENTS)}
                         title="Zutaten verwalten"
                     />
+                    <div
+                        className={this.getTabClassName(Views.SETTINGS)}
+                        onClick={() => this.handleIconClick(Views.SETTINGS)}
+                        title="Einstellungen"
+                        role="button"
+                        aria-label="Einstellungen"
+                    >
+                        <FontAwesomeIcon icon={faGear} size="lg" />
+                    </div>
                 </div>
                 <div className="header-status">
                   <div className="status-display-wrapper">

--- a/src/containers/Settings/SettingsPage.css
+++ b/src/containers/Settings/SettingsPage.css
@@ -1,0 +1,215 @@
+.settings-page {
+  padding: 1.5rem 2rem;
+  color: var(--color-black);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.settings-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.settings-eyebrow {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-weight: 700;
+  color: #b26a00;
+  margin: 0 0 0.25rem 0;
+}
+
+.settings-header h2 {
+  margin: 0;
+  font-size: 1.5rem;
+}
+
+.settings-subtitle {
+  margin: 0.25rem 0 0 0;
+  color: #444;
+}
+
+.settings-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  background: var(--color-input-bg2);
+  border-radius: 0.75rem;
+  border: 1px solid var(--color-input-border);
+  font-weight: 600;
+}
+
+.status-dot {
+  width: 0.75rem;
+  height: 0.75rem;
+  border-radius: 50%;
+  background: #43a047;
+  box-shadow: 0 0 0 3px rgba(67, 160, 71, 0.15);
+}
+
+.settings-message {
+  padding: 0.75rem 1rem;
+  background: #e8f5e9;
+  color: #1b5e20;
+  border: 1px solid #c8e6c9;
+  border-radius: 0.5rem;
+  box-shadow: 0 1px 2px rgba(0,0,0,0.08);
+}
+
+.settings-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1rem;
+}
+
+.settings-card {
+  background: var(--color-white);
+  border: 1px solid var(--color-input-border);
+  border-radius: 1rem;
+  padding: 1rem;
+  box-shadow: 0 2px 6px rgba(0,0,0,0.06);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.settings-card-header {
+  margin-bottom: 0.25rem;
+}
+
+.settings-card h3 {
+  margin: 0;
+}
+
+.settings-card p {
+  margin: 0.25rem 0 0 0;
+  color: #555;
+}
+
+.setting-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding-top: 0.5rem;
+  border-top: 1px solid var(--color-input-border);
+}
+
+.setting-label-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.setting-label-group label {
+  font-weight: 700;
+}
+
+.setting-description {
+  color: #666;
+  font-size: 0.9rem;
+}
+
+.setting-options {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.settings-chip {
+  padding: 0.5rem 0.9rem;
+  border-radius: 999px;
+  border: 1px solid var(--color-input-border);
+  background: var(--color-input-bg2);
+  cursor: pointer;
+  transition: all 0.15s ease;
+  font-weight: 600;
+}
+
+.settings-chip.active {
+  background: linear-gradient(180deg, #ffb74d 10%, #ff9800 100%);
+  color: #5d3300;
+  border-color: #b26a00;
+  box-shadow: 0 4px 10px rgba(255, 152, 0, 0.2);
+}
+
+.settings-chip:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 4px 8px rgba(0,0,0,0.08);
+}
+
+.setting-toggle {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: 600;
+}
+
+.setting-toggle input {
+  width: 1.2rem;
+  height: 1.2rem;
+}
+
+.settings-select {
+  padding: 0.5rem 0.75rem;
+  border-radius: 0.5rem;
+  border: 1px solid var(--color-input-border);
+  background: var(--color-input-bg2);
+  min-width: 180px;
+}
+
+.settings-footer {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  justify-content: flex-start;
+  padding-top: 0.5rem;
+  border-top: 1px solid var(--color-input-border);
+}
+
+.settings-primary {
+  padding: 0.75rem 1.25rem;
+  border-radius: 0.75rem;
+  background: linear-gradient(180deg, #ffb74d 10%, #ff9800 100%);
+  border: 1px solid #b26a00;
+  color: #5d3300;
+  font-weight: 800;
+  cursor: pointer;
+  box-shadow: 0 4px 10px rgba(255, 152, 0, 0.2);
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.settings-primary:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 6px 14px rgba(0,0,0,0.12);
+}
+
+.settings-primary:active {
+  transform: translateY(0);
+}
+
+.settings-hint {
+  margin: 0;
+  color: #666;
+}
+
+@media (max-width: 768px) {
+  .settings-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .setting-row {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .settings-footer {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}

--- a/src/containers/Settings/SettingsPage.tsx
+++ b/src/containers/Settings/SettingsPage.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react';
+import React from 'react';
 import { connect } from 'react-redux';
 import './SettingsPage.css';
 import { ThemeName } from '../../utils/theme';
@@ -9,145 +9,179 @@ interface SettingsPageProps {
     setTheme: (theme: ThemeName) => void;
 }
 
-const SettingsPage: React.FC<SettingsPageProps> = ({ theme, setTheme }) => {
-    const [autoConnect, setAutoConnect] = useState<boolean>(true);
-    const [notificationsEnabled, setNotificationsEnabled] = useState<boolean>(false);
-    const [temperatureUnit, setTemperatureUnit] = useState<'celsius' | 'fahrenheit'>('celsius');
-    const [statusMessage, setStatusMessage] = useState<string | null>(null);
+interface SettingsPageState {
+    autoConnect: boolean;
+    notificationsEnabled: boolean;
+    temperatureUnit: 'celsius' | 'fahrenheit';
+    statusMessage: string | null;
+}
 
-    const activeThemeLabel = useMemo(() => theme === 'dark-alt' ? 'Dunkles Theme' : 'Helles Theme', [theme]);
+class SettingsPage extends React.Component<SettingsPageProps, SettingsPageState> {
+    constructor(props: SettingsPageProps) {
+        super(props);
 
-    const handleThemeChange = (nextTheme: ThemeName) => {
-        setTheme(nextTheme);
-        setStatusMessage(`Theme auf "${nextTheme === 'dark-alt' ? 'dunkel' : 'hell'}" aktualisiert.`);
+        this.state = {
+            autoConnect: true,
+            notificationsEnabled: false,
+            temperatureUnit: 'celsius',
+            statusMessage: null,
+        };
+    }
+
+    get activeThemeLabel() {
+        return this.props.theme === 'dark-alt' ? 'Dunkles Theme' : 'Helles Theme';
+    }
+
+    handleThemeChange = (nextTheme: ThemeName) => {
+        this.props.setTheme(nextTheme);
+        this.setState({
+            statusMessage: `Theme auf "${nextTheme === 'dark-alt' ? 'dunkel' : 'hell'}" aktualisiert.`,
+        });
     };
 
-    const handleSave = () => {
-        setStatusMessage('Einstellungen gespeichert.');
+    handleSave = () => {
+        this.setState({ statusMessage: 'Einstellungen gespeichert.' });
     };
 
-    return (
-        <div className="settings-page">
-            <header className="settings-header">
-                <div>
-                    <p className="settings-eyebrow">Neue Seite</p>
-                    <h2>Einstellungen</h2>
-                    <p className="settings-subtitle">
-                        Passe das Verhalten der Anwendung an und speichere deine persönlichen Vorlieben.
-                    </p>
-                </div>
-                <div className="settings-status">
-                    <span className="status-dot" aria-hidden="true"></span>
-                    <span className="status-label">{activeThemeLabel}</span>
-                </div>
-            </header>
+    handleNotificationChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+        this.setState({ notificationsEnabled: event.target.checked });
+    };
 
-            {statusMessage && (
-                <div className="settings-message" role="status" aria-live="polite">
-                    {statusMessage}
-                </div>
-            )}
+    handleAutoConnectChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+        this.setState({ autoConnect: event.target.checked });
+    };
 
-            <div className="settings-grid">
-                <section className="settings-card">
-                    <div className="settings-card-header">
-                        <h3>Darstellung</h3>
-                        <p>Steuere das aktive Theme der Oberfläche.</p>
+    handleTemperatureUnitChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
+        this.setState({ temperatureUnit: event.target.value as 'celsius' | 'fahrenheit' });
+    };
+
+    render() {
+        const { theme } = this.props;
+        const { autoConnect, notificationsEnabled, temperatureUnit, statusMessage } = this.state;
+
+        return (
+            <div className="settings-page">
+                <header className="settings-header">
+                    <div>
+                        <p className="settings-eyebrow">Neue Seite</p>
+                        <h2>Einstellungen</h2>
+                        <p className="settings-subtitle">
+                            Passe das Verhalten der Anwendung an und speichere deine persönlichen Vorlieben.
+                        </p>
                     </div>
-                    <div className="setting-row">
-                        <div className="setting-label-group">
-                            <label>Theme auswählen</label>
-                            <span className="setting-description">Wechsle jederzeit zwischen heller und dunkler Ansicht.</span>
+                    <div className="settings-status">
+                        <span className="status-dot" aria-hidden="true"></span>
+                        <span className="status-label">{this.activeThemeLabel}</span>
+                    </div>
+                </header>
+
+                {statusMessage && (
+                    <div className="settings-message" role="status" aria-live="polite">
+                        {statusMessage}
+                    </div>
+                )}
+
+                <div className="settings-grid">
+                    <section className="settings-card">
+                        <div className="settings-card-header">
+                            <h3>Darstellung</h3>
+                            <p>Steuere das aktive Theme der Oberfläche.</p>
                         </div>
-                        <div className="setting-options">
-                            <button
-                                className={`settings-chip ${theme === 'default' ? 'active' : ''}`}
-                                type="button"
-                                onClick={() => handleThemeChange('default')}
+                        <div className="setting-row">
+                            <div className="setting-label-group">
+                                <label>Theme auswählen</label>
+                                <span className="setting-description">Wechsle jederzeit zwischen heller und dunkler Ansicht.</span>
+                            </div>
+                            <div className="setting-options">
+                                <button
+                                    className={`settings-chip ${theme === 'default' ? 'active' : ''}`}
+                                    type="button"
+                                    onClick={() => this.handleThemeChange('default')}
+                                >
+                                    Helles Theme
+                                </button>
+                                <button
+                                    className={`settings-chip ${theme === 'dark-alt' ? 'active' : ''}`}
+                                    type="button"
+                                    onClick={() => this.handleThemeChange('dark-alt')}
+                                >
+                                    Dunkles Theme
+                                </button>
+                            </div>
+                        </div>
+                    </section>
+
+                    <section className="settings-card">
+                        <div className="settings-card-header">
+                            <h3>Benachrichtigungen</h3>
+                            <p>Kontrolliere, ob Hinweistexte automatisch angezeigt werden sollen.</p>
+                        </div>
+                        <div className="setting-row">
+                            <div className="setting-label-group">
+                                <label htmlFor="notifications">Systemmeldungen</label>
+                                <span className="setting-description">Zeige Hinweise direkt in der Statusleiste an.</span>
+                            </div>
+                            <div className="setting-toggle">
+                                <input
+                                    id="notifications"
+                                    type="checkbox"
+                                    checked={notificationsEnabled}
+                                    onChange={this.handleNotificationChange}
+                                />
+                                <label htmlFor="notifications">{notificationsEnabled ? 'Aktiviert' : 'Deaktiviert'}</label>
+                            </div>
+                        </div>
+                    </section>
+
+                    <section className="settings-card">
+                        <div className="settings-card-header">
+                            <h3>Verbindung</h3>
+                            <p>Steuere Hintergrundaktionen zum Abruf der Produktionsdaten.</p>
+                        </div>
+                        <div className="setting-row">
+                            <div className="setting-label-group">
+                                <label htmlFor="autoconnect">Automatisch verbinden</label>
+                                <span className="setting-description">Startet die Synchronisation unmittelbar nach dem Laden.</span>
+                            </div>
+                            <div className="setting-toggle">
+                                <input
+                                    id="autoconnect"
+                                    type="checkbox"
+                                    checked={autoConnect}
+                                    onChange={this.handleAutoConnectChange}
+                                />
+                                <label htmlFor="autoconnect">{autoConnect ? 'Aktiviert' : 'Deaktiviert'}</label>
+                            </div>
+                        </div>
+
+                        <div className="setting-row">
+                            <div className="setting-label-group">
+                                <label htmlFor="temperature-unit">Temperatureinheit</label>
+                                <span className="setting-description">Lege fest, in welcher Einheit Werte angezeigt werden.</span>
+                            </div>
+                            <select
+                                id="temperature-unit"
+                                className="settings-select"
+                                value={temperatureUnit}
+                                onChange={this.handleTemperatureUnitChange}
                             >
-                                Helles Theme
-                            </button>
-                            <button
-                                className={`settings-chip ${theme === 'dark-alt' ? 'active' : ''}`}
-                                type="button"
-                                onClick={() => handleThemeChange('dark-alt')}
-                            >
-                                Dunkles Theme
-                            </button>
+                                <option value="celsius">Celsius (°C)</option>
+                                <option value="fahrenheit">Fahrenheit (°F)</option>
+                            </select>
                         </div>
-                    </div>
-                </section>
+                    </section>
+                </div>
 
-                <section className="settings-card">
-                    <div className="settings-card-header">
-                        <h3>Benachrichtigungen</h3>
-                        <p>Kontrolliere, ob Hinweistexte automatisch angezeigt werden sollen.</p>
-                    </div>
-                    <div className="setting-row">
-                        <div className="setting-label-group">
-                            <label htmlFor="notifications">Systemmeldungen</label>
-                            <span className="setting-description">Zeige Hinweise direkt in der Statusleiste an.</span>
-                        </div>
-                        <div className="setting-toggle">
-                            <input
-                                id="notifications"
-                                type="checkbox"
-                                checked={notificationsEnabled}
-                                onChange={(event) => setNotificationsEnabled(event.target.checked)}
-                            />
-                            <label htmlFor="notifications">{notificationsEnabled ? 'Aktiviert' : 'Deaktiviert'}</label>
-                        </div>
-                    </div>
-                </section>
-
-                <section className="settings-card">
-                    <div className="settings-card-header">
-                        <h3>Verbindung</h3>
-                        <p>Steuere Hintergrundaktionen zum Abruf der Produktionsdaten.</p>
-                    </div>
-                    <div className="setting-row">
-                        <div className="setting-label-group">
-                            <label htmlFor="autoconnect">Automatisch verbinden</label>
-                            <span className="setting-description">Startet die Synchronisation unmittelbar nach dem Laden.</span>
-                        </div>
-                        <div className="setting-toggle">
-                            <input
-                                id="autoconnect"
-                                type="checkbox"
-                                checked={autoConnect}
-                                onChange={(event) => setAutoConnect(event.target.checked)}
-                            />
-                            <label htmlFor="autoconnect">{autoConnect ? 'Aktiviert' : 'Deaktiviert'}</label>
-                        </div>
-                    </div>
-
-                    <div className="setting-row">
-                        <div className="setting-label-group">
-                            <label htmlFor="temperature-unit">Temperatureinheit</label>
-                            <span className="setting-description">Lege fest, in welcher Einheit Werte angezeigt werden.</span>
-                        </div>
-                        <select
-                            id="temperature-unit"
-                            className="settings-select"
-                            value={temperatureUnit}
-                            onChange={(event) => setTemperatureUnit(event.target.value as 'celsius' | 'fahrenheit')}
-                        >
-                            <option value="celsius">Celsius (°C)</option>
-                            <option value="fahrenheit">Fahrenheit (°F)</option>
-                        </select>
-                    </div>
-                </section>
+                <footer className="settings-footer">
+                    <button className="settings-primary" type="button" onClick={this.handleSave}>
+                        Einstellungen speichern
+                    </button>
+                    <p className="settings-hint">Alle Änderungen lassen sich jederzeit zurücksetzen.</p>
+                </footer>
             </div>
-
-            <footer className="settings-footer">
-                <button className="settings-primary" type="button" onClick={handleSave}>
-                    Einstellungen speichern
-                </button>
-                <p className="settings-hint">Alle Änderungen lassen sich jederzeit zurücksetzen.</p>
-            </footer>
-        </div>
-    );
-};
+        );
+    }
+}
 
 const mapStateToProps = (state: any) => ({
     theme: state.applicationReducer.theme as ThemeName,

--- a/src/containers/Settings/SettingsPage.tsx
+++ b/src/containers/Settings/SettingsPage.tsx
@@ -1,0 +1,160 @@
+import React, { useMemo, useState } from 'react';
+import { connect } from 'react-redux';
+import './SettingsPage.css';
+import { ThemeName } from '../../utils/theme';
+import { ApplicationActions } from '../../actions/actions';
+
+interface SettingsPageProps {
+    theme: ThemeName;
+    setTheme: (theme: ThemeName) => void;
+}
+
+const SettingsPage: React.FC<SettingsPageProps> = ({ theme, setTheme }) => {
+    const [autoConnect, setAutoConnect] = useState<boolean>(true);
+    const [notificationsEnabled, setNotificationsEnabled] = useState<boolean>(false);
+    const [temperatureUnit, setTemperatureUnit] = useState<'celsius' | 'fahrenheit'>('celsius');
+    const [statusMessage, setStatusMessage] = useState<string | null>(null);
+
+    const activeThemeLabel = useMemo(() => theme === 'dark-alt' ? 'Dunkles Theme' : 'Helles Theme', [theme]);
+
+    const handleThemeChange = (nextTheme: ThemeName) => {
+        setTheme(nextTheme);
+        setStatusMessage(`Theme auf "${nextTheme === 'dark-alt' ? 'dunkel' : 'hell'}" aktualisiert.`);
+    };
+
+    const handleSave = () => {
+        setStatusMessage('Einstellungen gespeichert.');
+    };
+
+    return (
+        <div className="settings-page">
+            <header className="settings-header">
+                <div>
+                    <p className="settings-eyebrow">Neue Seite</p>
+                    <h2>Einstellungen</h2>
+                    <p className="settings-subtitle">
+                        Passe das Verhalten der Anwendung an und speichere deine persönlichen Vorlieben.
+                    </p>
+                </div>
+                <div className="settings-status">
+                    <span className="status-dot" aria-hidden="true"></span>
+                    <span className="status-label">{activeThemeLabel}</span>
+                </div>
+            </header>
+
+            {statusMessage && (
+                <div className="settings-message" role="status" aria-live="polite">
+                    {statusMessage}
+                </div>
+            )}
+
+            <div className="settings-grid">
+                <section className="settings-card">
+                    <div className="settings-card-header">
+                        <h3>Darstellung</h3>
+                        <p>Steuere das aktive Theme der Oberfläche.</p>
+                    </div>
+                    <div className="setting-row">
+                        <div className="setting-label-group">
+                            <label>Theme auswählen</label>
+                            <span className="setting-description">Wechsle jederzeit zwischen heller und dunkler Ansicht.</span>
+                        </div>
+                        <div className="setting-options">
+                            <button
+                                className={`settings-chip ${theme === 'default' ? 'active' : ''}`}
+                                type="button"
+                                onClick={() => handleThemeChange('default')}
+                            >
+                                Helles Theme
+                            </button>
+                            <button
+                                className={`settings-chip ${theme === 'dark-alt' ? 'active' : ''}`}
+                                type="button"
+                                onClick={() => handleThemeChange('dark-alt')}
+                            >
+                                Dunkles Theme
+                            </button>
+                        </div>
+                    </div>
+                </section>
+
+                <section className="settings-card">
+                    <div className="settings-card-header">
+                        <h3>Benachrichtigungen</h3>
+                        <p>Kontrolliere, ob Hinweistexte automatisch angezeigt werden sollen.</p>
+                    </div>
+                    <div className="setting-row">
+                        <div className="setting-label-group">
+                            <label htmlFor="notifications">Systemmeldungen</label>
+                            <span className="setting-description">Zeige Hinweise direkt in der Statusleiste an.</span>
+                        </div>
+                        <div className="setting-toggle">
+                            <input
+                                id="notifications"
+                                type="checkbox"
+                                checked={notificationsEnabled}
+                                onChange={(event) => setNotificationsEnabled(event.target.checked)}
+                            />
+                            <label htmlFor="notifications">{notificationsEnabled ? 'Aktiviert' : 'Deaktiviert'}</label>
+                        </div>
+                    </div>
+                </section>
+
+                <section className="settings-card">
+                    <div className="settings-card-header">
+                        <h3>Verbindung</h3>
+                        <p>Steuere Hintergrundaktionen zum Abruf der Produktionsdaten.</p>
+                    </div>
+                    <div className="setting-row">
+                        <div className="setting-label-group">
+                            <label htmlFor="autoconnect">Automatisch verbinden</label>
+                            <span className="setting-description">Startet die Synchronisation unmittelbar nach dem Laden.</span>
+                        </div>
+                        <div className="setting-toggle">
+                            <input
+                                id="autoconnect"
+                                type="checkbox"
+                                checked={autoConnect}
+                                onChange={(event) => setAutoConnect(event.target.checked)}
+                            />
+                            <label htmlFor="autoconnect">{autoConnect ? 'Aktiviert' : 'Deaktiviert'}</label>
+                        </div>
+                    </div>
+
+                    <div className="setting-row">
+                        <div className="setting-label-group">
+                            <label htmlFor="temperature-unit">Temperatureinheit</label>
+                            <span className="setting-description">Lege fest, in welcher Einheit Werte angezeigt werden.</span>
+                        </div>
+                        <select
+                            id="temperature-unit"
+                            className="settings-select"
+                            value={temperatureUnit}
+                            onChange={(event) => setTemperatureUnit(event.target.value as 'celsius' | 'fahrenheit')}
+                        >
+                            <option value="celsius">Celsius (°C)</option>
+                            <option value="fahrenheit">Fahrenheit (°F)</option>
+                        </select>
+                    </div>
+                </section>
+            </div>
+
+            <footer className="settings-footer">
+                <button className="settings-primary" type="button" onClick={handleSave}>
+                    Einstellungen speichern
+                </button>
+                <p className="settings-hint">Alle Änderungen lassen sich jederzeit zurücksetzen.</p>
+            </footer>
+        </div>
+    );
+};
+
+const mapStateToProps = (state: any) => ({
+    theme: state.applicationReducer.theme as ThemeName,
+});
+
+const mapDispatchToProps = (dispatch: any) => ({
+    setTheme: (theme: ThemeName) => dispatch(ApplicationActions.setTheme(theme)),
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(SettingsPage);

--- a/src/containers/index.tsx
+++ b/src/containers/index.tsx
@@ -14,6 +14,7 @@ import {FinishedBrew} from "../model/FinishedBrew";
 import FinishedBrewsTable from "./MainView/FinishBrewsBeers/FinishedBrewsTable";
 import BrewingCalculations from "./BrewingCalculations/BrewingCalculations";
 import IngredientsFormPage from "./DatabaseOverview/IngredientsFormPage";
+import SettingsPage from "./Settings/SettingsPage";
 
 interface indexMainProps {
     viewState: Views;
@@ -94,6 +95,7 @@ class Index extends React.Component<indexMainProps> {
                 <div className="ingredients-wrapper">
                     {viewState === Views.INGREDIENTS && <IngredientsFormPage />}
                 </div>
+                {viewState === Views.SETTINGS && <SettingsPage />}
                 <SimpleBar style={{maxHeight: '100%', overflowY: 'auto'}}>
                     {viewState === Views.FINISHED_BREWS && <FinishedBrewsTable></FinishedBrewsTable>}
                 </SimpleBar>

--- a/src/enums/eViews.ts
+++ b/src/enums/eViews.ts
@@ -4,5 +4,6 @@ export enum Views {
     DATABASE = 2,
     FINISHED_BREWS = 3,
     BREWING_CALCULATIONS = 4,
-    INGREDIENTS = 5
+    INGREDIENTS = 5,
+    SETTINGS = 6,
 }


### PR DESCRIPTION
## Summary
- add a dedicated settings page with controls for theme, notifications, and connection preferences
- add navigation entry and view wiring to open the settings page from the header

## Testing
- npm test -- --watch=false *(fails: react-scripts missing before dependencies are installed)*
- npm install *(fails: registry returned 403 when fetching packages)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69393757d6fc832fa636d2996c27cc1b)