### PR TITLE
Style text-only buttons with orange background

### DIFF
--- a/src/containers/DatabaseOverview/BeerForm.css
+++ b/src/containers/DatabaseOverview/BeerForm.css
@@ -58,8 +58,8 @@ textarea {
 
 button {
     padding: 4px 8px;
-    background-color: transparent;
-    color: var(--color-accent);
+    background-color: var(--color-accent);
+    color: var(--color-black);
     border: none;
     border-radius: 4px; /* Gerundete Ecken wie bei FinishedBrewsTable */
     cursor: pointer;
@@ -75,16 +75,16 @@ button {
     height: 40px;
     width: 120px;
     padding: 4px 8px;
-    background-color: transparent;
-    color: var(--color-accent);
+    background-color: var(--color-accent);
+    color: var(--color-black);
     border: none;
     border-radius: 4px;
     cursor: pointer;
 }
 
 button:hover {
-    background-color: transparent;
-    color: #fff;
+    background-color: #ffb74d;
+    color: var(--color-black);
 }
 
 select {


### PR DESCRIPTION
## Summary
- give default and submit buttons an orange background and dark text to highlight text-only actions
- adjust hover state to maintain the orange theme and readability

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69394c3ada34832f83447fd1c351ca87)