### PR TITLE
Add specific styles for beer recipe action buttons

### DIFF
--- a/src/containers/MainView/BeerRecipes/Table.css
+++ b/src/containers/MainView/BeerRecipes/Table.css
@@ -83,3 +83,57 @@
   background-color: #d32f2f;
   color: #fff;
 }
+
+.Table .table-action-button {
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  padding: 0.25rem 0.75rem;
+  font-size: 0.75rem;
+  font-weight: bold;
+  cursor: pointer;
+  transition: background 0.2s, transform 0.1s;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 2rem;
+  min-width: 2.5rem;
+  background-color: #757575;
+}
+
+.Table .table-action-button:hover {
+  transform: translateY(-1px);
+}
+
+.Table .table-action-button:disabled {
+  background-color: #bdbdbd;
+  color: #888;
+  cursor: not-allowed;
+  border: none;
+  opacity: 1;
+}
+
+.Table .export-button {
+  background-color: var(--color-accent);
+  color: #222;
+}
+
+.Table .export-button:hover {
+  background-color: #ffa726;
+}
+
+.Table .brew-button {
+  background-color: #2e7d32;
+}
+
+.Table .brew-button:hover {
+  background-color: #388e3c;
+}
+
+.Table .cancel-brew-button {
+  background-color: #b71c1c;
+}
+
+.Table .cancel-brew-button:hover {
+  background-color: #d32f2f;
+}

--- a/src/containers/MainView/BeerRecipes/Table.tsx
+++ b/src/containers/MainView/BeerRecipes/Table.tsx
@@ -173,7 +173,7 @@ export class BeerTableComponent extends React.Component<BeerTableProps, BeerTabl
                                         <TableCell className="table-cell">
                                             <div style={{ display: 'flex', gap: '0.5rem' }}>
                                                 <button
-
+                                                    className="table-action-button export-button"
                                                     onClick={e => {
                                                         e.stopPropagation();
                                                         this.handleExportShoppingListPdfForBeer(item);
@@ -183,6 +183,7 @@ export class BeerTableComponent extends React.Component<BeerTableProps, BeerTabl
                                                     <span role="img" aria-label="Einkaufsliste" style={{fontSize: '1.2rem'}}>🛒</span>
                                                 </button>
                                                 <button
+                                                    className={`table-action-button ${beerToBrew && beerToBrew.id === item.id ? 'cancel-brew-button' : 'brew-button'}`}
                                                     onClick={e => {
                                                         e.stopPropagation();
                                                         if (beerToBrew && beerToBrew.id === item.id) {


### PR DESCRIPTION
## Summary
- add dedicated CSS classes to beer recipe export and brew/cancel buttons
- style the new action buttons for clearer hover, disabled, and state-specific appearances

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6939500985c8832fa2230fd880597bdb)