### PR TITLE
Introduce structured BrewingStatus model, normalization and selectors; migrate UI to use structured status

### DIFF
--- a/src/containers/Mobile/MobileStatusView/MobileProductionView.tsx
+++ b/src/containers/Mobile/MobileStatusView/MobileProductionView.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import './MobileProductionView.css';
-import { BrewingStatus } from '../../../model/BrewingStatus';
+import { BrewingStatus } from '../../../model/brewingStatus.types';
 import { ProductionActions } from '../../../actions/actions';
 import { TimeFormatter } from "../../../utils/TimeFormatter";
 import MobileBrewingCalculationsView from '../MobileBrewingCalculationsView/MobileBrewingCalculationsView';
+import {getBrewingStatusLabel, getStatusChangeKey, isStepWaiting} from '../../../utils/brewingStatus/selectors';
 
 interface MobileProductionViewProps {
     temperature: number;
@@ -28,8 +29,8 @@ class MobileProductionView extends React.Component<MobileProductionViewProps, Mo
     };
 
     componentDidUpdate(prevProps: MobileProductionViewProps) {
-        const prevStatus = prevProps.brewingStatus?.StatusText;
-        const currStatus = this.props.brewingStatus?.StatusText;
+        const prevStatus = getStatusChangeKey(prevProps.brewingStatus);
+        const currStatus = getStatusChangeKey(this.props.brewingStatus);
         if (prevStatus !== undefined && currStatus !== prevStatus) {
             // Status hat sich geändert, triggere Vibration (falls unterstützt)
             if (navigator.vibrate) {
@@ -69,7 +70,7 @@ class MobileProductionView extends React.Component<MobileProductionViewProps, Mo
     render() {
         const { brewingStatus, startPolling, isPollingRunning } = this.props;
         const { activeTab } = this.state;
-        const statusText = brewingStatus?.Name;
+        const statusText = getBrewingStatusLabel(brewingStatus);
         return (
             <div
                 className="mobile-production-container"
@@ -89,27 +90,27 @@ class MobileProductionView extends React.Component<MobileProductionViewProps, Mo
                         <div className="mobile-info-list">
                             <div className="mobile-info-block">
                                 <span className="mobile-label">Temperatur:</span>
-                                <span className="mobile-value">{brewingStatus?.Temperature ?? '-'} °C</span>
+                                <span className="mobile-value">{brewingStatus?.temperature?.current ?? '-'} °C</span>
                             </div>
                             <div className="mobile-info-block">
                                 <span className="mobile-label">Zieltemperatur:</span>
-                                <span className="mobile-value">{brewingStatus?.TargetTemperature ?? '-'} °C</span>
+                                <span className="mobile-value">{brewingStatus?.temperature?.target ?? '-'} °C</span>
                             </div>
                             <div className="mobile-info-block">
                                 <span className="mobile-label">Typ:</span>
-                                <span className="mobile-value">{brewingStatus?.Type || '-'}</span>
+                                <span className="mobile-value">{brewingStatus?.currentStep?.phase || '-'}</span>
                             </div>
                             <div className="mobile-info-block">
                                 <span className="mobile-label">Warten:</span>
-                                <span className="mobile-value">{brewingStatus?.WaitingStatus ? 'Ja' : 'Nein'}</span>
+                                <span className="mobile-value">{isStepWaiting(brewingStatus) ? 'Ja' : 'Nein'}</span>
                             </div>
                             <div className="mobile-info-block">
                                 <span className="mobile-label">Heizt auf:</span>
-                                <span className="mobile-value">{brewingStatus?.HeatUpStatus ? 'Ja' : 'Nein'}</span>
+                                <span className="mobile-value">{brewingStatus?.currentStep?.mode === 'HEATING' ? 'Ja' : 'Nein'}</span>
                             </div>
                             <div className="mobile-info-block">
                                 <span className="mobile-label">Rührwerk:</span>
-                                <span className="mobile-value">{brewingStatus?.AgitatorStatus ? 'An' : 'Aus'}</span>
+                                <span className="mobile-value">{brewingStatus?.hardware?.agitator === 'ON' ? 'An' : 'Aus'}</span>
                             </div>
                             <div className="mobile-info-block">
                                 <span className="mobile-label">Laufzeit:</span>

--- a/src/containers/Production/Production.tsx
+++ b/src/containers/Production/Production.tsx
@@ -15,7 +15,8 @@ import {ToggleState} from "../../enums/eToggleState";
 import {MashAgitatorStates} from "../../model/MashAgitator";
 import QuantityPicker from '../../components/Controlls/QuantityPicker/QuantityPicker';
 import {BrewingData} from "../../model/BrewingData";
-import {BrewingStatus, HeatingStates} from "../../model/BrewingStatus";
+import {HeatingStates} from "../../model/BrewingStatus";
+import {BrewingStatus, ProcessMode, ProcessPhase, ProcessState} from "../../model/brewingStatus.types";
 import {TimeFormatter} from "../../utils/TimeFormatter";
 import ModalDialog, {DialogType} from "../../components/ModalDialog/ModalDialog";
 import {ProgressBar} from "react-bootstrap";
@@ -23,13 +24,13 @@ import {MashingType} from "../../enums/eMashingType";
 import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
 import {faRepeat} from '@fortawesome/free-solid-svg-icons';
 import Switch from "react-switch";
-import {TextMapper} from "../../utils/TextMapper";
 import {IconProp} from "@fortawesome/fontawesome-svg-core";
 import {FinishedBrew} from "../../model/FinishedBrew";
 import {eBrewState} from "../../enums/eBrewState";
 import {BackendAvailable} from "../../reducers/productionReducer";
 import {ProcessList, createProcessSteps} from "./ProcessList/ProcessList";
 import { dataCollector } from '../../utils/DataCollector/dataCollector';
+import {getBrewingStatusLabel} from "../../utils/brewingStatus/selectors";
 export interface ProcessStep {
     name: string;
 }
@@ -78,6 +79,7 @@ interface ProductionState {
     brewingFinished: boolean
     indexOfCurrentStep: number;
     brewingIsRunning: boolean;
+    announcedHopTimes: number[];
 }
 
 class Production extends React.Component<ProductionProps, ProductionState> {
@@ -114,7 +116,8 @@ class Production extends React.Component<ProductionProps, ProductionState> {
             showFinishDialog: false,
             brewingFinished: false,
             indexOfCurrentStep: 0,
-            brewingIsRunning: false
+            brewingIsRunning: false,
+            announcedHopTimes: []
         }
     }
 
@@ -158,9 +161,9 @@ class Production extends React.Component<ProductionProps, ProductionState> {
                 this.setState({waterSwitchState: false, waterFillingError: true});
             }, delay);
         }
-        if (brewingStatus?.HeatingStates !== prevProps?.brewingStatus?.HeatingStates) {
+        if (brewingStatus?.currentStep?.mode !== prevProps?.brewingStatus?.currentStep?.mode) {
             let timelineData: TimelineData | undefined;
-            if (brewingStatus.HeatUpStatus) {
+            if (brewingStatus.currentStep.mode === ProcessMode.HEATING) {
                 timelineData = {
                     type: 'heating', elapsed: brewingStatus?.elapsedTime
                 }
@@ -174,17 +177,15 @@ class Production extends React.Component<ProductionProps, ProductionState> {
             }
 
         }
-        if( brewingStatus?.StatusText !== prevProps?.brewingStatus?.StatusText)
-        {
-            const currentIndex = this.state.indexOfCurrentStep +1;
-            this.setState({indexOfCurrentStep:currentIndex});
+        if (typeof brewingStatus?.currentStep?.index === "number" && brewingStatus.currentStep.index !== prevProps?.brewingStatus?.currentStep?.index) {
+            this.setState({indexOfCurrentStep: brewingStatus.currentStep.index});
         }
 
 
-        if (brewingStatus?.Type === MashingType.COOKING && !showHopsDialog) {
+        if (brewingStatus?.currentStep?.phase === ProcessPhase.COOKING && !showHopsDialog) {
             this.checkForHopAddition()
         }
-        if(brewingStatus?.Type === MashingType.FINISH && ! showFinishDialog ! && !this.state.brewingFinished)
+        if(brewingStatus?.process?.state === ProcessState.FINISHED && ! showFinishDialog ! && !this.state.brewingFinished)
         {
             this.setState({showFinishDialog: true})
         }
@@ -192,14 +193,25 @@ class Production extends React.Component<ProductionProps, ProductionState> {
     }
 
     checkForHopAddition() {
-        const {hopsTimes} = this.state;
+        const {hopsTimes, announcedHopTimes} = this.state;
         const {brewingStatus} = this.props;
-        const roundedElapsedTime = Math.floor(brewingStatus.elapsedTime)
-            if (hopsTimes.hasOwnProperty(roundedElapsedTime)) {
-                const value = hopsTimes[roundedElapsedTime];
-                this.setState({showHopsDialog: true, hopName: value});
-            }
 
+        // Hopfengaben müssen relativ zur Kochphase berechnet werden,
+        // nicht relativ zur gesamten Sudlaufzeit.
+        const aCookingElapsed = Math.floor(brewingStatus.currentStep?.elapsedTime ?? 0);
+        if (!hopsTimes.hasOwnProperty(aCookingElapsed)) {
+            return;
+        }
+        if (announcedHopTimes.includes(aCookingElapsed)) {
+            return;
+        }
+
+        const aHopName = hopsTimes[aCookingElapsed];
+        this.setState((aPrevState) => ({
+            showHopsDialog: true,
+            hopName: aHopName,
+            announcedHopTimes: [...aPrevState.announcedHopTimes, aCookingElapsed]
+        }));
     }
 
     calculateTheHopTimes() {
@@ -212,7 +224,7 @@ class Production extends React.Component<ProductionProps, ProductionState> {
             hopsDict[secTime] = item.name;
 
         })
-        this.setState({hopsTimes: hopsDict});
+        this.setState({hopsTimes: hopsDict, announcedHopTimes: []});
     }
 
     setAgitatorStates(mainSwitchState: boolean) {
@@ -329,7 +341,7 @@ class Production extends React.Component<ProductionProps, ProductionState> {
 
         return (
             <div className='Flame'>
-              {brewingStatus?.HeatingStates === HeatingStates.ON && (
+              {(brewingStatus?.hardware?.heater === HeatingStates.ON || brewingStatus?.currentStep?.mode === ProcessMode.HEATING) && (
                     <>
                         <Flame/>
                         <Flame/>
@@ -381,12 +393,12 @@ class Production extends React.Component<ProductionProps, ProductionState> {
     renderTemperature() {
         const {brewingStatus, temperature} = this.props;
         let value: number;
-        if (brewingStatus?.Temperature === undefined || Number(brewingStatus?.Temperature) === 0) {
+        if (brewingStatus?.temperature?.current === undefined || Number(brewingStatus?.temperature?.current) === 0) {
             value = temperature;
         } else {
-            value = isNaN(Number(brewingStatus?.Temperature)) ? 0 : Number(brewingStatus?.Temperature);
+            value = isNaN(Number(brewingStatus?.temperature?.current)) ? 0 : Number(brewingStatus?.temperature?.current);
         }
-        const targetValue = isNaN(Number(brewingStatus?.TargetTemperature)) ? 0 : Number(brewingStatus?.TargetTemperature);
+        const targetValue = isNaN(Number(brewingStatus?.temperature?.target)) ? 0 : Number(brewingStatus?.temperature?.target);
         return (<div className="Temp">
             <Gauge showAreas={true} value={value} targetValue={targetValue}
                    height={220}
@@ -494,7 +506,7 @@ class Production extends React.Component<ProductionProps, ProductionState> {
 
             <div className="Water">
                 <WaterControl liters={waterStatus.liters} agitatorSpeed={currentAgitatorSpeed}
-                              agitatorState={brewingStatus?.AgitatorStatus}></WaterControl>
+                              agitatorState={brewingStatus?.hardware?.agitator === "ON"}></WaterControl>
 
             </div>);
     }
@@ -503,12 +515,12 @@ class Production extends React.Component<ProductionProps, ProductionState> {
         const {brewingStatus} = this.props;
         let statusText = '';
         if (!isUndefined(brewingStatus)) {
-                statusText = TextMapper.mapToText(brewingStatus?.StatusText);
+                statusText = getBrewingStatusLabel(brewingStatus);
 
-                if(brewingStatus?.HeatingStates === HeatingStates.ON){
+                if(brewingStatus?.currentStep?.mode === ProcessMode.HEATING){
                     return (
                         <div className="container mt-4">
-                            <h3 className='progressLabel'>{brewingStatus.Name}</h3>
+                            <h3 className='progressLabel'>{brewingStatus.currentStep?.name ?? "-"}</h3>
                             <p className='progressLabel'>{statusText}</p>
                         </div>
                     );
@@ -523,7 +535,7 @@ class Production extends React.Component<ProductionProps, ProductionState> {
                 };
                 return (
                     <div className="container mt-4">
-                        <h3 className='progressLabel'>{brewingStatus.Name}</h3>
+                        <h3 className='progressLabel'>{brewingStatus.currentStep?.name ?? "-"}</h3>
                         <p className='progressLabel'>{statusText}</p>
                             <ProgressBar animated striped now={finishedInPercent} label={`${finishedInPercent}%`}
                                          style={progressBarStyle}/>
@@ -607,7 +619,7 @@ class Production extends React.Component<ProductionProps, ProductionState> {
     renderProcessList() {
         const { selectedBeer, brewingStatus } = this.props;
         // Fallback auf 0, falls brewingStatus oder brewingStatus.index nicht definiert ist
-        const currentStepIndex = brewingStatus && typeof brewingStatus.index === 'number' ? brewingStatus.index : 0;
+        const currentStepIndex = brewingStatus && typeof brewingStatus.currentStep?.index === 'number' ? brewingStatus.currentStep.index : 0;
         return (
             <ProcessList selectedBeer={selectedBeer} currentStepIndex={currentStepIndex} onNextStep={this.props.nextProcedureStep} />
         );
@@ -621,8 +633,8 @@ class Production extends React.Component<ProductionProps, ProductionState> {
         return (
             <div className="containerProduction ">
                 {
-                    //showHopsDialog &&
-                    //(this.renderHopDialog())
+                    showHopsDialog &&
+                    (this.renderHopDialog())
                 }
                 {
                     isBackenAvailable &&

--- a/src/containers/index.tsx
+++ b/src/containers/index.tsx
@@ -6,15 +6,15 @@ import Production from "./Production/Production";
 import DatabaseOverview from "./DatabaseOverview/BeerForm";
 import SimpleBar from "simplebar-react";
 import ModalDialog, {DialogType} from "../components/ModalDialog/ModalDialog";
-import {BrewingStatus} from "../model/BrewingStatus";
+import {BrewingStatus} from "../model/brewingStatus.types";
 import {BeerActions, ProductionActions} from "../actions/actions";
 import {ConfirmStates} from "../enums/eConfirmStates";
-import {TextMapper} from "../utils/TextMapper";
 import {FinishedBrew} from "../model/FinishedBrew";
 import FinishedBrewsTable from "./MainView/FinishBrewsBeers/FinishedBrewsTable";
 import BrewingCalculations from "./BrewingCalculations/BrewingCalculations";
 import IngredientsFormPage from "./DatabaseOverview/IngredientsFormPage";
 import SettingsPage from "./Settings/SettingsPage";
+import {getBrewingStatusLabel, shouldShowConfirmButton, shouldShowWaitingDialog} from "../utils/brewingStatus/selectors";
 
 interface indexMainProps {
     viewState: Views;
@@ -37,8 +37,8 @@ class Index extends React.Component<indexMainProps> {
     componentDidUpdate(prevProps: Readonly<indexMainProps>, prevState: Readonly<{}>, snapshot?: any) {
         const {brewingStatus} = this.props;
 
-        if (brewingStatus?.HeatUpStatus !== prevProps?.brewingStatus?.HeatUpStatus) {
-            console.log("HeatUpStatus has changed");
+        if (brewingStatus?.currentStep?.mode !== prevProps?.brewingStatus?.currentStep?.mode) {
+            console.log("Step mode has changed");
         }
     }
 
@@ -48,19 +48,7 @@ class Index extends React.Component<indexMainProps> {
     }
 
     getDialogMessage() {
-        const {brewingStatus} = this.props;
-        switch (brewingStatus?.StatusText) {
-            case 'WAITING_FOR_MASHING_IN':
-                return 'Einmaischen, bitte abschließen';
-            case 'WAITING_FOR_IODINE_TEST':
-                return 'Bitte Jod Test durchführen!';
-            case 'WAITING_FOR_COOKING_START':
-                return 'Kann der Koch Prozess gestartet werden?';
-            case 'WAITING_FOR_WATER_BOIL':
-                return 'Bitte bestätigen, wenn Wasser kocht!';
-            default:
-                return '';
-        }
+        return getBrewingStatusLabel(this.props.brewingStatus);
     }
 
     showDialog() {
@@ -70,10 +58,10 @@ class Index extends React.Component<indexMainProps> {
             <div>
                 <ModalDialog
                     type={DialogType.CONFIRM}
-                    open={brewingStatus?.WaitingStatus}
+                    open={shouldShowWaitingDialog(brewingStatus)}
                     content={message}
                     header={"Confirm"}
-                    onConfirm={this.confirmDialog}
+                    onConfirm={shouldShowConfirmButton(brewingStatus) ? this.confirmDialog : () => {}}
                 />
             </div>
         );

--- a/src/epics/productionEpics.ts
+++ b/src/epics/productionEpics.ts
@@ -3,11 +3,11 @@ import {from, of, interval, EMPTY, timer, filter, takeWhile, startWith, Observab
 import { catchError, map, mergeMap, switchMap, takeUntil, delay, retryWhen, take, toArray } from 'rxjs/operators';
 import { ProductionActions } from '../actions/actions';
 import { ProductionRepository } from '../repositorys/ProductionRepository';
-import {BrewingStatus} from "../model/BrewingStatus";
 import { delayWhen } from 'rxjs/operators';
 import { dataCollector } from '../utils/DataCollector/dataCollector';
 import { WebSocketController } from '../utils/WebSocketController';
 import {BaseURL} from "../global";
+import {isProcessAborted, isProcessFinished, isProcessInError} from "../utils/brewingStatus/selectors";
 
 const BREWING_STATUS_POLL_INTERVAL = 1000;
 const WS_URL = (typeof BaseURL !== 'undefined' ? BaseURL : '').replace(/^http/, 'ws');
@@ -87,7 +87,7 @@ export const sendBrewingDataEpic$ = (action$: any) =>
                 if (startResult) {
                   return interval(BREWING_STATUS_POLL_INTERVAL).pipe(
                     switchMap(() => from(ProductionRepository.getBrewingStatus())),
-                    takeWhile(({ brewingStatus }) => brewingStatus?.StatusText !== "BREWING_FINISHED", true),
+                    takeWhile(({ brewingStatus }) => !(brewingStatus && (isProcessFinished(brewingStatus) || isProcessAborted(brewingStatus) || isProcessInError(brewingStatus))), true),
                     switchMap(({ available, brewingStatus }) => {
                       if (available?.isBackenAvailable && brewingStatus !== undefined) {
                         // BrewingStatus im DataCollector speichern

--- a/src/model/BrewingStatus.ts
+++ b/src/model/BrewingStatus.ts
@@ -1,20 +1,6 @@
-import {ToggleState} from "../enums/eToggleState";
+export type {BrewingStatus} from './brewingStatus.types';
 
 export enum HeatingStates {
-    ON = "HeatingStates.ON",
-    OFF = "HeatingStates.OFF"
-}
-export interface BrewingStatus {
-    elapsedTime: number;
-    currentTime: number,
-    Temperature: number,
-    TargetTemperature: number,
-    StatusText: string,
-    HeatingStates: string,
-    Name: string,
-    Type: string,
-    WaitingStatus: boolean,
-    HeatUpStatus: boolean,
-    AgitatorStatus: boolean,
-    index: number,
+    ON = 'ON',
+    OFF = 'OFF'
 }

--- a/src/model/brewingStatus.types.ts
+++ b/src/model/brewingStatus.types.ts
@@ -1,0 +1,87 @@
+export enum ProcessState {
+    IDLE = "IDLE",
+    ACTIVE = "ACTIVE",
+    FINISHED = "FINISHED",
+    ABORTED = "ABORTED",
+    ERROR = "ERROR"
+}
+
+export enum ProcessPhase {
+    NONE = "NONE",
+    MASHING_IN = "MASHING_IN",
+    RAST = "RAST",
+    MASHING_OUT = "MASHING_OUT",
+    COOKING = "COOKING",
+    COOLING = "COOLING",
+    FINISHED = "FINISHED"
+}
+
+export enum ProcessMode {
+    NONE = "NONE",
+    HEATING = "HEATING",
+    HOLDING = "HOLDING",
+    TIMER_RUNNING = "TIMER_RUNNING",
+    WAITING = "WAITING",
+    FINISHED = "FINISHED",
+    ERROR = "ERROR"
+}
+
+export enum WaitingFor {
+    NONE = "NONE",
+    USER_CONFIRMATION = "USER_CONFIRMATION",
+    IODINE_TEST = "IODINE_TEST",
+    MASHING_IN_CONFIRMATION = "MASHING_IN_CONFIRMATION",
+    MASHING_OUT_CONFIRMATION = "MASHING_OUT_CONFIRMATION",
+    COOKING_CONFIRMATION = "COOKING_CONFIRMATION",
+    BOILING_CONFIRMATION = "BOILING_CONFIRMATION"
+}
+
+export interface BrewingStatus {
+    elapsedTime: number;
+    currentTime: number;
+    process: {
+        state: ProcessState;
+    };
+    currentStep: {
+        index?: number;
+        count?: number;
+        phase: ProcessPhase;
+        mode: ProcessMode;
+        name?: string;
+        duration?: number;
+        elapsedTime?: number;
+        remainingTime?: number;
+        type?: string;
+    };
+    temperature: {
+        current?: number;
+        target?: number;
+    };
+    hardware: {
+        heater?: string;
+        agitator?: string;
+    };
+    waiting: {
+        waitingFor: WaitingFor;
+        canConfirm: boolean;
+    };
+    error: {
+        code?: string | null;
+        details?: string | null;
+    };
+}
+
+export type LegacyBrewingStatus = {
+    elapsedTime?: number;
+    currentTime?: number;
+    Temperature?: number;
+    TargetTemperature?: number;
+    StatusText?: string;
+    HeatingStates?: string;
+    Name?: string;
+    Type?: string;
+    WaitingStatus?: boolean;
+    HeatUpStatus?: boolean;
+    AgitatorStatus?: boolean;
+    index?: number;
+};

--- a/src/repositorys/ProductionRepository.ts
+++ b/src/repositorys/ProductionRepository.ts
@@ -5,7 +5,8 @@ import {ProductionActions} from "../actions/actions";
 import store from "../store";
 import {MashAgitatorStates} from "../model/MashAgitator";
 import {BrewingData} from "../model/BrewingData";
-import {BrewingStatus} from "../model/BrewingStatus";
+import {BrewingStatus} from "../model/brewingStatus.types";
+import {normalizeBrewingStatus} from "../utils/brewingStatus/normalizeBrewingStatus";
 import {ConfirmStates} from "../enums/eConfirmStates";
 import {WaterStatus} from "../components/Controlls/WaterControll/WaterControl";
 import {BackendAvailable} from "../reducers/productionReducer";
@@ -117,7 +118,7 @@ export class ProductionRepository {
                 const available: BackendAvailable = {
                     isBackenAvailable: true, statusText: response.statusText
                 };
-                const parsedBrewingStatus: BrewingStatus = JSON.parse(JSON.stringify(response.data));
+                const parsedBrewingStatus: BrewingStatus = normalizeBrewingStatus(response.data);
                 return { available, brewingStatus: parsedBrewingStatus };
             } else {
                 const available: BackendAvailable = {

--- a/src/utils/DataCollector/dataCollector.ts
+++ b/src/utils/DataCollector/dataCollector.ts
@@ -1,4 +1,5 @@
-import { BrewingStatus } from '../../model/BrewingStatus';
+import { BrewingStatus } from '../../model/brewingStatus.types';
+import { getStatusChangeKey } from '../brewingStatus/selectors';
 
 interface BrewingStatusMeasurement {
   elapsedTime: number;
@@ -8,84 +9,35 @@ interface BrewingStatusMeasurement {
 }
 
 type BrewingStatusGrouped = {
-  [name: string]: {
-    [statusText: string]: BrewingStatusMeasurement[];
-  };
+  [statusKey: string]: BrewingStatusMeasurement[];
 };
 
 class DataCollector {
   private brewingStatus: BrewingStatus | null = null;
   private groupedData: BrewingStatusGrouped = {};
-  private lastStatusKey: { Name: string; StatusText: string } | null = null;
-  private lastMeasurement: BrewingStatusMeasurement | null = null;
+  private lastStatusKey: string | null = null;
 
-  setBrewingStatus(status: BrewingStatus) {
-    const { Name, StatusText, elapsedTime, currentTime, Temperature, TargetTemperature } = status;
-
-    const currentKey = { Name, StatusText };
-    const currentMeasurement: BrewingStatusMeasurement = {
-      elapsedTime,
-      currentTime,
-      Temperature,
-      TargetTemperature,
+  setBrewingStatus(aStatus: BrewingStatus) {
+    const aStatusKey = getStatusChangeKey(aStatus);
+    const aCurrentMeasurement: BrewingStatusMeasurement = {
+      elapsedTime: aStatus.elapsedTime,
+      currentTime: aStatus.currentTime,
+      // Kompatibilitätsausgabe für bestehende Charts/Export.
+      Temperature: Number(aStatus.temperature.current ?? 0),
+      TargetTemperature: Number(aStatus.temperature.target ?? 0),
     };
 
-    const isStatusChanged =
-        this.lastStatusKey &&
-        (this.lastStatusKey.Name !== Name || this.lastStatusKey.StatusText !== StatusText);
-
-    // Falls der Status sich geändert hat, füge die letzte Messung dem vorherigen Status hinzu
-    if (isStatusChanged && this.lastStatusKey && this.lastMeasurement) {
-      const { Name: prevName, StatusText: prevStatusText } = this.lastStatusKey;
-
-      if (!this.groupedData[prevName]) {
-        this.groupedData[prevName] = {};
-      }
-
-      if (!this.groupedData[prevName][prevStatusText]) {
-        this.groupedData[prevName][prevStatusText] = [];
-      }
-
-      this.groupedData[prevName][prevStatusText].push(this.lastMeasurement);
-      console.debug('[DataCollector] Statuswechsel: letzte Messung übernommen:', {
-        prevName,
-        prevStatusText,
-        lastMeasurement: this.lastMeasurement
-      });
+    if (!this.groupedData[aStatusKey]) {
+      this.groupedData[aStatusKey] = [];
     }
 
-    // Initialisiere aktuelle Gruppe, falls nicht vorhanden
-    if (!this.groupedData[Name]) {
-      this.groupedData[Name] = {};
+    const aLastStored = this.groupedData[aStatusKey].at(-1);
+    if (!aLastStored || aLastStored.Temperature !== aCurrentMeasurement.Temperature) {
+      this.groupedData[aStatusKey].push(aCurrentMeasurement);
     }
 
-    if (!this.groupedData[Name][StatusText]) {
-      // Neue Gruppe → erste Messung direkt speichern
-      this.groupedData[Name][StatusText] = [currentMeasurement];
-      console.debug('[DataCollector] Neuer Status → erste Messung gespeichert:', {
-        Name,
-        StatusText,
-        groupedLength: 1,
-        measurement: currentMeasurement,
-      });
-    } else {
-      const lastStored = this.groupedData[Name][StatusText].at(-1);
-
-      if (lastStored?.Temperature !== Temperature) {
-        this.groupedData[Name][StatusText].push(currentMeasurement);
-        console.debug('[DataCollector] Temperaturänderung → neue Messung gespeichert:', {
-          Name,
-          StatusText,
-          groupedLength: this.groupedData[Name][StatusText].length,
-          measurement: currentMeasurement,
-        });
-      }
-    }
-
-    // Status & letzte Messung merken
-    this.lastStatusKey = currentKey;
-    this.lastMeasurement = currentMeasurement;
-    this.brewingStatus = status;
+    this.lastStatusKey = aStatusKey;
+    this.brewingStatus = aStatus;
   }
 
   getAllDataAsBlob(): Blob {

--- a/src/utils/brewingStatus/normalizeBrewingStatus.test.ts
+++ b/src/utils/brewingStatus/normalizeBrewingStatus.test.ts
@@ -1,0 +1,26 @@
+import {normalizeBrewingStatus} from './normalizeBrewingStatus';
+import {ProcessMode, ProcessPhase, ProcessState, WaitingFor} from '../../model/brewingStatus.types';
+
+describe('normalizeBrewingStatus', () => {
+  it('uses structured payload', () => {
+    const s = normalizeBrewingStatus({process:{state:'ACTIVE'}, currentStep:{phase:'RAST', mode:'TIMER_RUNNING', remainingTime:12}, waiting:{waitingFor:'NONE', canConfirm:false}, temperature:{current:60,target:63}});
+    expect(s.process.state).toBe(ProcessState.ACTIVE);
+    expect(s.currentStep.phase).toBe(ProcessPhase.RAST);
+    expect(s.currentStep.mode).toBe(ProcessMode.TIMER_RUNNING);
+  });
+
+  it('falls back to legacy payload', () => {
+    const s = normalizeBrewingStatus({Type:'COOKING', HeatUpStatus:true, WaitingStatus:false, Temperature:50, TargetTemperature:100, AgitatorStatus:true});
+    expect(s.currentStep.phase).toBe(ProcessPhase.COOKING);
+    expect(s.currentStep.mode).toBe(ProcessMode.HEATING);
+    expect(s.temperature.current).toBe(50);
+    expect(s.hardware.agitator).toBe('ON');
+  });
+
+  it('structured values win over legacy values', () => {
+    const s = normalizeBrewingStatus({process:{state:'FINISHED'}, currentStep:{phase:'RAST', mode:'HOLDING'}, Type:'COOKING', HeatUpStatus:true, waiting:{waitingFor:'IODINE_TEST', canConfirm:true}});
+    expect(s.currentStep.phase).toBe(ProcessPhase.RAST);
+    expect(s.currentStep.mode).toBe(ProcessMode.HOLDING);
+    expect(s.waiting.waitingFor).toBe(WaitingFor.IODINE_TEST);
+  });
+});

--- a/src/utils/brewingStatus/normalizeBrewingStatus.ts
+++ b/src/utils/brewingStatus/normalizeBrewingStatus.ts
@@ -1,0 +1,22 @@
+import {BrewingStatus, LegacyBrewingStatus, ProcessMode, ProcessPhase, ProcessState, WaitingFor} from '../../model/brewingStatus.types';
+const isObject = (aValue: unknown): aValue is Record<string, any> => typeof aValue === 'object' && aValue !== null;
+const normalizePhase = (aValue: unknown): ProcessPhase => { if (typeof aValue !== 'string') return ProcessPhase.NONE; const mapped = aValue.toUpperCase(); return (Object.values(ProcessPhase) as string[]).includes(mapped) ? mapped as ProcessPhase : ProcessPhase.NONE; };
+const normalizeMode = (aValue: unknown): ProcessMode => { if (typeof aValue !== 'string') return ProcessMode.NONE; const mapped = aValue.toUpperCase(); return (Object.values(ProcessMode) as string[]).includes(mapped) ? mapped as ProcessMode : ProcessMode.NONE; };
+const normalizeState = (aValue: unknown): ProcessState => { if (typeof aValue !== 'string') return ProcessState.IDLE; const mapped = aValue.toUpperCase(); return (Object.values(ProcessState) as string[]).includes(mapped) ? mapped as ProcessState : ProcessState.IDLE; };
+const normalizeWaitingFor = (aValue: unknown): WaitingFor => { if (typeof aValue !== 'string') return WaitingFor.NONE; const mapped = aValue.toUpperCase(); return (Object.values(WaitingFor) as string[]).includes(mapped) ? mapped as WaitingFor : WaitingFor.NONE; };
+const mapLegacyTypeToPhase = (aType: unknown): ProcessPhase => { const value = typeof aType === 'string' ? aType.toUpperCase() : ''; if (value.includes('COOK')) return ProcessPhase.COOKING; if (value.includes('FINISH')) return ProcessPhase.FINISHED; if (value.includes('RAST')) return ProcessPhase.RAST; if (value.includes('MASHING_IN') || value.includes('EINMA')) return ProcessPhase.MASHING_IN; if (value.includes('MASHING_OUT') || value.includes('ABMA')) return ProcessPhase.MASHING_OUT; return ProcessPhase.NONE; };
+/**
+ * Zentrale Kompatibilitätsschicht:
+ * - Neue strukturierte Backend-Felder sind führend.
+ * - Alte UI-Felder sind nur Fallback.
+ * So vermeiden wir, dass Komponenten wieder direkt an StatusText & Co. gekoppelt werden.
+ */
+export const normalizeBrewingStatus = (aRawStatus: unknown): BrewingStatus => {
+ const aRaw = isObject(aRawStatus) ? aRawStatus : {}; const aLegacy = aRaw as LegacyBrewingStatus;
+ const aLegacyPhase = mapLegacyTypeToPhase(aLegacy.Type);
+ const aStructuredPhase = normalizePhase(aRaw.currentStep?.phase);
+ let aLegacyMode = ProcessMode.NONE; if (aLegacy.WaitingStatus === true) aLegacyMode = ProcessMode.WAITING; else if (aLegacy.HeatUpStatus === true) aLegacyMode = ProcessMode.HEATING;
+ const aHeater = typeof aRaw.hardware?.heater === 'string' ? aRaw.hardware.heater : (typeof aLegacy.HeatingStates === 'string' ? (aLegacy.HeatingStates.includes('ON') ? 'ON' : 'OFF') : undefined);
+ const aAgitator = typeof aRaw.hardware?.agitator === 'string' ? aRaw.hardware.agitator : (typeof aLegacy.AgitatorStatus === 'boolean' ? (aLegacy.AgitatorStatus ? 'ON' : 'OFF') : undefined);
+ return { elapsedTime: Number(aRaw.elapsedTime ?? aLegacy.elapsedTime ?? 0), currentTime: Number(aRaw.currentTime ?? aLegacy.currentTime ?? 0), process: { state: normalizeState(aRaw.process?.state) }, currentStep: { index: typeof aRaw.currentStep?.index === 'number' ? aRaw.currentStep.index : aLegacy.index, count: typeof aRaw.currentStep?.count === 'number' ? aRaw.currentStep.count : undefined, phase: aStructuredPhase !== ProcessPhase.NONE ? aStructuredPhase : aLegacyPhase, mode: (() => { const aMode = normalizeMode(aRaw.currentStep?.mode); return aMode !== ProcessMode.NONE ? aMode : aLegacyMode; })(), name: aRaw.currentStep?.name ?? aLegacy.Name, duration: aRaw.currentStep?.duration, elapsedTime: aRaw.currentStep?.elapsedTime, remainingTime: aRaw.currentStep?.remainingTime, type: aRaw.currentStep?.type ?? aLegacy.Type }, temperature: { current: aRaw.temperature?.current ?? aLegacy.Temperature, target: aRaw.temperature?.target ?? aLegacy.TargetTemperature }, hardware: { heater: aHeater, agitator: aAgitator }, waiting: { waitingFor: normalizeWaitingFor(aRaw.waiting?.waitingFor), canConfirm: typeof aRaw.waiting?.canConfirm === 'boolean' ? aRaw.waiting.canConfirm : !!aLegacy.WaitingStatus }, error: { code: aRaw.error?.code ?? null, details: aRaw.error?.details ?? null } };
+};

--- a/src/utils/brewingStatus/selectors.test.ts
+++ b/src/utils/brewingStatus/selectors.test.ts
@@ -1,0 +1,30 @@
+import {getBrewingStatusLabel, getConfirmButtonLabel, shouldShowConfirmButton, shouldShowCountdown} from './selectors';
+import {BrewingStatus, ProcessMode, ProcessPhase, ProcessState, WaitingFor} from '../../model/brewingStatus.types';
+
+const makeStatus = (aPart: Partial<BrewingStatus>): BrewingStatus => ({
+  elapsedTime: 0, currentTime: 0,
+  process: {state: ProcessState.ACTIVE},
+  currentStep: {phase: ProcessPhase.NONE, mode: ProcessMode.NONE},
+  temperature: {}, hardware: {}, waiting: {waitingFor: WaitingFor.NONE, canConfirm: false}, error: {},
+  ...aPart
+});
+
+describe('brewing selectors', () => {
+  it('process priority labels', () => {
+    expect(getBrewingStatusLabel(makeStatus({process:{state:ProcessState.ERROR}}))).toContain('Fehler');
+    expect(getBrewingStatusLabel(makeStatus({process:{state:ProcessState.ABORTED}}))).toContain('abgebrochen');
+    expect(getBrewingStatusLabel(makeStatus({process:{state:ProcessState.FINISHED}}))).toContain('abgeschlossen');
+    expect(getBrewingStatusLabel(makeStatus({process:{state:ProcessState.IDLE}}))).toContain('Bereit');
+  });
+
+  it('waiting and confirm handling', () => {
+    const s = makeStatus({currentStep:{phase:ProcessPhase.RAST, mode:ProcessMode.WAITING}, waiting:{waitingFor:WaitingFor.IODINE_TEST, canConfirm:true}});
+    expect(shouldShowConfirmButton(s)).toBe(true);
+    expect(getConfirmButtonLabel(s)).toBe('Iodine bestätigen');
+  });
+
+  it('countdown shown only for timer running', () => {
+    expect(shouldShowCountdown(makeStatus({currentStep:{phase:ProcessPhase.RAST, mode:ProcessMode.TIMER_RUNNING}}))).toBe(true);
+    expect(shouldShowCountdown(makeStatus({currentStep:{phase:ProcessPhase.RAST, mode:ProcessMode.HEATING}}))).toBe(false);
+  });
+});

--- a/src/utils/brewingStatus/selectors.ts
+++ b/src/utils/brewingStatus/selectors.ts
@@ -1,0 +1,51 @@
+import {BrewingStatus, ProcessMode, ProcessPhase, ProcessState, WaitingFor} from '../../model/brewingStatus.types';
+
+/**
+ * Diese Selektoren kapseln alle UI-Entscheidungen.
+ * Grundidee: Die UI soll nicht mehr auf alte Textfelder (StatusText etc.) reagieren,
+ * sondern auf strukturierte Backend-Fakten (state/phase/mode/waitingFor).
+ */
+export const isProcessIdle = (aStatus?: BrewingStatus) => aStatus?.process.state === ProcessState.IDLE;
+export const isProcessActive = (aStatus?: BrewingStatus) => aStatus?.process.state === ProcessState.ACTIVE;
+export const isProcessFinished = (aStatus?: BrewingStatus) => aStatus?.process.state === ProcessState.FINISHED;
+export const isProcessAborted = (aStatus?: BrewingStatus) => aStatus?.process.state === ProcessState.ABORTED;
+export const isProcessInError = (aStatus?: BrewingStatus) => aStatus?.process.state === ProcessState.ERROR;
+export const isStepWaiting = (aStatus?: BrewingStatus) => aStatus?.currentStep.mode === ProcessMode.WAITING;
+export const shouldShowWaitingDialog = (aStatus?: BrewingStatus) => !!aStatus && isProcessActive(aStatus) && isStepWaiting(aStatus);
+export const shouldShowConfirmButton = (aStatus?: BrewingStatus) => !!aStatus && isStepWaiting(aStatus) && aStatus.waiting.canConfirm && aStatus.waiting.waitingFor !== WaitingFor.NONE;
+export const getConfirmButtonLabel = (aStatus?: BrewingStatus) => {
+    switch (aStatus?.waiting.waitingFor) {
+        case WaitingFor.IODINE_TEST: return 'Iodine bestätigen';
+        case WaitingFor.MASHING_IN_CONFIRMATION: return 'Einmaischen bestätigen';
+        case WaitingFor.MASHING_OUT_CONFIRMATION: return 'Abmaischen bestätigen';
+        case WaitingFor.COOKING_CONFIRMATION: return 'Kochen bestätigen';
+        case WaitingFor.BOILING_CONFIRMATION: return 'Siedepunkt bestätigen';
+        case WaitingFor.USER_CONFIRMATION: return 'Bestätigen';
+        default: return 'Bestätigen';
+    }
+};
+/** WAITING ist ein Prozess-Blocker. HOLDING ist dagegen nur Temperaturhalten und kein Blocker. */
+export const getBrewingStatusLabel = (aStatus?: BrewingStatus) => {
+    if (!aStatus) return 'Bereit / kein Brauvorgang aktiv';
+    if (isProcessInError(aStatus)) return 'Fehler im Prozess';
+    if (isProcessAborted(aStatus)) return 'Brauvorgang abgebrochen';
+    if (isProcessFinished(aStatus)) return 'Brauvorgang abgeschlossen';
+    if (isProcessIdle(aStatus)) return 'Bereit / kein Brauvorgang aktiv';
+    const aPhase = aStatus.currentStep.phase; const aMode = aStatus.currentStep.mode; const aWaitingFor = aStatus.waiting.waitingFor;
+    if (aMode === ProcessMode.WAITING && aPhase === ProcessPhase.MASHING_IN && aWaitingFor === WaitingFor.MASHING_IN_CONFIRMATION) return 'Einmaischen: bitte bestätigen';
+    if (aMode === ProcessMode.WAITING && aPhase === ProcessPhase.RAST && aWaitingFor === WaitingFor.IODINE_TEST) return 'Warten auf Iodine-Test';
+    if (aMode === ProcessMode.WAITING && aPhase === ProcessPhase.MASHING_OUT && aWaitingFor === WaitingFor.MASHING_OUT_CONFIRMATION) return 'Abmaischen: Bestätigung nötig';
+    if (aMode === ProcessMode.WAITING && aPhase === ProcessPhase.COOKING && aWaitingFor === WaitingFor.BOILING_CONFIRMATION) return 'Warten auf Siedepunkt-Bestätigung';
+    if (aPhase === ProcessPhase.MASHING_IN && aMode === ProcessMode.HEATING) return 'Einmaischen: Aufheizen läuft';
+    if (aPhase === ProcessPhase.RAST && aMode === ProcessMode.HEATING) return 'Rast: Aufheizen auf Solltemperatur';
+    if (aPhase === ProcessPhase.RAST && aMode === ProcessMode.HOLDING) return 'Rasttemperatur wird gehalten';
+    if (aPhase === ProcessPhase.RAST && aMode === ProcessMode.TIMER_RUNNING) return 'Rast läuft';
+    if (aPhase === ProcessPhase.COOKING && aMode === ProcessMode.HEATING) return 'Kochen: Aufheizen';
+    if (aPhase === ProcessPhase.COOKING && aMode === ProcessMode.TIMER_RUNNING) return 'Kochen läuft';
+    return 'Brauprozess aktiv';
+};
+export const shouldShowCountdown = (aStatus?: BrewingStatus) => aStatus?.currentStep.mode === ProcessMode.TIMER_RUNNING;
+export const getCountdownValue = (aStatus?: BrewingStatus) => aStatus?.currentStep.remainingTime ?? aStatus?.currentTime ?? 0;
+export const shouldShowTemperatureStatus = (aStatus?: BrewingStatus) => !!aStatus && isProcessActive(aStatus) && [ProcessMode.HEATING, ProcessMode.HOLDING, ProcessMode.TIMER_RUNNING, ProcessMode.WAITING].includes(aStatus.currentStep.mode);
+export const getCurrentStepIdentity = (aStatus?: BrewingStatus) => `${aStatus?.currentStep.index ?? -1}|${aStatus?.currentStep.phase ?? ProcessPhase.NONE}|${aStatus?.currentStep.mode ?? ProcessMode.NONE}|${aStatus?.currentStep.name ?? ''}`;
+export const getStatusChangeKey = (aStatus?: BrewingStatus) => `${aStatus?.process.state ?? ProcessState.IDLE}|${getCurrentStepIdentity(aStatus)}|${aStatus?.waiting.waitingFor ?? WaitingFor.NONE}`;


### PR DESCRIPTION
### Motivation
- Replace fragile legacy `StatusText`/flat fields with a structured `BrewingStatus` model to make UI logic robust and backend-format agnostic.
- Provide a compatibility layer so older backend payloads still work while new structured fields are preferred.
- Centralize UI decisions (waiting/confirm/labels/countdown) into selectors to avoid duplicated text-based checks spread across components.
- Improve data collection and hop-announcement logic to avoid duplicate announcements and to compute hop times relative to the cooking phase.

### Description
- Add `src/model/brewingStatus.types.ts` defining `BrewingStatus` and enums (`ProcessState`, `ProcessPhase`, `ProcessMode`, `WaitingFor`) and export the type from the legacy model module.
- Implement `normalizeBrewingStatus` in `src/utils/brewingStatus/normalizeBrewingStatus.ts` to merge structured payloads with legacy fallbacks and use it in `ProductionRepository._doGetBrewingStatus`.
- Add selectors (`src/utils/brewingStatus/selectors.ts`) encapsulating UI rules such as `getBrewingStatusLabel`, `shouldShowWaitingDialog`, `shouldShowConfirmButton`, `isStepWaiting` and tests in `selectors.test.ts`.
- Migrate components and code to structured fields and selectors: updated `Production`, `MobileProductionView`, `index.tsx`, `epics/productionEpics.ts`, `DataCollector` and other imports to use the new model and selectors (e.g. temperature fields, heater/agitator state, current step info, process state checks, progress label, polling/WS logic).
- Update `DataCollector` to key grouped measurements by a stable `getStatusChangeKey`, store compatible `Temperature/TargetTemperature` values, and simplify de-duplication logic.
- Fix hop notification logic by calculating elapsed seconds relative to the cooking phase and tracking `announcedHopTimes` to prevent repeat dialogs.
- Add unit tests: `normalizeBrewingStatus.test.ts` and `selectors.test.ts` and minor enum adjustments (`HeatingStates` values) and other import updates.

### Testing
- Ran unit tests for the new normalization logic in `src/utils/brewingStatus/normalizeBrewingStatus.test.ts`, which passed.
- Ran unit tests for the selectors in `src/utils/brewingStatus/selectors.test.ts`, which passed.
- Ran the project's automated test suite (`npm test`) and verified that all tests succeeded after the migration.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9c9d32d58832f9fbfe87f18575893)