### PR TITLE
Make brewing status polling resilient and set polling flag on stop

### DIFF
--- a/src/epics/productionEpics.ts
+++ b/src/epics/productionEpics.ts
@@ -1,9 +1,8 @@
 import { ofType } from 'redux-observable';
-import {from, of, interval, EMPTY, timer, filter, takeWhile, startWith, Observable} from 'rxjs';
-import { catchError, map, mergeMap, switchMap, takeUntil, delay, retryWhen, take, toArray } from 'rxjs/operators';
+import {from, of, interval, EMPTY, filter, takeWhile, startWith, Observable} from 'rxjs';
+import { catchError, map, mergeMap, switchMap, takeUntil } from 'rxjs/operators';
 import { ProductionActions } from '../actions/actions';
 import { ProductionRepository } from '../repositorys/ProductionRepository';
-import { delayWhen } from 'rxjs/operators';
 import { dataCollector } from '../utils/DataCollector/dataCollector';
 import { WebSocketController } from '../utils/WebSocketController';
 import {BaseURL} from "../global";
@@ -86,7 +85,12 @@ export const sendBrewingDataEpic$ = (action$: any) =>
               switchMap((startResult) => {
                 if (startResult) {
                   return interval(BREWING_STATUS_POLL_INTERVAL).pipe(
-                    switchMap(() => from(ProductionRepository.getBrewingStatus())),
+                    switchMap(() =>
+                      from(ProductionRepository.getBrewingStatus()).pipe(
+                        catchError(() => of(null))
+                      )
+                    ),
+                    filter((status): status is { available: any; brewingStatus: any } => status !== null),
                     takeWhile(({ brewingStatus }) => !(brewingStatus && (isProcessFinished(brewingStatus) || isProcessAborted(brewingStatus) || isProcessInError(brewingStatus))), true),
                     switchMap(({ available, brewingStatus }) => {
                       if (available?.isBackenAvailable && brewingStatus !== undefined) {

--- a/src/reducers/productionReducer.ts
+++ b/src/reducers/productionReducer.ts
@@ -83,7 +83,7 @@ const productionReducer = (
             return { ...aState, isPollingRunning: true };
         }
         case ProductionActions.ActionTypes.STOP_POLLING: {
-            return { ...aState };
+            return { ...aState, isPollingRunning: false };
         }
         case ProductionActions.ActionTypes.CONFIRM: {
             return { ...aState };


### PR DESCRIPTION
### Motivation
- Temporary failures from `getBrewingStatus()` (e.g. during a step transition) caused the entire polling interval to terminate, stopping UI updates. 
- The reducer did not clear the polling flag, leaving `isPollingRunning` inconsistent after a stop. 
- Some RxJS imports were unused after the polling resilience changes and should be cleaned up. 

### Description
- In `sendBrewingDataEpic$` wrap each tick's `from(ProductionRepository.getBrewingStatus())` in a per-tick `catchError(() => of(null))` and add a `filter` to ignore `null` results so transient request failures do not terminate the interval stream. 
- In `productionReducer` set `isPollingRunning: false` on the `STOP_POLLING` action so the state reflects that polling has stopped. 
- Removed now-unused RxJS imports from `src/epics/productionEpics.ts`. 

### Testing
- Attempted to run unit tests with `npm test -- --watch=false --runInBand src/repositorys/ProductionRepository.test.ts`, but the test run failed in this environment because `react-scripts` is not installed. 
- No other automated tests were executed in this environment; changes are limited and isolated to `src/epics/productionEpics.ts` and `src/reducers/productionReducer.ts`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa2619fba8832f8b347ff4d6f60108)