### PR TITLE
Add productionRecipe mapping/validation and integrate into Production start flow

### DIFF
--- a/src/containers/Production/Production.tsx
+++ b/src/containers/Production/Production.tsx
@@ -15,6 +15,7 @@ import {ToggleState} from "../../enums/eToggleState";
 import {MashAgitatorStates} from "../../model/MashAgitator";
 import QuantityPicker from '../../components/Controlls/QuantityPicker/QuantityPicker';
 import {BrewingData} from "../../model/BrewingData";
+import {mapBeerToBrewingData} from "../../utils/productionRecipe";
 import {HeatingStates} from "../../model/BrewingStatus";
 import {BrewingStatus, ProcessMode, ProcessPhase, ProcessState} from "../../model/brewingStatus.types";
 import {TimeFormatter} from "../../utils/TimeFormatter";
@@ -300,20 +301,13 @@ class Production extends React.Component<ProductionProps, ProductionState> {
     }
     startBrewing = () => {
         const {selectedBeer, sendBrewingData} = this.props;
-        const ein = selectedBeer.fermentation.find(item => item.type === 'Einmaischen');
-        const aus = selectedBeer.fermentation.find(item => item.type === 'Abmaischen');
-
-        if (ein?.temperature !== undefined && aus?.temperature !== undefined) {
-            const brewingData: BrewingData = {
-                MashdownTemperature: aus.temperature,
-                MashupTemperature: ein.temperature,
-                CookingTemperature: selectedBeer.cookingTemperatur,
-                CookingTime: selectedBeer.cookingTime,
-                Rasten: selectedBeer.fermentation
-            }
-            this.setState({brewingIsRunning: true});
-            sendBrewingData(brewingData);
+        const result = mapBeerToBrewingData(selectedBeer);
+        if (!result.ok || !result.brewingData) {
+            alert(result.error ?? 'Rezeptdaten sind für den Start ungültig.');
+            return;
         }
+        this.setState({brewingIsRunning: true});
+        sendBrewingData(result.brewingData as BrewingData);
     }
 
     startPolling = () => {

--- a/src/utils/productionRecipe.test.ts
+++ b/src/utils/productionRecipe.test.ts
@@ -1,0 +1,74 @@
+import { mapBeerToBrewingData } from './productionRecipe';
+import { RestExecutionMode } from '../enums/eRestExecutionMode';
+import { Beer } from '../model/Beer';
+
+const makeBeer = (overrides?: Partial<Beer>): Beer => ({
+  id: '1',
+  name: 'Test',
+  type: 'Ale',
+  color: 'Amber',
+  alcohol: 5,
+  originalwort: 12,
+  bitterness: 30,
+  description: '',
+  rating: 0,
+  mashVolume: 10,
+  spargeVolume: 5,
+  cookingTime: 60,
+  cookingTemperatur: 100,
+  fermentation: [
+    { type: 'Einmaischen', temperature: 52, time: 10 },
+    { type: 'Rast 1', temperature: 64, time: 40, executionMode: RestExecutionMode.TIMED },
+    { type: 'Dickmaische führen', temperature: 66, time: 0, executionMode: RestExecutionMode.CONFIRMATION_HOLD },
+    { type: 'Abmaischen', temperature: 78, time: 10 }
+  ],
+  malts: [],
+  wortBoiling: { totalTime: 60, hops: [] },
+  fermentationMaturation: { fermentationTemperature: 18, carbonation: 2.5, yeast: [] },
+  ...overrides,
+});
+
+describe('productionRecipe mapping', () => {
+  it('keeps executionMode in /Recipe/ payload and strips time for CONFIRMATION_HOLD', () => {
+    const result = mapBeerToBrewingData(makeBeer());
+
+    expect(result.ok).toBe(true);
+    const decoction = result.brewingData?.Rasten.find((s) => s.type === 'Dickmaische führen');
+    expect(decoction).toEqual(expect.objectContaining({ executionMode: RestExecutionMode.CONFIRMATION_HOLD }));
+    expect(decoction).not.toHaveProperty('time');
+  });
+
+  it('normalizes missing executionMode to TIMED for production payload', () => {
+    const result = mapBeerToBrewingData(makeBeer({ fermentation: [
+      { type: 'Einmaischen', temperature: 52, time: 10 },
+      { type: 'Rast 1', temperature: 64, time: 40 },
+      { type: 'Abmaischen', temperature: 78, time: 10 }
+    ] }));
+
+    expect(result.ok).toBe(true);
+    const rest = result.brewingData?.Rasten.find((s) => s.type === 'Rast 1');
+    expect(rest).toEqual(expect.objectContaining({ executionMode: RestExecutionMode.TIMED, time: 40 }));
+  });
+
+  it('blocks TIMED rest with missing/invalid time before sending', () => {
+    const result = mapBeerToBrewingData(makeBeer({ fermentation: [
+      { type: 'Einmaischen', temperature: 52, time: 10 },
+      { type: 'Rast 1', temperature: 64, executionMode: RestExecutionMode.TIMED },
+      { type: 'Abmaischen', temperature: 78, time: 10 }
+    ] }));
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain('Zeitgesteuerte Rast');
+  });
+
+  it('does not infer CONFIRMATION_HOLD from time=0', () => {
+    const result = mapBeerToBrewingData(makeBeer({ fermentation: [
+      { type: 'Einmaischen', temperature: 52, time: 10 },
+      { type: 'Rast 1', temperature: 64, time: 0 },
+      { type: 'Abmaischen', temperature: 78, time: 10 }
+    ] }));
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain('Zeitgesteuerte Rast');
+  });
+});

--- a/src/utils/productionRecipe.ts
+++ b/src/utils/productionRecipe.ts
@@ -1,0 +1,67 @@
+import { Beer, FermentationSteps } from '../model/Beer';
+import { BrewingData } from '../model/BrewingData';
+import { RestExecutionMode } from '../enums/eRestExecutionMode';
+
+const isValidTemperature = (value: unknown) => typeof value === 'number' && Number.isFinite(value) && value > 0;
+const isValidTimedDuration = (value: unknown) => typeof value === 'number' && Number.isFinite(value) && value > 0;
+
+export interface ProductionRecipeNormalizationResult {
+  ok: boolean;
+  brewingData?: BrewingData;
+  fermentationSteps?: FermentationSteps[];
+  error?: string;
+}
+
+export function normalizeFermentationStepsForProduction(steps: FermentationSteps[]): ProductionRecipeNormalizationResult {
+  const normalized: FermentationSteps[] = [];
+
+  for (const step of steps ?? []) {
+    const executionMode = step.executionMode ?? RestExecutionMode.TIMED;
+
+    if (!isValidTemperature(step.temperature)) {
+      return { ok: false, error: `Ungültige Rasttemperatur bei Schritt "${step.type}".` };
+    }
+
+    // Wichtig: executionMode steuert die Logik. time=0 markiert NICHT CONFIRMATION_HOLD.
+    if (executionMode === RestExecutionMode.CONFIRMATION_HOLD) {
+      const { time, ...restWithoutTime } = step;
+      normalized.push({ ...restWithoutTime, executionMode });
+      continue;
+    }
+
+    if (!isValidTimedDuration(step.time)) {
+      return { ok: false, error: `Zeitgesteuerte Rast "${step.type}" benötigt Zeit > 0.` };
+    }
+
+    normalized.push({
+      ...step,
+      executionMode,
+      time: step.time
+    });
+  }
+
+  return { ok: true, fermentationSteps: normalized };
+}
+
+export function mapBeerToBrewingData(beer: Beer): ProductionRecipeNormalizationResult {
+  const ein = beer.fermentation.find(item => item.type === 'Einmaischen');
+  const aus = beer.fermentation.find(item => item.type === 'Abmaischen');
+
+  if (!ein || !aus || !isValidTemperature(ein.temperature) || !isValidTemperature(aus.temperature)) {
+    return { ok: false, error: 'Einmaischen/Abmaischen Temperatur fehlt oder ist ungültig.' };
+  }
+
+  const normalizedStepsResult = normalizeFermentationStepsForProduction(beer.fermentation);
+  if (!normalizedStepsResult.ok) return normalizedStepsResult;
+
+  return {
+    ok: true,
+    brewingData: {
+      MashdownTemperature: aus.temperature,
+      MashupTemperature: ein.temperature,
+      CookingTemperature: beer.cookingTemperatur,
+      CookingTime: beer.cookingTime,
+      Rasten: normalizedStepsResult.fermentationSteps ?? []
+    }
+  };
+}


### PR DESCRIPTION
### Motivation

- Centralize and validate conversion from `Beer` model to `BrewingData` for starting a brew and prevent invalid recipes from being sent to the backend. 
- Make rest execution modes explicit and avoid inferring `CONFIRMATION_HOLD` from `time = 0`, and ensure timed rests have a positive duration.

### Description

- Add `src/utils/productionRecipe.ts` exposing `mapBeerToBrewingData` and `normalizeFermentationStepsForProduction` with temperature/time validation and executionMode normalization. 
- Update `src/containers/Production/Production.tsx` to use `mapBeerToBrewingData` in `startBrewing`, show an alert on invalid recipe data, and only send `BrewingData` when mapping succeeds. 
- Add unit tests `src/utils/productionRecipe.test.ts` covering confirmation-hold handling, defaulting missing `executionMode` to `TIMED`, blocking timed rests with missing/invalid time, and ensuring `time = 0` is not treated as `CONFIRMATION_HOLD`.

### Testing

- Added unit tests in `src/utils/productionRecipe.test.ts` that exercise the mapping and validation rules described above. 
- Ran the automated test suite via `npm test` and the new tests passed. 
- Verified that `startBrewing` early-returns and shows an alert when `mapBeerToBrewingData` reports invalid input.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02efdfc6e8832f89e8a8f583b15e31)