### PR TITLE
Support hop usage and time units (boil vs dry-hop) with normalization and validation

### DIFF
--- a/src/containers/DatabaseOverview/BeerForm.tsx
+++ b/src/containers/DatabaseOverview/BeerForm.tsx
@@ -1,6 +1,9 @@
 import React, { ChangeEvent, FormEvent } from 'react';
 import {Beer, FermentationSteps, Hop, Malt, Yeast} from "../../model/Beer";
 import {BeerDTO, HopDTO, MaltDTO, YeastDTO} from "../../model/BeerDTO";
+import { HopUsage } from "../../enums/eHopUsage";
+import { HopTimeUnit } from "../../enums/eHopTimeUnit";
+import { normalizeHopDto, updateHopUsage, validateHopDto } from "./hopDefaults";
 import {BeerActions} from "../../actions/actions";
 import {connect} from "react-redux";
 import {isEqual} from "lodash";
@@ -86,7 +89,7 @@ class BeerForm extends React.Component<BeerFormProps, BeerFormState> {
                 { type: 'Kochen', temperature: 0, time: 0 }
             ],
             maltsDTO: [{ id: '', name: '', quantity: 0 }],
-            hopsDTO: [{ id: '', name: '', quantity: 0, time: 0 }],
+            hopsDTO: [{ id: '', name: '', quantity: 0, time: 0, usage: HopUsage.BOIL, timeUnit: HopTimeUnit.MINUTES }],
             yeastsDTO: [{ id: '', name: '', quantity: 0 }],
             isSubmitSuccessful: false,
         };
@@ -134,7 +137,8 @@ class BeerForm extends React.Component<BeerFormProps, BeerFormState> {
                 cookingTemperatur: importedBeer.cookingTemperatur || 0,
                 fermentationSteps: importedBeer.fermentation ? [...importedBeer.fermentation] : [],
                 maltsDTO: importedBeer.malts ? importedBeer.malts.map(m => ({ id: m.id, name: m.name, quantity: m.quantity })) : [],
-                hopsDTO: importedBeer.wortBoiling && importedBeer.wortBoiling.hops ? importedBeer.wortBoiling.hops.map(h => ({ id: h.id, name: h.name, quantity: h.quantity, time: h.time })) : [],
+                // Altrezepte ohne usage/timeUnit bleiben kompatibel und werden auf BOIL/MINUTES normiert.
+                hopsDTO: importedBeer.wortBoiling && importedBeer.wortBoiling.hops ? importedBeer.wortBoiling.hops.map(aHop => normalizeHopDto(aHop)) : [],
                 yeastsDTO: importedBeer.fermentationMaturation && importedBeer.fermentationMaturation.yeast ? importedBeer.fermentationMaturation.yeast.map(y => ({ id: y.id, name: y.name, quantity: y.quantity })) : [],
                 isSubmitSuccessful: false,
             }, () => {
@@ -200,15 +204,27 @@ class BeerForm extends React.Component<BeerFormProps, BeerFormState> {
         });
     }
 
-    handleHopChange = (value: string, name: string, index: number) => {
+    handleHopChange = (aValue: string, aName: string, aIndex: number) => {
         this.setState((prevState) => {
             const hopsDTO = [...prevState.hopsDTO];
-            const step = hopsDTO[index];
-            // @ts-ignore
-            step[name] = value;
+            const step = hopsDTO[aIndex];
+
+            if (aName === "usage") {
+                hopsDTO[aIndex] = updateHopUsage(step, aValue as HopUsage);
+            } else if (aName === "quantity" || aName === "time") {
+                // usage/timeUnit wird getrennt geführt; Zeit darf nicht als DRY_HOP-Marker missbraucht werden.
+                const parsed = Number(aValue);
+                // @ts-ignore
+                step[aName] = isNaN(parsed) ? 0 : parsed;
+            } else if (aName === "timeUnit") {
+                step.timeUnit = aValue as HopTimeUnit;
+            } else {
+                // @ts-ignore
+                step[aName] = aValue;
+            }
+
             return { hopsDTO };
         }, () => {
-            // Nach jeder Statusänderung den aktuellen Formularstatus speichern
             this.props.saveBeerFormState(this.state);
         });
     }
@@ -264,13 +280,19 @@ class BeerForm extends React.Component<BeerFormProps, BeerFormState> {
             })
             .filter((m): m is MaltDTO => m !== undefined);
 
-        const hops_DTO = hopsDTO
+        const normalizedHops = hopsDTO.map((aHop) => normalizeHopDto(aHop));
+        if (!normalizedHops.every((aHop) => validateHopDto(aHop))) {
+            alert('Bitte prüfe die Hopfengaben: Menge und Zeit müssen > 0 sein. Kochhopfen nutzt Minuten, Hopfen stopfen Stunden oder Tage.');
+            return;
+        }
+
+        const hops_DTO = normalizedHops
             .map((aHop) => {
                 const hop = hops.find((hop) => hop.name === aHop.name);
                 if (!hop) return undefined;
                 const quantity = aHop.quantity;
                 const time = aHop.time;
-                return { id: hop.id, name: hop.name, quantity: quantity, time: time };
+                return { id: hop.id, name: hop.name, quantity: quantity, time: time, usage: aHop.usage, timeUnit: aHop.timeUnit };
             })
             .filter((h): h is HopDTO => h !== undefined);
 
@@ -351,7 +373,7 @@ class BeerForm extends React.Component<BeerFormProps, BeerFormState> {
 
     addHops = () => {
         this.setState((prevState) => ({
-            hopsDTO: [...prevState.hopsDTO, { id: '', name: '', quantity: 0, time: 0 }],
+            hopsDTO: [...prevState.hopsDTO, { id: '', name: '', quantity: 0, time: 0, usage: HopUsage.BOIL, timeUnit: HopTimeUnit.MINUTES }],
         }));
     }
 
@@ -419,7 +441,8 @@ class BeerForm extends React.Component<BeerFormProps, BeerFormState> {
                 cookingTemperatur: selectedBeer.cookingTemperatur || 0,
                 fermentationSteps: selectedBeer.fermentation ? [...selectedBeer.fermentation] : [],
                 maltsDTO: selectedBeer.malts ? selectedBeer.malts.map(m => ({ id: m.id, name: m.name, quantity: m.quantity })) : [],
-                hopsDTO: selectedBeer.wortBoiling && selectedBeer.wortBoiling.hops ? selectedBeer.wortBoiling.hops.map(h => ({ id: h.id, name: h.name, quantity: h.quantity, time: h.time })) : [],
+                // Bestehende Rezepte ohne neue Felder werden im UI als Kochhopfen in Minuten dargestellt.
+                hopsDTO: selectedBeer.wortBoiling && selectedBeer.wortBoiling.hops ? selectedBeer.wortBoiling.hops.map(aHop => normalizeHopDto(aHop)) : [],
                 yeastsDTO: selectedBeer.fermentationMaturation && selectedBeer.fermentationMaturation.yeast ? selectedBeer.fermentationMaturation.yeast.map(y => ({ id: y.id, name: y.name, quantity: y.quantity })) : [],
                 isSubmitSuccessful: false,
             }, () => {
@@ -706,7 +729,9 @@ class BeerForm extends React.Component<BeerFormProps, BeerFormState> {
                                     <tr>
                                         <th>Name</th>
                                         <th>Menge (g)</th>
-                                        <th>Zeit (min)</th>
+                                        <th>Verwendung</th>
+                                        <th>Zeitangabe</th>
+                                        <th>Einheit</th>
                                         <th className="action-column">Aktion</th>
                                     </tr>
                                 </thead>
@@ -739,14 +764,42 @@ class BeerForm extends React.Component<BeerFormProps, BeerFormState> {
                                                 />
                                             </td>
                                             <td>
+                                                <select
+                                                    name="usage"
+                                                    value={step.usage ?? HopUsage.BOIL}
+                                                    onChange={(e) => this.handleHopChange(e.target.value, "usage", index)}
+                                                    required={true}
+                                                >
+                                                    <option value={HopUsage.BOIL}>Kochhopfen</option>
+                                                    <option value={HopUsage.DRY_HOP}>Hopfen stopfen</option>
+                                                </select>
+                                            </td>
+                                            <td>
+                                                <label style={{ display: "block", fontSize: 12 }}>
+                                                    {step.usage === HopUsage.DRY_HOP ? "Kontaktzeit" : "Kochzeit / Restkochzeit"}
+                                                </label>
                                                 <input
                                                     type="number"
                                                     name="time"
-                                                    min={0}
+                                                    min={1}
                                                     value={step.time}
                                                     onChange={(e) => this.handleHopChange(e.target.value, "time", index)}
                                                     required={true}
                                                 />
+                                            </td>
+                                            <td>
+                                                {step.usage === HopUsage.DRY_HOP ? (
+                                                    <select
+                                                        name="timeUnit"
+                                                        value={step.timeUnit ?? HopTimeUnit.DAYS}
+                                                        onChange={(e) => this.handleHopChange(e.target.value, "timeUnit", index)}
+                                                    >
+                                                        <option value={HopTimeUnit.HOURS}>Stunden</option>
+                                                        <option value={HopTimeUnit.DAYS}>Tage</option>
+                                                    </select>
+                                                ) : (
+                                                    <span>Minuten</span>
+                                                )}
                                             </td>
                                             <td className="action-column">
                                                 <button

--- a/src/containers/DatabaseOverview/hopDefaults.test.ts
+++ b/src/containers/DatabaseOverview/hopDefaults.test.ts
@@ -1,0 +1,49 @@
+import { HopTimeUnit } from '../../enums/eHopTimeUnit';
+import { HopUsage } from '../../enums/eHopUsage';
+import { normalizeHopDto, updateHopUsage, validateHopDto } from './hopDefaults';
+
+describe('hopDefaults', () => {
+    test('old hop without usage/timeUnit defaults to BOIL/MINUTES', () => {
+        const hop = normalizeHopDto({ id: '1', name: 'Cascade', quantity: 10, time: 15 });
+        expect(hop.usage).toBe(HopUsage.BOIL);
+        expect(hop.timeUnit).toBe(HopTimeUnit.MINUTES);
+    });
+
+    test('BOIL hop stays BOIL/MINUTES in payload-relevant shape', () => {
+        const hop = normalizeHopDto({ id: '1', name: 'Cascade', quantity: 10, time: 15, usage: HopUsage.BOIL, timeUnit: HopTimeUnit.DAYS });
+        expect(hop.usage).toBe(HopUsage.BOIL);
+        expect(hop.timeUnit).toBe(HopTimeUnit.MINUTES);
+    });
+
+    test('DRY_HOP defaults to DAYS when no valid unit is set', () => {
+        const hop = normalizeHopDto({ id: '1', name: 'Cascade', quantity: 10, time: 5, usage: HopUsage.DRY_HOP });
+        expect(hop.usage).toBe(HopUsage.DRY_HOP);
+        expect(hop.timeUnit).toBe(HopTimeUnit.DAYS);
+    });
+
+    test('switch BOIL -> DRY_HOP does not set time to 0', () => {
+        const original = normalizeHopDto({ id: '1', name: 'Cascade', quantity: 10, time: 7, usage: HopUsage.BOIL, timeUnit: HopTimeUnit.MINUTES });
+        const updated = updateHopUsage(original, HopUsage.DRY_HOP);
+        expect(updated.usage).toBe(HopUsage.DRY_HOP);
+        expect(updated.time).toBe(7);
+        expect(updated.timeUnit).toBe(HopTimeUnit.DAYS);
+    });
+
+    test('switch DRY_HOP -> BOIL sets MINUTES', () => {
+        const original = normalizeHopDto({ id: '1', name: 'Cascade', quantity: 10, time: 7, usage: HopUsage.DRY_HOP, timeUnit: HopTimeUnit.HOURS });
+        const updated = updateHopUsage(original, HopUsage.BOIL);
+        expect(updated.usage).toBe(HopUsage.BOIL);
+        expect(updated.timeUnit).toBe(HopTimeUnit.MINUTES);
+    });
+
+    test('loaded recipe with usage/timeUnit preserves those fields', () => {
+        const hop = normalizeHopDto({ id: '1', name: 'Cascade', quantity: 10, time: 2, usage: HopUsage.DRY_HOP, timeUnit: HopTimeUnit.HOURS });
+        expect(hop.usage).toBe(HopUsage.DRY_HOP);
+        expect(hop.timeUnit).toBe(HopTimeUnit.HOURS);
+    });
+
+    test('invalid usage/timeUnit combination is rejected by validation', () => {
+        const invalid = { id: '1', name: 'Cascade', quantity: 10, time: 30, usage: HopUsage.BOIL, timeUnit: HopTimeUnit.DAYS };
+        expect(validateHopDto(invalid)).toBe(false);
+    });
+});

--- a/src/containers/DatabaseOverview/hopDefaults.ts
+++ b/src/containers/DatabaseOverview/hopDefaults.ts
@@ -1,0 +1,45 @@
+import { HopTimeUnit } from '../../enums/eHopTimeUnit';
+import { HopUsage } from '../../enums/eHopUsage';
+import { HopDTO } from '../../model/BeerDTO';
+
+export const normalizeHopDto = (aHop: Partial<HopDTO>): HopDTO => {
+    const usage = aHop.usage ?? HopUsage.BOIL;
+    const timeUnit = usage === HopUsage.BOIL
+        ? HopTimeUnit.MINUTES
+        : (aHop.timeUnit === HopTimeUnit.HOURS || aHop.timeUnit === HopTimeUnit.DAYS ? aHop.timeUnit : HopTimeUnit.DAYS);
+
+    return {
+        id: aHop.id ?? '',
+        name: aHop.name ?? '',
+        quantity: Number(aHop.quantity ?? 0),
+        time: Number(aHop.time ?? 0),
+        usage,
+        timeUnit,
+    };
+};
+
+export const updateHopUsage = (aHop: HopDTO, aUsage: HopUsage): HopDTO => {
+    if (aUsage === HopUsage.DRY_HOP) {
+        const nextTimeUnit = !aHop.timeUnit || aHop.timeUnit === HopTimeUnit.MINUTES
+            ? HopTimeUnit.DAYS
+            : aHop.timeUnit;
+        return { ...aHop, usage: HopUsage.DRY_HOP, timeUnit: nextTimeUnit };
+    }
+
+    return { ...aHop, usage: HopUsage.BOIL, timeUnit: HopTimeUnit.MINUTES };
+};
+
+export const validateHopDto = (aHop: HopDTO): boolean => {
+    const usage = aHop.usage ?? HopUsage.BOIL;
+    const timeUnit = aHop.timeUnit ?? HopTimeUnit.MINUTES;
+
+    if (!(usage === HopUsage.BOIL || usage === HopUsage.DRY_HOP)) return false;
+    if (Number(aHop.quantity) <= 0) return false;
+    if (Number(aHop.time) <= 0) return false;
+
+    if (usage === HopUsage.BOIL) {
+        return timeUnit === HopTimeUnit.MINUTES;
+    }
+
+    return timeUnit === HopTimeUnit.HOURS || timeUnit === HopTimeUnit.DAYS;
+};

--- a/src/enums/eHopTimeUnit.ts
+++ b/src/enums/eHopTimeUnit.ts
@@ -1,0 +1,5 @@
+export enum HopTimeUnit {
+    MINUTES = 'MINUTES',
+    HOURS = 'HOURS',
+    DAYS = 'DAYS',
+}

--- a/src/enums/eHopUsage.ts
+++ b/src/enums/eHopUsage.ts
@@ -1,0 +1,4 @@
+export enum HopUsage {
+    BOIL = 'BOIL',
+    DRY_HOP = 'DRY_HOP',
+}

--- a/src/model/Beer.ts
+++ b/src/model/Beer.ts
@@ -1,5 +1,7 @@
 import { MashingType } from '../enums/eMashingType';
 import { RestExecutionMode } from '../enums/eRestExecutionMode';
+import { HopTimeUnit } from '../enums/eHopTimeUnit';
+import { HopUsage } from '../enums/eHopUsage';
 export interface FermentationSteps {
     type: string;
     temperature: number;
@@ -22,6 +24,8 @@ export interface Hop {
     alpha: number;
     quantity: number;
     time: number;
+    usage?: HopUsage;
+    timeUnit?: HopTimeUnit;
 }
 
 export interface WortBoiling {

--- a/src/model/BeerDTO.ts
+++ b/src/model/BeerDTO.ts
@@ -1,5 +1,7 @@
 import { MashingType } from '../enums/eMashingType';
 import { RestExecutionMode } from '../enums/eRestExecutionMode';
+import { HopTimeUnit } from '../enums/eHopTimeUnit';
+import { HopUsage } from '../enums/eHopUsage';
 export interface FermentationStepsDTO {
     type: string;
     temperature: number;
@@ -18,6 +20,8 @@ export interface HopDTO {
     id: string;
     quantity: number;
     time: number;
+    usage?: HopUsage;
+    timeUnit?: HopTimeUnit;
 }
 
 export interface WortBoilingDTO {


### PR DESCRIPTION
### Motivation

- Add explicit support for hop usage modes (boil vs dry-hop) and corresponding time units to model and UI to enable correct handling of dry-hopping and backward compatibility with older recipes.
- Provide normalization and validation so imported/legacy recipes without the new fields are mapped to sensible defaults and invalid combinations are rejected before submit.

### Description

- Introduced new enums `HopUsage` and `HopTimeUnit` in `src/enums` and extended `Hop`/`HopDTO` types in `src/model/Beer.ts` and `src/model/BeerDTO.ts` to carry `usage` and `timeUnit` fields.
- Added `src/containers/DatabaseOverview/hopDefaults.ts` implementing `normalizeHopDto`, `updateHopUsage`, and `validateHopDto` for defaulting, switching and validating hop entries.
- Updated `BeerForm.tsx` to initialize hops with `usage`/`timeUnit`, normalize hops when importing or selecting beers, enforce validation prior to submit, and handle UI changes for usage and time unit selection including `handleHopChange`, `addHops`, and table columns.
- Added unit tests `hopDefaults.test.ts` covering defaulting behavior, usage switches, preservation of fields, and validation rules.

### Testing

- Added unit tests in `src/containers/DatabaseOverview/hopDefaults.test.ts` exercising `normalizeHopDto`, `updateHopUsage`, and `validateHopDto` and these tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02f79cf770832fbd7a3f1153ae0489)