### PR TITLE
Normalize and validate fermentation steps on import; add helpers and tests

### DIFF
--- a/src/containers/DatabaseOverview/BeerForm.tsx
+++ b/src/containers/DatabaseOverview/BeerForm.tsx
@@ -4,6 +4,7 @@ import {BeerDTO, HopDTO, MaltDTO, YeastDTO} from "../../model/BeerDTO";
 import { HopUsage } from "../../enums/eHopUsage";
 import { HopTimeUnit } from "../../enums/eHopTimeUnit";
 import { normalizeHopDto, updateHopUsage, validateHopDto } from "./hopDefaults";
+import { isValidExecutionMode, normalizeFermentationStep } from "./fermentationDefaults";
 import {BeerActions} from "../../actions/actions";
 import {connect} from "react-redux";
 import {isEqual} from "lodash";
@@ -135,7 +136,8 @@ class BeerForm extends React.Component<BeerFormProps, BeerFormState> {
                 spargeVolume: importedBeer.spargeVolume || 0,
                 cookingTime: importedBeer.cookingTime || 0,
                 cookingTemperatur: importedBeer.cookingTemperatur || 0,
-                fermentationSteps: importedBeer.fermentation ? [...importedBeer.fermentation] : [],
+                // Importierte Rasten werden defensiv normalisiert (Altformat ohne executionMode => TIMED).
+                fermentationSteps: importedBeer.fermentation ? importedBeer.fermentation.map((step) => normalizeFermentationStep(step)) : [],
                 maltsDTO: importedBeer.malts ? importedBeer.malts.map(m => ({ id: m.id, name: m.name, quantity: m.quantity })) : [],
                 // Altrezepte ohne usage/timeUnit bleiben kompatibel und werden auf BOIL/MINUTES normiert.
                 hopsDTO: importedBeer.wortBoiling && importedBeer.wortBoiling.hops ? importedBeer.wortBoiling.hops.map(aHop => normalizeHopDto(aHop)) : [],
@@ -185,6 +187,8 @@ class BeerForm extends React.Component<BeerFormProps, BeerFormState> {
             const isFixed = this.fixedTypes.includes(step.type);
             if (isFixed) continue;
             const mode = this.getExecutionMode(step);
+            // Unbekannte Modi aus Importen nicht stillschweigend akzeptieren.
+            if (!isValidExecutionMode(mode)) return false;
             if (step.temperature === undefined || Number(step.temperature) <= 0) return false;
             if (mode === RestExecutionMode.TIMED && (step.time === undefined || Number(step.time) <= 0)) return false;
         }

--- a/src/containers/DatabaseOverview/fermentationDefaults.test.ts
+++ b/src/containers/DatabaseOverview/fermentationDefaults.test.ts
@@ -1,0 +1,29 @@
+import { RestExecutionMode } from '../../enums/eRestExecutionMode';
+import { normalizeFermentationStep, isValidExecutionMode } from './fermentationDefaults';
+
+describe('fermentationDefaults', () => {
+    test('imported step without executionMode defaults to TIMED', () => {
+        const step = normalizeFermentationStep({ type: 'Rast 1', temperature: 64, time: 40 });
+        expect(step.executionMode).toBe(RestExecutionMode.TIMED);
+    });
+
+    test('imported CONFIRMATION_HOLD without time remains CONFIRMATION_HOLD', () => {
+        const step = normalizeFermentationStep({
+            type: 'Dickmaische führen',
+            temperature: 64,
+            executionMode: RestExecutionMode.CONFIRMATION_HOLD,
+        });
+        expect(step.executionMode).toBe(RestExecutionMode.CONFIRMATION_HOLD);
+        expect(step.time).toBeUndefined();
+    });
+
+    test('time=0 is not converted to CONFIRMATION_HOLD', () => {
+        const step = normalizeFermentationStep({ type: 'Rast 1', temperature: 64, time: 0 });
+        expect(step.executionMode).toBe(RestExecutionMode.TIMED);
+        expect(step.time).toBe(0);
+    });
+
+    test('invalid executionMode is rejected clearly by validator helper', () => {
+        expect(isValidExecutionMode('SOMETHING_ELSE')).toBe(false);
+    });
+});

--- a/src/containers/DatabaseOverview/fermentationDefaults.ts
+++ b/src/containers/DatabaseOverview/fermentationDefaults.ts
@@ -1,0 +1,20 @@
+import { RestExecutionMode } from '../../enums/eRestExecutionMode';
+import { FermentationSteps } from '../../model/Beer';
+
+const allowedExecutionModes = [RestExecutionMode.TIMED, RestExecutionMode.CONFIRMATION_HOLD];
+
+export const normalizeFermentationStep = (step: Partial<FermentationSteps>): FermentationSteps => {
+    // Altrezepte ohne executionMode bleiben kompatibel und werden als TIMED behandelt.
+    const executionMode = step.executionMode ?? RestExecutionMode.TIMED;
+
+    return {
+        type: step.type ?? '',
+        temperature: Number(step.temperature ?? 0),
+        time: step.time,
+        executionMode,
+    };
+};
+
+export const isValidExecutionMode = (value: unknown): value is RestExecutionMode => {
+    return allowedExecutionModes.includes(value as RestExecutionMode);
+};

--- a/src/utils/productionRecipe.test.ts
+++ b/src/utils/productionRecipe.test.ts
@@ -61,6 +61,20 @@ describe('productionRecipe mapping', () => {
     expect(result.error).toContain('Zeitgesteuerte Rast');
   });
 
+
+  it('keeps imported CONFIRMATION_HOLD without time through production mapping', () => {
+    const result = mapBeerToBrewingData(makeBeer({ fermentation: [
+      { type: 'Einmaischen', temperature: 52, time: 10 },
+      { type: 'Dickmaische führen', temperature: 66, executionMode: RestExecutionMode.CONFIRMATION_HOLD },
+      { type: 'Abmaischen', temperature: 78, time: 10 }
+    ] }));
+
+    expect(result.ok).toBe(true);
+    const hold = result.brewingData?.Rasten.find((s) => s.type === 'Dickmaische führen');
+    expect(hold).toEqual(expect.objectContaining({ executionMode: RestExecutionMode.CONFIRMATION_HOLD }));
+    expect(hold).not.toHaveProperty('time');
+  });
+
   it('does not infer CONFIRMATION_HOLD from time=0', () => {
     const result = mapBeerToBrewingData(makeBeer({ fermentation: [
       { type: 'Einmaischen', temperature: 52, time: 10 },


### PR DESCRIPTION
### Motivation
- Ensure backward compatibility for older recipes that omit `executionMode` by normalizing them to a safe default. 
- Prevent silently accepting unknown or invalid fermentation `executionMode` values that could break validation or production mapping. 
- Cover new normalization/validation behavior with unit tests to avoid regressions. 

### Description
- Add `src/containers/DatabaseOverview/fermentationDefaults.ts` which introduces `normalizeFermentationStep` to default missing `executionMode` to `RestExecutionMode.TIMED` and `isValidExecutionMode` to explicitly validate allowed modes. 
- Update `src/containers/DatabaseOverview/BeerForm.tsx` to normalize imported fermentation steps via `normalizeFermentationStep` when filling the form and to use `isValidExecutionMode` inside `validateFermentationSteps` to reject unknown modes. 
- Add `src/containers/DatabaseOverview/fermentationDefaults.test.ts` unit tests for normalization and validation behavior and extend `src/utils/productionRecipe.test.ts` with a test ensuring `CONFIRMATION_HOLD` steps without `time` are preserved through production mapping. 

### Testing
- Ran the unit test suite including `fermentationDefaults.test.ts` and the updated `productionRecipe` tests, and the new/updated tests passed. 
- Verified that production mapping tests covering `TIMED`, `CONFIRMATION_HOLD`, and `time=0` behaviors still pass. 
- No automated test failures were observed when running the project's test runner.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02faa7248c832f847448e30a1a5fc0)