### PR TITLE
Fix HopDTO type narrowing in BeerForm submit flow

### DIFF
--- a/src/containers/DatabaseOverview/BeerForm.tsx
+++ b/src/containers/DatabaseOverview/BeerForm.tsx
@@ -291,12 +291,19 @@ class BeerForm extends React.Component<BeerFormProps, BeerFormState> {
         }
 
         const hops_DTO = normalizedHops
-            .map((aHop) => {
+            .map((aHop): HopDTO | undefined => {
                 const hop = hops.find((hop) => hop.name === aHop.name);
                 if (!hop) return undefined;
                 const quantity = aHop.quantity;
                 const time = aHop.time;
-                return { id: hop.id, name: hop.name, quantity: quantity, time: time, usage: aHop.usage, timeUnit: aHop.timeUnit };
+                return {
+                    id: hop.id,
+                    name: hop.name,
+                    quantity,
+                    time,
+                    usage: aHop.usage,
+                    timeUnit: aHop.timeUnit,
+                };
             })
             .filter((h): h is HopDTO => h !== undefined);
 


### PR DESCRIPTION
### Motivation
- Fix TypeScript compile errors (`TS2677` / `TS2322`) in `src/containers/DatabaseOverview/BeerForm.tsx` by making the hop mapping callback return type explicit so the subsequent type guard is valid.

### Description
- Annotated the `normalizedHops.map` callback in `BeerForm.handleSubmit` to return `HopDTO | undefined`, reformatted the returned hop object for clearer inference, and retained the `.filter((h): h is HopDTO => h !== undefined)` type guard to preserve behavior.

### Testing
- Ran `npm run -s tsc -- --noEmit`, which exited non-zero in this environment and did not produce a successful compile report.
- Ran `npm run build`, which failed due to a missing `react-scripts` in the execution environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0301b22534832fa5c0218843c870a7)