### PR TITLE
Reset file input after import in BeerForm to allow re-importing same file

### DIFF
--- a/src/containers/DatabaseOverview/BeerForm.tsx
+++ b/src/containers/DatabaseOverview/BeerForm.tsx
@@ -901,6 +901,8 @@ class BeerForm extends React.Component<BeerFormProps, BeerFormState> {
         if (file) {
             importBeer(file);
         }
+        // Damit auch dieselbe Datei erneut ein onChange-Event auslöst.
+        event.target.value = '';
     };
 
     render() {


### PR DESCRIPTION
### Motivation
- Ensure selecting the same file again triggers an `onChange` event when importing beer JSON files through the form.

### Description
- In `handleImportBeerJson` added `event.target.value = ''` after calling `importBeer(file)` to clear the file input so the same file can be re-selected, with a clarifying comment.

### Testing
- Ran TypeScript typecheck and the existing frontend unit tests; all checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03057e7154832f9f01ec172db9701f)