### PR TITLE
Add delete-beer flow (actions, epic, reducer, repository, UI)

### DIFF
--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -39,7 +39,9 @@ export namespace BeerActions {
         GENERATE_SHOPPING_LIST_PDF_FAILURE = 'BeerActions.GENERATE_SHOPPING_LIST_PDF_FAILURE',
         IMPORT_BEER = 'BeerActions.IMPORT_BEER',
         ADD_IMPORTED_BEER = 'BeerActions.ADD_IMPORTED_BEER',
-        UPDATE_RECIPE_SCALING = 'BeerActions.UPDATE_RECIPE_SCALING'
+        UPDATE_RECIPE_SCALING = 'BeerActions.UPDATE_RECIPE_SCALING',
+        DELETE_BEER = 'BeerActions.DELETE_BEER',
+        DELETE_BEER_SUCCESS = 'BeerActions.DELETE_BEER_SUCCESS'
 
     }
 
@@ -202,6 +204,20 @@ export namespace BeerActions {
         }
     }
 
+    export interface DeleteBeer {
+        readonly type: ActionTypes.DELETE_BEER
+        payload: {
+            beerId: string
+        }
+    }
+
+    export interface DeleteBeerSuccess {
+        readonly type: ActionTypes.DELETE_BEER_SUCCESS
+        payload: {
+            deletedBeerId: string
+        }
+    }
+
     export type AllBeerActions =
         SubmitBeer |
         SubmitBeerSuccess |
@@ -226,7 +242,9 @@ export namespace BeerActions {
         GenerateShoppingListPdfSuccess |
         GenerateShoppingListPdfFailure |
         AddImportedBeer |
-        UpdateRecipeScaling
+        UpdateRecipeScaling |
+        DeleteBeer |
+        DeleteBeerSuccess
 
 
     export function isSubmitSuccessful(aIsSuccessful: boolean, aMessage: string, aType: string): SetIsSubmitSuccessful {
@@ -394,6 +412,20 @@ export namespace BeerActions {
             payload: {
                 scalingValues: aScalingValues
             }
+        }
+    }
+
+    export function deleteBeer(aBeerId: string): DeleteBeer {
+        return {
+            type: ActionTypes.DELETE_BEER,
+            payload: {beerId: aBeerId}
+        }
+    }
+
+    export function deleteBeerSuccess(aDeletedBeerId: string): DeleteBeerSuccess {
+        return {
+            type: ActionTypes.DELETE_BEER_SUCCESS,
+            payload: {deletedBeerId: aDeletedBeerId}
         }
     }
 

--- a/src/containers/MainView/BeerRecipes/Table.tsx
+++ b/src/containers/MainView/BeerRecipes/Table.tsx
@@ -16,6 +16,7 @@ export interface BeerTableProps {
     isPollingRunning?: boolean;
     exportShoppingListPdf: (beer: Beer) => void;
     selectedBeer: Beer;
+    deleteBeer: (aBeerId: string) => void;
 }
 
 
@@ -93,6 +94,17 @@ export class BeerTableComponent extends React.Component<BeerTableProps, BeerTabl
 
 
     };
+
+    handleDeleteBeer = (aBeer: Beer) => {
+        const aBeerNamePart = aBeer.name ? ` „${aBeer.name}“` : '';
+        const aShouldDelete = window.confirm(`Möchtest du das Rezept${aBeerNamePart} wirklich löschen?`);
+
+        if (!aShouldDelete) {
+            return;
+        }
+
+        this.props.deleteBeer(aBeer.id);
+    }
 
     render() {
         const {beers, beerToBrew, isPollingRunning} = this.props;
@@ -203,6 +215,16 @@ export class BeerTableComponent extends React.Component<BeerTableProps, BeerTabl
                                                         {beerToBrew && beerToBrew.id === item.id ? '✖️' : '🍺'}
                                                     </span>
                                                 </button>
+                                                <button
+                                                    className="table-action-button cancel-brew-button"
+                                                    onClick={e => {
+                                                        e.stopPropagation();
+                                                        this.handleDeleteBeer(item);
+                                                    }}
+                                                    title="Rezept löschen"
+                                                >
+                                                    <span role="img" aria-label="Rezept löschen" style={{fontSize: '1.4rem', marginTop: '0.3rem'}}>🗑️</span>
+                                                </button>
                                             </div>
                                         </TableCell>
                                     </TableRow>
@@ -229,6 +251,7 @@ const mapDispatchToProps = (dispatch: any) => ({
     setSelectedBeer: (beer: Beer) => dispatch(setSelectedBeer(beer)),
     setBeerToBrew: (beer: Beer | undefined ) => dispatch(BeerActions.setBeerToBrew(beer)),
     exportShoppingListPdf: (beer: Beer) => dispatch(BeerActions.generateShoppingListPdf(beer)),
+    deleteBeer: (aBeerId: string) => dispatch(BeerActions.deleteBeer(aBeerId)),
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(BeerTableComponent);

--- a/src/epics/beerEpics.ts
+++ b/src/epics/beerEpics.ts
@@ -175,6 +175,25 @@ export const importBeerEpic = (aAction$: any) =>
         )
     );
 
+export const deleteBeerEpic = (action$: any) =>
+    action$.pipe(
+        ofType(BeerActions.ActionTypes.DELETE_BEER),
+        mergeMap((action: any) =>
+            from(BeerRepository.deleteBeer(action.payload.beerId)).pipe(
+                map(() => BeerActions.deleteBeerSuccess(action.payload.beerId)),
+                catchError((aError: Error) =>
+                    from([
+                        ApplicationActions.openErrorDialog(
+                            true,
+                            "Bier fehler",
+                            "Bier konnte nicht gelöscht werden: " + aError.message
+                        )
+                    ])
+                )
+            )
+        )
+    );
+
 
 export const beerEpics = [
   getBeersEpic,
@@ -185,5 +204,6 @@ export const beerEpics = [
   sendNewFinishedBeerEpic,
   generateFinishedBrewsPdfEpic,
   generateShoppingListPdfEpic,
-  importBeerEpic
+  importBeerEpic,
+  deleteBeerEpic
 ];

--- a/src/reducers/beerReducer.ts
+++ b/src/reducers/beerReducer.ts
@@ -76,6 +76,19 @@ const beerDataReducer = (
     case BeerActions.ActionTypes.SET_BEER_TO_BREW: {
       return { ...aState, beerToBrew: aAction.payload.beer };
     }
+    case BeerActions.ActionTypes.DELETE_BEER_SUCCESS: {
+      const beers = (aState.beers ?? []).filter(aBeer => aBeer.id !== aAction.payload.deletedBeerId);
+      const isSelectedBeerDeleted = aState.selectedBeer?.id === aAction.payload.deletedBeerId;
+      const isBeerToBrewDeleted = aState.beerToBrew?.id === aAction.payload.deletedBeerId;
+
+      // Falls das ausgewählte Rezept gelöscht wurde, wird eine sichere Auswahl gesetzt.
+      const selectedBeer = isSelectedBeerDeleted ? beers.at(-1) : aState.selectedBeer;
+
+      // Sicherheitsverhalten: Ein gelöschtes Rezept darf nicht weiter als "zu brauen" markiert bleiben.
+      const beerToBrew = isBeerToBrewDeleted ? undefined : aState.beerToBrew;
+
+      return { ...aState, beers, selectedBeer, beerToBrew };
+    }
 
     case BeerActions.ActionTypes.GET_FINISHED_BEERS: {
       return { ...aState, isFetching: aAction.payload.isFetching };

--- a/src/repositorys/BeerRepository.ts
+++ b/src/repositorys/BeerRepository.ts
@@ -20,8 +20,11 @@ export class BeerRepository extends BaseRepository {
         console.log(aFile)
         return this.postFile<any>("importbeer", aFile);
     }
-}
 
+    static async deleteBeer(aBeerId: string): Promise<void> {
+        return this.delete(`beer/${aBeerId}`);
+    }
+}
 
 
 


### PR DESCRIPTION
### Motivation

- Provide the ability to delete a beer recipe from the UI and remove it from application state and backend.

### Description

- Added new action types, interfaces and action creators for `DELETE_BEER` and `DELETE_BEER_SUCCESS` in `src/actions/actions.ts` to represent the delete flow.
- Implemented `deleteBeer` API call in `src/repositorys/BeerRepository.ts` which issues a `DELETE` to `beer/{id}`.
- Added `deleteBeerEpic` in `src/epics/beerEpics.ts` to call the repository and dispatch `deleteBeerSuccess` on success or open an error dialog on failure, and registered the epic in the exported `beerEpics` array.
- Updated `src/reducers/beerReducer.ts` to handle `DELETE_BEER_SUCCESS` by removing the beer from the list, clearing `beerToBrew` if it was the deleted beer, and safely adjusting `selectedBeer` if necessary.
- Updated the beer table UI in `src/containers/MainView/BeerRecipes/Table.tsx` to show a delete button with a confirmation dialog and dispatch `deleteBeer` when confirmed, and wired the new action into `mapDispatchToProps`.

### Testing

- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a031b6d40c0832fabf1e5c408b4a38c)