### PR TITLE
Add 'Additional Ingredients' feature (model, actions, reducer, epic, repo, UI)

### DIFF
--- a/src/actions/additionalIngredients.actions.ts
+++ b/src/actions/additionalIngredients.actions.ts
@@ -1,0 +1,68 @@
+import {AdditionalIngredient, AdditionalIngredientCreatePayload} from "../model/AdditionalIngredient";
+
+export namespace AdditionalIngredientsActions {
+    export enum ActionTypes {
+        GET_ADDITIONAL_INGREDIENTS = 'AdditionalIngredientsActions.GET_ADDITIONAL_INGREDIENTS',
+        GET_ADDITIONAL_INGREDIENTS_SUCCESS = 'AdditionalIngredientsActions.GET_ADDITIONAL_INGREDIENTS_SUCCESS',
+        SUBMIT_NEW_ADDITIONAL_INGREDIENT = 'AdditionalIngredientsActions.SUBMIT_NEW_ADDITIONAL_INGREDIENT',
+        SUBMIT_NEW_ADDITIONAL_INGREDIENT_SUCCESS = 'AdditionalIngredientsActions.SUBMIT_NEW_ADDITIONAL_INGREDIENT_SUCCESS'
+    }
+
+    export interface GetAdditionalIngredients {
+        readonly type: ActionTypes.GET_ADDITIONAL_INGREDIENTS
+        payload: {
+            isFetching: boolean
+        }
+    }
+
+    export interface GetAdditionalIngredientsSuccess {
+        readonly type: ActionTypes.GET_ADDITIONAL_INGREDIENTS_SUCCESS
+        payload: {
+            additionalIngredients: AdditionalIngredient[]
+        }
+    }
+
+    export interface SubmitNewAdditionalIngredient {
+        readonly type: ActionTypes.SUBMIT_NEW_ADDITIONAL_INGREDIENT
+        payload: {
+            ingredient: AdditionalIngredientCreatePayload
+        }
+    }
+
+    export interface SubmitNewAdditionalIngredientSuccess {
+        readonly type: ActionTypes.SUBMIT_NEW_ADDITIONAL_INGREDIENT_SUCCESS
+    }
+
+    export type AllAdditionalIngredientsActions =
+        GetAdditionalIngredients |
+        GetAdditionalIngredientsSuccess |
+        SubmitNewAdditionalIngredient |
+        SubmitNewAdditionalIngredientSuccess
+
+    export function getAdditionalIngredients(aIsFetching: boolean): GetAdditionalIngredients {
+        return {
+            type: ActionTypes.GET_ADDITIONAL_INGREDIENTS,
+            payload: {isFetching: aIsFetching}
+        }
+    }
+
+    export function getAdditionalIngredientsSuccess(aAdditionalIngredients: AdditionalIngredient[]): GetAdditionalIngredientsSuccess {
+        return {
+            type: ActionTypes.GET_ADDITIONAL_INGREDIENTS_SUCCESS,
+            payload: {additionalIngredients: aAdditionalIngredients}
+        }
+    }
+
+    export function submitNewAdditionalIngredient(aIngredient: AdditionalIngredientCreatePayload): SubmitNewAdditionalIngredient {
+        return {
+            type: ActionTypes.SUBMIT_NEW_ADDITIONAL_INGREDIENT,
+            payload: {ingredient: aIngredient}
+        }
+    }
+
+    export function submitNewAdditionalIngredientSuccess(): SubmitNewAdditionalIngredientSuccess {
+        return {
+            type: ActionTypes.SUBMIT_NEW_ADDITIONAL_INGREDIENT_SUCCESS
+        }
+    }
+}

--- a/src/containers/DatabaseOverview/IngredientsFormPage.tsx
+++ b/src/containers/DatabaseOverview/IngredientsFormPage.tsx
@@ -27,6 +27,8 @@ import './IngredientsFormPage.css';
 import { MaltsActions } from "../../actions/malt.actions";
 import { HopsActions } from "../../actions/hops.actions";
 import { YeastActions } from "../../actions/yeast.actions";
+import {AdditionalIngredientsActions} from "../../actions/additionalIngredients.actions";
+import {AdditionalIngredient} from "../../model/AdditionalIngredient";
 
 
 class IngredientsFormPage extends React.Component<any, any> {
@@ -42,7 +44,10 @@ class IngredientsFormPage extends React.Component<any, any> {
             newYeast: {},
             showNewMaltRow: false,
             showNewHopRow: false,
-            showNewYeastRow: false
+            showNewYeastRow: false,
+            newAdditionalIngredient: { name: "", description: "" },
+            showNewAdditionalIngredientRow: false,
+            additionalIngredientError: ""
         };
     }
 
@@ -50,6 +55,7 @@ class IngredientsFormPage extends React.Component<any, any> {
         this.props.getMalt(true);
         this.props.getHop(true);
         this.props.getYeast(true);
+        this.props.getAdditionalIngredients(true);
     }
 
     componentDidUpdate() {
@@ -98,12 +104,34 @@ class IngredientsFormPage extends React.Component<any, any> {
         }
     };
 
+    handleAddAdditionalIngredient = () => {
+        const { newAdditionalIngredient } = this.state;
+        const aTrimmedName = (newAdditionalIngredient.name || "").trim();
+
+        if (!aTrimmedName) {
+            // Name darf nicht leer sein, damit kein ungültiger API-Request gesendet wird.
+            this.setState({ additionalIngredientError: "Name ist erforderlich." });
+            return;
+        }
+
+        this.props.submitNewAdditionalIngredient({
+            name: aTrimmedName,
+            description: newAdditionalIngredient.description || ""
+        });
+
+        this.setState({
+            newAdditionalIngredient: { name: "", description: "" },
+            showNewAdditionalIngredientRow: false,
+            additionalIngredientError: ""
+        });
+    };
+
 
     render() {
-        const { malts, hops, yeasts } = this.props;
+        const { malts, hops, yeasts, additionalIngredients } = this.props;
         const {
-            newMalt, newHop, newYeast,
-            showNewMaltRow, showNewHopRow, showNewYeastRow
+            newMalt, newHop, newYeast, newAdditionalIngredient,
+            showNewMaltRow, showNewHopRow, showNewYeastRow, showNewAdditionalIngredientRow, additionalIngredientError
         } = this.state;
 
 
@@ -365,6 +393,73 @@ class IngredientsFormPage extends React.Component<any, any> {
                         </AccordionDetails>
                     </Accordion>
 
+                    {/* ----------------------------------- WEITERE ZUTATEN ----------------------------------- */}
+                    <Accordion sx={{ backgroundColor: COLOR_BREW_BG }}>
+                        <AccordionSummary
+                            sx={{ backgroundColor: COLOR_ACCENT, borderRadius: "0 0 10px 10px" }}
+                            expandIcon={<ExpandMoreIcon />}
+                        >
+                            <Typography>Weitere Zutaten</Typography>
+                        </AccordionSummary>
+
+                        <AccordionDetails sx={{ backgroundColor: COLOR_BREW_BG }}>
+                            <div className="filter-container">
+                                <button className="finish-btn" onClick={() => this.setState({ showNewAdditionalIngredientRow: true, additionalIngredientError: "" })}>
+                                    Neue Zutat
+                                </button>
+                                <button className="finish-btn" onClick={() => this.props.getAdditionalIngredients(true)}>
+                                    Aktualisieren
+                                </button>
+                            </div>
+
+                            <TableContainer className="FinishedBrewsTable" sx={{ maxHeight: 400 }}>
+                                <Table stickyHeader>
+                                    <TableHead>
+                                        <TableRow>
+                                            <TableCell>Name</TableCell>
+                                            <TableCell>Beschreibung</TableCell>
+                                            <TableCell>Aktion</TableCell>
+                                        </TableRow>
+                                    </TableHead>
+
+                                    <TableBody>
+                                        {showNewAdditionalIngredientRow && (
+                                            <TableRow>
+                                                <TableCell>
+                                                    <input className="table-edit-field"
+                                                           value={newAdditionalIngredient.name || ""}
+                                                           onChange={e => this.setState({ newAdditionalIngredient: { ...newAdditionalIngredient, name: e.target.value }, additionalIngredientError: "" })}
+                                                    />
+                                                    {additionalIngredientError && <div style={{ color: '#d32f2f', fontSize: '0.8rem' }}>{additionalIngredientError}</div>}
+                                                </TableCell>
+                                                <TableCell>
+                                                    <input className="table-edit-field"
+                                                           value={newAdditionalIngredient.description || ""}
+                                                           onChange={e => this.setState({ newAdditionalIngredient: { ...newAdditionalIngredient, description: e.target.value } })}
+                                                    />
+                                                </TableCell>
+                                                <TableCell>
+                                                    <div className="action-buttons">
+                                                        <button className="finish-btn" onClick={this.handleAddAdditionalIngredient}>Hinzufügen</button>
+                                                        <button className="cancel-btn" onClick={() => this.setState({ showNewAdditionalIngredientRow: false, additionalIngredientError: "" })}>✖️</button>
+                                                    </div>
+                                                </TableCell>
+                                            </TableRow>
+                                        )}
+
+                                        {additionalIngredients.map((aIngredient: AdditionalIngredient) => (
+                                            <TableRow key={aIngredient.id}>
+                                                <TableCell>{aIngredient.name}</TableCell>
+                                                <TableCell>{aIngredient.description}</TableCell>
+                                                <TableCell />
+                                            </TableRow>
+                                        ))}
+                                    </TableBody>
+                                </Table>
+                            </TableContainer>
+                        </AccordionDetails>
+                    </Accordion>
+
                 </div>
             </SimpleBar>
         );
@@ -378,7 +473,8 @@ class IngredientsFormPage extends React.Component<any, any> {
 const mapStateToProps = (state: any) => ({
     malts: state.maltsReducer.malts || [],
     hops: state.hopsReducer.hops || [],
-    yeasts: state.yeastReducer.yeasts || []
+    yeasts: state.yeastReducer.yeasts || [],
+    additionalIngredients: state.additionalIngredientsReducer.additionalIngredients || []
 });
 
 const mapDispatchToProps = (dispatch: any) => ({
@@ -387,7 +483,9 @@ const mapDispatchToProps = (dispatch: any) => ({
     getYeast: (isFetching: boolean) => dispatch(YeastActions.getYeasts(isFetching)),
     submitNewMalt: (malt: Malts) => dispatch(MaltsActions.submitNewMalt(malt)),
     submitNewHop: (hop: Hops) => dispatch(HopsActions.submitNewHop(hop)),
-    submitNewYeast: (yeast: Yeasts) => dispatch(YeastActions.submitNewYeast(yeast))
+    submitNewYeast: (yeast: Yeasts) => dispatch(YeastActions.submitNewYeast(yeast)),
+    getAdditionalIngredients: (isFetching: boolean) => dispatch(AdditionalIngredientsActions.getAdditionalIngredients(isFetching)),
+    submitNewAdditionalIngredient: (aIngredient: { name: string; description?: string }) => dispatch(AdditionalIngredientsActions.submitNewAdditionalIngredient(aIngredient))
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(IngredientsFormPage);

--- a/src/epics/additionalIngredientsEpic.ts
+++ b/src/epics/additionalIngredientsEpic.ts
@@ -1,0 +1,56 @@
+import {ofType} from "redux-observable";
+import {ApplicationActions} from "../actions/actions";
+import {catchError, mergeMap} from "rxjs/operators";
+import {from} from "rxjs";
+import {AdditionalIngredientsActions} from "../actions/additionalIngredients.actions";
+import {AdditionalIngredientRepository} from "../repositorys/AdditionalIngredientRepository";
+import {AdditionalIngredient} from "../model/AdditionalIngredient";
+
+export const getAdditionalIngredientsEpic = (action$: any) =>
+    action$.pipe(
+        ofType(AdditionalIngredientsActions.ActionTypes.GET_ADDITIONAL_INGREDIENTS),
+        mergeMap(() =>
+            from(AdditionalIngredientRepository.getAdditionalIngredients()).pipe(
+                mergeMap((aIngredients: AdditionalIngredient[]) => from([
+                    AdditionalIngredientsActions.getAdditionalIngredientsSuccess(aIngredients)
+                ])),
+                catchError((aError: Error) =>
+                    from([
+                        ApplicationActions.openErrorDialog(
+                            true,
+                            "Weitere Zutaten Fehler",
+                            "Get AdditionalIngredients: " + aError.message
+                        )
+                    ])
+                )
+            )
+        )
+    );
+
+export const submitNewAdditionalIngredientEpic = (action$: any) =>
+    action$.pipe(
+        ofType(AdditionalIngredientsActions.ActionTypes.SUBMIT_NEW_ADDITIONAL_INGREDIENT),
+        mergeMap((aAction: any) =>
+            from(AdditionalIngredientRepository.submitAdditionalIngredient(aAction.payload.ingredient)).pipe(
+                // Nach erfolgreichem Anlegen laden wir die Liste neu, damit der State sicher aktuell ist.
+                mergeMap(() => from([
+                    AdditionalIngredientsActions.submitNewAdditionalIngredientSuccess(),
+                    AdditionalIngredientsActions.getAdditionalIngredients(true)
+                ])),
+                catchError((aError: Error) =>
+                    from([
+                        ApplicationActions.openErrorDialog(
+                            true,
+                            "Weitere Zutaten Fehler",
+                            "Submit AdditionalIngredient: " + aError.message
+                        )
+                    ])
+                )
+            )
+        )
+    );
+
+export const additionalIngredientsEpic = [
+    getAdditionalIngredientsEpic,
+    submitNewAdditionalIngredientEpic
+]

--- a/src/model/AdditionalIngredient.ts
+++ b/src/model/AdditionalIngredient.ts
@@ -1,0 +1,10 @@
+export interface AdditionalIngredient {
+    id: string;
+    name: string;
+    description?: string;
+}
+
+export interface AdditionalIngredientCreatePayload {
+    name: string;
+    description?: string;
+}

--- a/src/reducers/additionalIngredientsReducer.ts
+++ b/src/reducers/additionalIngredientsReducer.ts
@@ -1,0 +1,31 @@
+import {AdditionalIngredient} from "../model/AdditionalIngredient";
+import {AdditionalIngredientsActions} from "../actions/additionalIngredients.actions";
+import AllAdditionalIngredientsActions = AdditionalIngredientsActions.AllAdditionalIngredientsActions;
+
+export interface AdditionalIngredientsReducerState {
+    additionalIngredients: AdditionalIngredient[] | undefined
+    isFetching: boolean,
+    isSubmitAdditionalIngredientSuccessful: boolean | undefined,
+}
+
+export const initialAdditionalIngredientsState: AdditionalIngredientsReducerState = {
+    additionalIngredients: undefined,
+    isFetching: false,
+    isSubmitAdditionalIngredientSuccessful: true,
+}
+
+export const additionalIngredientsReducer = (aState: AdditionalIngredientsReducerState = initialAdditionalIngredientsState, aAction: AllAdditionalIngredientsActions) => {
+    switch (aAction.type) {
+        case AdditionalIngredientsActions.ActionTypes.GET_ADDITIONAL_INGREDIENTS: {
+            return {...aState, isFetching: aAction.payload.isFetching};
+        }
+        case AdditionalIngredientsActions.ActionTypes.GET_ADDITIONAL_INGREDIENTS_SUCCESS: {
+            return {...aState, additionalIngredients: aAction.payload.additionalIngredients};
+        }
+        case AdditionalIngredientsActions.ActionTypes.SUBMIT_NEW_ADDITIONAL_INGREDIENT_SUCCESS: {
+            return {...aState, isSubmitAdditionalIngredientSuccessful: true};
+        }
+        default:
+            return aState;
+    }
+}

--- a/src/reducers/rootReducer.ts
+++ b/src/reducers/rootReducer.ts
@@ -5,6 +5,7 @@ import { productionReducer, ProductionReducerState, initialProductionState } fro
 import { hopsReducer, HopsReducerState, initialHopsState } from './hopsReducer';
 import {maltsReducer, MaltsReducerState, initialMaltsState} from './maltsReducer';
 import {yeastReducer, YeastReducerState, initialYeastState} from './yeastReducer';
+import {additionalIngredientsReducer, AdditionalIngredientsReducerState, initialAdditionalIngredientsState} from './additionalIngredientsReducer';
 
 export const rootReducer = combineReducers({
     applicationReducer: applicationReducer,
@@ -12,9 +13,10 @@ export const rootReducer = combineReducers({
     productionReducer: productionReducer,
     hopsReducer: hopsReducer,
     maltsReducer: maltsReducer,
-    yeastReducer: yeastReducer
+    yeastReducer: yeastReducer,
+    additionalIngredientsReducer: additionalIngredientsReducer
 
 });
 
-export type { ApplicationReducerState, BeerDataReducerState, ProductionReducerState, HopsReducerState, MaltsReducerState, YeastReducerState };
-export { initialApplicationState, initialBeerState, initialProductionState ,initialHopsState, initialMaltsState, initialYeastState};
+export type { ApplicationReducerState, BeerDataReducerState, ProductionReducerState, HopsReducerState, MaltsReducerState, YeastReducerState, AdditionalIngredientsReducerState };
+export { initialApplicationState, initialBeerState, initialProductionState ,initialHopsState, initialMaltsState, initialYeastState, initialAdditionalIngredientsState};

--- a/src/repositorys/AdditionalIngredientRepository.ts
+++ b/src/repositorys/AdditionalIngredientRepository.ts
@@ -1,0 +1,12 @@
+import {BaseRepository} from "./BaseRepository";
+import {AdditionalIngredient, AdditionalIngredientCreatePayload} from "../model/AdditionalIngredient";
+
+export class AdditionalIngredientRepository extends BaseRepository {
+    static getAdditionalIngredients(): Promise<AdditionalIngredient[]> {
+        return this.get<AdditionalIngredient[]>("additionalingredients");
+    }
+
+    static submitAdditionalIngredient(aIngredient: AdditionalIngredientCreatePayload): Promise<void> {
+        return this.post("additionalingredient", aIngredient);
+    }
+}

--- a/src/store.ts
+++ b/src/store.ts
@@ -7,10 +7,11 @@ import { productionEpics } from './epics/productionEpics';
 import { hopsEpic} from "./epics/hopsEpic";
 import { maltsEpic} from "./epics/maltsEpic";
 import {yeastEpic} from "./epics/yeastEpic";
+import {additionalIngredientsEpic} from "./epics/additionalIngredientsEpic";
 
 const epicMiddleware = createEpicMiddleware();
 
-const rootEpic = combineEpics(...beerEpics, ...productionEpics, ...hopsEpic, ...maltsEpic, ...yeastEpic);
+const rootEpic = combineEpics(...beerEpics, ...productionEpics, ...hopsEpic, ...maltsEpic, ...yeastEpic, ...additionalIngredientsEpic);
 
 // Erstellen Sie den Store mit der Middleware
 const store = configureStore({


### PR DESCRIPTION
### Motivation
- Introduce support for managing "Weitere Zutaten" (additional ingredients) in the database overview so users can view, refresh and add extra ingredients. 
- Provide API integration and Redux plumbing to fetch and submit additional ingredients consistently with existing ingredient types.

### Description
- Added `AdditionalIngredient` model and `AdditionalIngredientCreatePayload` in `src/model/AdditionalIngredient.ts` to define the data shape. 
- Implemented Redux actions in `src/actions/additionalIngredients.actions.ts` including action types and creators `getAdditionalIngredients`, `getAdditionalIngredientsSuccess`, `submitNewAdditionalIngredient` and `submitNewAdditionalIngredientSuccess`.
- Added epics in `src/epics/additionalIngredientsEpic.ts` to handle `GET_ADDITIONAL_INGREDIENTS` and `SUBMIT_NEW_ADDITIONAL_INGREDIENT`, calling `AdditionalIngredientRepository` and dispatching success or error via `ApplicationActions.openErrorDialog` on failure. 
- Implemented `AdditionalIngredientRepository` in `src/repositorys/AdditionalIngredientRepository.ts` with `getAdditionalIngredients` and `submitAdditionalIngredient` that call the backend endpoints. 
- Added `additionalIngredientsReducer` in `src/reducers/additionalIngredientsReducer.ts` and registered it in `src/reducers/rootReducer.ts`, and exported its state type and initial state. 
- Registered the new epics in the root epic by updating `src/store.ts`. 
- Integrated UI in `src/containers/DatabaseOverview/IngredientsFormPage.tsx`: added a new accordion table for "Weitere Zutaten" with refresh and add flows, client-side validation for non-empty `name`, error message handling, and wired Redux props and dispatchers (`getAdditionalIngredients` and `submitNewAdditionalIngredient`).

### Testing
- No automated tests were added or modified for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a032afd7258832fa698a0404ae9f5be)