### PR TITLE
Add 'Additional Ingredients' feature: model, UI, Redux, epics and repository

### DIFF
--- a/src/actions/additionalIngredients.actions.ts
+++ b/src/actions/additionalIngredients.actions.ts
@@ -1,0 +1,68 @@
+import {AdditionalIngredient, AdditionalIngredientCreatePayload} from "../model/AdditionalIngredient";
+
+export namespace AdditionalIngredientsActions {
+    export enum ActionTypes {
+        GET_ADDITIONAL_INGREDIENTS = 'AdditionalIngredientsActions.GET_ADDITIONAL_INGREDIENTS',
+        GET_ADDITIONAL_INGREDIENTS_SUCCESS = 'AdditionalIngredientsActions.GET_ADDITIONAL_INGREDIENTS_SUCCESS',
+        SUBMIT_NEW_ADDITIONAL_INGREDIENT = 'AdditionalIngredientsActions.SUBMIT_NEW_ADDITIONAL_INGREDIENT',
+        SUBMIT_NEW_ADDITIONAL_INGREDIENT_SUCCESS = 'AdditionalIngredientsActions.SUBMIT_NEW_ADDITIONAL_INGREDIENT_SUCCESS'
+    }
+
+    export interface GetAdditionalIngredients {
+        readonly type: ActionTypes.GET_ADDITIONAL_INGREDIENTS
+        payload: {
+            isFetching: boolean
+        }
+    }
+
+    export interface GetAdditionalIngredientsSuccess {
+        readonly type: ActionTypes.GET_ADDITIONAL_INGREDIENTS_SUCCESS
+        payload: {
+            additionalIngredients: AdditionalIngredient[]
+        }
+    }
+
+    export interface SubmitNewAdditionalIngredient {
+        readonly type: ActionTypes.SUBMIT_NEW_ADDITIONAL_INGREDIENT
+        payload: {
+            ingredient: AdditionalIngredientCreatePayload
+        }
+    }
+
+    export interface SubmitNewAdditionalIngredientSuccess {
+        readonly type: ActionTypes.SUBMIT_NEW_ADDITIONAL_INGREDIENT_SUCCESS
+    }
+
+    export type AllAdditionalIngredientsActions =
+        GetAdditionalIngredients |
+        GetAdditionalIngredientsSuccess |
+        SubmitNewAdditionalIngredient |
+        SubmitNewAdditionalIngredientSuccess
+
+    export function getAdditionalIngredients(aIsFetching: boolean): GetAdditionalIngredients {
+        return {
+            type: ActionTypes.GET_ADDITIONAL_INGREDIENTS,
+            payload: {isFetching: aIsFetching}
+        }
+    }
+
+    export function getAdditionalIngredientsSuccess(aAdditionalIngredients: AdditionalIngredient[]): GetAdditionalIngredientsSuccess {
+        return {
+            type: ActionTypes.GET_ADDITIONAL_INGREDIENTS_SUCCESS,
+            payload: {additionalIngredients: aAdditionalIngredients}
+        }
+    }
+
+    export function submitNewAdditionalIngredient(aIngredient: AdditionalIngredientCreatePayload): SubmitNewAdditionalIngredient {
+        return {
+            type: ActionTypes.SUBMIT_NEW_ADDITIONAL_INGREDIENT,
+            payload: {ingredient: aIngredient}
+        }
+    }
+
+    export function submitNewAdditionalIngredientSuccess(): SubmitNewAdditionalIngredientSuccess {
+        return {
+            type: ActionTypes.SUBMIT_NEW_ADDITIONAL_INGREDIENT_SUCCESS
+        }
+    }
+}

--- a/src/containers/DatabaseOverview/BeerForm.tsx
+++ b/src/containers/DatabaseOverview/BeerForm.tsx
@@ -1,6 +1,6 @@
 import React, { ChangeEvent, FormEvent } from 'react';
-import {Beer, FermentationSteps, Hop, Malt, Yeast} from "../../model/Beer";
-import {BeerDTO, HopDTO, MaltDTO, YeastDTO} from "../../model/BeerDTO";
+import {AdditionalIngredientPhase, AdditionalIngredientTimeUnit, Beer, BeerAdditionalIngredient, FermentationSteps, Hop, Malt, Yeast} from "../../model/Beer";
+import {AdditionalIngredientDTO, BeerDTO, HopDTO, MaltDTO, YeastDTO} from "../../model/BeerDTO";
 import { HopUsage } from "../../enums/eHopUsage";
 import { HopTimeUnit } from "../../enums/eHopTimeUnit";
 import { normalizeHopDto, updateHopUsage, validateHopDto } from "./hopDefaults";
@@ -18,6 +18,8 @@ import SimpleBar from 'simplebar-react';
 import {MaltsActions} from "../../actions/malt.actions";
 import {HopsActions} from "../../actions/hops.actions";
 import {YeastActions} from "../../actions/yeast.actions";
+import {AdditionalIngredientsActions} from "../../actions/additionalIngredients.actions";
+import {AdditionalIngredient} from "../../model/AdditionalIngredient";
 import { COLOR_WHITE, COLOR_BREW_BG, COLOR_ACCENT, BORDER_TRANSPARENT, COLOR_DARK_BG, COLOR_BORDER_INPUT_ALT } from '../../colors';
 
 interface BeerFormProps {
@@ -25,10 +27,12 @@ interface BeerFormProps {
     getMalt: (isFetching: boolean) => void;
     getHop: (isFetching: boolean) => void;
     getYeast: (isFetching: boolean) => void;
+    getAdditionalIngredients: (isFetching: boolean) => void;
     saveBeerFormState: (formState: any) => void;
     malts: Malt[];
     hops: Hop[];
     yeasts: Yeast[];
+    additionalIngredients: AdditionalIngredient[];
     isSubmitSuccessful: boolean;
     messageType: string;
     message: string;
@@ -56,6 +60,7 @@ interface BeerFormState {
     maltsDTO: MaltDTO[];
     hopsDTO: HopDTO[];
     yeastsDTO: YeastDTO[];
+    additionalIngredientsDTO: AdditionalIngredientDTO[];
     isSubmitSuccessful: boolean;
     missingMalts?: string[];
     missingHops?: string[];
@@ -92,6 +97,7 @@ class BeerForm extends React.Component<BeerFormProps, BeerFormState> {
             maltsDTO: [{ id: '', name: '', quantity: 0 }],
             hopsDTO: [{ id: '', name: '', quantity: 0, time: 0, usage: HopUsage.BOIL, timeUnit: HopTimeUnit.MINUTES }],
             yeastsDTO: [{ id: '', name: '', quantity: 0 }],
+            additionalIngredientsDTO: [],
             isSubmitSuccessful: false,
         };
 
@@ -108,10 +114,11 @@ class BeerForm extends React.Component<BeerFormProps, BeerFormState> {
     };
 
     componentDidMount() {
-        const {getMalt, getHop, getYeast} = this.props;
+        const {getMalt, getHop, getYeast, getAdditionalIngredients} = this.props;
         getMalt(true);
         getHop(true);
         getYeast(true);
+        getAdditionalIngredients(true);
     }
 
     componentDidUpdate(prevProps: Readonly<BeerFormProps>, prevState: Readonly<BeerFormState>, snapshot?: any) {
@@ -142,6 +149,8 @@ class BeerForm extends React.Component<BeerFormProps, BeerFormState> {
                 // Altrezepte ohne usage/timeUnit bleiben kompatibel und werden auf BOIL/MINUTES normiert.
                 hopsDTO: importedBeer.wortBoiling && importedBeer.wortBoiling.hops ? importedBeer.wortBoiling.hops.map(aHop => normalizeHopDto(aHop)) : [],
                 yeastsDTO: importedBeer.fermentationMaturation && importedBeer.fermentationMaturation.yeast ? importedBeer.fermentationMaturation.yeast.map(y => ({ id: y.id, name: y.name, quantity: y.quantity })) : [],
+                // Alte Rezepte ohne additionalIngredients bleiben kompatibel und werden als leere Liste geführt.
+                additionalIngredientsDTO: importedBeer.additionalIngredients ? importedBeer.additionalIngredients.map(aIngredient => this.normalizeAdditionalIngredient(aIngredient)) : [],
                 isSubmitSuccessful: false,
             }, () => {
                 this.props.saveBeerFormState(this.state);
@@ -246,6 +255,67 @@ class BeerForm extends React.Component<BeerFormProps, BeerFormState> {
         });
     }
 
+    normalizeAdditionalIngredient = (aIngredient: any): AdditionalIngredientDTO => {
+        return {
+            id: aIngredient?.id,
+            name: aIngredient?.name ?? '',
+            quantity: Number(aIngredient?.quantity ?? 0),
+            unit: aIngredient?.unit ?? 'g',
+            phase: Object.values(AdditionalIngredientPhase).includes(aIngredient?.phase)
+                ? aIngredient.phase
+                : AdditionalIngredientPhase.MATURATION,
+            time: aIngredient?.time !== undefined && aIngredient?.time !== null ? Number(aIngredient.time) : undefined,
+            timeUnit: Object.values(AdditionalIngredientTimeUnit).includes(aIngredient?.timeUnit)
+                ? aIngredient.timeUnit
+                : AdditionalIngredientTimeUnit.DAYS,
+            description: aIngredient?.description ?? ''
+        };
+    }
+
+    handleAdditionalIngredientChange = (aValue: string, aName: string, aIndex: number) => {
+        this.setState((prevState) => {
+            const additionalIngredientsDTO = [...prevState.additionalIngredientsDTO];
+            const aStep = additionalIngredientsDTO[aIndex];
+
+            if (aName === "quantity" || aName === "time") {
+                const aParsed = Number(aValue);
+                // time ist optional; leeres Feld bleibt undefined statt 0 als Marker.
+                // @ts-ignore
+                aStep[aName] = aValue === '' ? undefined : (isNaN(aParsed) ? 0 : aParsed);
+            } else if (aName === "phase") {
+                aStep.phase = aValue as AdditionalIngredientPhase;
+            } else if (aName === "timeUnit") {
+                aStep.timeUnit = aValue as AdditionalIngredientTimeUnit;
+            } else if (aName === "name") {
+                const aMasterIngredient = this.props.additionalIngredients.find((aIngredient) => aIngredient.name === aValue);
+                aStep.name = aValue;
+                if (aMasterIngredient) {
+                    aStep.id = aMasterIngredient.id;
+                }
+            } else {
+                // @ts-ignore
+                aStep[aName] = aValue;
+            }
+
+            return { additionalIngredientsDTO };
+        }, () => {
+            this.props.saveBeerFormState(this.state);
+        });
+    }
+
+    validateAdditionalIngredients = (aIngredients: AdditionalIngredientDTO[]): boolean => {
+        for (const aIngredient of aIngredients) {
+            const aHasIdOrName = !!aIngredient.id || !!(aIngredient.name && aIngredient.name.trim().length > 0);
+            if (!aHasIdOrName) return false;
+            if (!(Number(aIngredient.quantity) > 0)) return false;
+            if (!aIngredient.unit || aIngredient.unit.trim().length === 0) return false;
+            if (!Object.values(AdditionalIngredientPhase).includes(aIngredient.phase)) return false;
+            if (aIngredient.time !== undefined && !(Number(aIngredient.time) > 0)) return false;
+            if (aIngredient.timeUnit !== undefined && !Object.values(AdditionalIngredientTimeUnit).includes(aIngredient.timeUnit)) return false;
+        }
+        return true;
+    }
+
 
 
     handleSubmit = (e: FormEvent) => {
@@ -269,6 +339,7 @@ class BeerForm extends React.Component<BeerFormProps, BeerFormState> {
             maltsDTO,
             hopsDTO,
             yeastsDTO,
+            additionalIngredientsDTO,
         } = this.state;
         if (!this.validateFermentationSteps(fermentationSteps)) {
             alert('Bitte prüfe den Maischeplan: Zeitgesteuerte Rasten benötigen Zeit > 0, Halte-Rasten nur Temperatur.');
@@ -316,6 +387,11 @@ class BeerForm extends React.Component<BeerFormProps, BeerFormState> {
             })
             .filter((y): y is YeastDTO => y !== undefined);
 
+        if (!this.validateAdditionalIngredients(additionalIngredientsDTO)) {
+            alert('Bitte prüfe weitere Zutaten: Zutat (ID/Name), Menge > 0, Einheit und gültige Phase sind erforderlich. Zeit darf nur > 0 gesetzt werden.');
+            return;
+        }
+
         const beer: BeerDTO = {
             id: id || '0',
             name,
@@ -333,7 +409,9 @@ class BeerForm extends React.Component<BeerFormProps, BeerFormState> {
             cookingTemperatur,
             malts: malts_DTO,
             wortBoiling: { totalTime: 0, hops: hops_DTO },
-            fermentationMaturation: { fermentationTemperature: 0, carbonation: 0, yeast: yeasts_DTO}
+            fermentationMaturation: { fermentationTemperature: 0, carbonation: 0, yeast: yeasts_DTO},
+            // additionalIngredients wird 1:1 aus dem Rezepteditor übernommen, damit Import/Load/Save verlustfrei bleibt.
+            additionalIngredients: additionalIngredientsDTO
         };
 
         console.log(beer);
@@ -358,6 +436,7 @@ class BeerForm extends React.Component<BeerFormProps, BeerFormState> {
             maltsDTO: [],
             hopsDTO: [],
             yeastsDTO: [],
+            additionalIngredientsDTO: [],
         }, () => {
             // Nach dem Zurücksetzen des Formulars aktualisieren wir den gespeicherten Status
             this.props.saveBeerFormState(this.state);
@@ -394,6 +473,19 @@ class BeerForm extends React.Component<BeerFormProps, BeerFormState> {
         }));
     }
 
+    addAdditionalIngredient = () => {
+        this.setState((prevState) => ({
+            additionalIngredientsDTO: [...prevState.additionalIngredientsDTO, {
+                quantity: 0,
+                unit: 'g',
+                phase: AdditionalIngredientPhase.MATURATION,
+                time: undefined,
+                timeUnit: AdditionalIngredientTimeUnit.DAYS,
+                description: ''
+            }],
+        }));
+    }
+
     removeFermentationStep = (index: number) => {
         this.setState((prevState) => {
             const fermentationSteps = [...prevState.fermentationSteps];
@@ -426,6 +518,14 @@ class BeerForm extends React.Component<BeerFormProps, BeerFormState> {
         });
     }
 
+    removeAdditionalIngredient = (aIndex: number) => {
+        this.setState((prevState) => {
+            const additionalIngredientsDTO = [...prevState.additionalIngredientsDTO];
+            additionalIngredientsDTO.splice(aIndex, 1);
+            return { additionalIngredientsDTO };
+        });
+    }
+
     handleBeerSelect = (e: ChangeEvent<HTMLSelectElement>) => {
         const { beers } = this.props;
         const selectedId = e.target.value;
@@ -455,6 +555,8 @@ class BeerForm extends React.Component<BeerFormProps, BeerFormState> {
                 // Bestehende Rezepte ohne neue Felder werden im UI als Kochhopfen in Minuten dargestellt.
                 hopsDTO: selectedBeer.wortBoiling && selectedBeer.wortBoiling.hops ? selectedBeer.wortBoiling.hops.map(aHop => normalizeHopDto(aHop)) : [],
                 yeastsDTO: selectedBeer.fermentationMaturation && selectedBeer.fermentationMaturation.yeast ? selectedBeer.fermentationMaturation.yeast.map(y => ({ id: y.id, name: y.name, quantity: y.quantity })) : [],
+                // Für alte DB-Einträge ohne Feld wird bewusst [] gesetzt.
+                additionalIngredientsDTO: selectedBeer.additionalIngredients ? selectedBeer.additionalIngredients.map(aIngredient => this.normalizeAdditionalIngredient(aIngredient)) : [],
                 isSubmitSuccessful: false,
             }, () => {
                 this.props.saveBeerFormState(this.state);
@@ -463,8 +565,8 @@ class BeerForm extends React.Component<BeerFormProps, BeerFormState> {
     };
 
     renderCreateBeerForm() {
-        const {maltsDTO, hopsDTO, yeastsDTO, isSubmitSuccessful, name, type, color, alcohol, originalwort, bitterness, description, rating, mashVolume, spargeVolume, fermentationSteps, cookingTime, cookingTemperatur} = this.state;
-        const { malts = [], hops = [], yeasts = [], messageType, message, beers = [] } = this.props;
+        const {maltsDTO, hopsDTO, yeastsDTO, additionalIngredientsDTO, isSubmitSuccessful, name, type, color, alcohol, originalwort, bitterness, description, rating, mashVolume, spargeVolume, fermentationSteps, cookingTime, cookingTemperatur} = this.state;
+        const { malts = [], hops = [], yeasts = [], additionalIngredients = [], messageType, message, beers = [] } = this.props;
 
         let info: string = "";
         if (isEqual(isSubmitSuccessful, true)) {
@@ -883,6 +985,87 @@ class BeerForm extends React.Component<BeerFormProps, BeerFormState> {
                         </div>
                         <button type="button" className="add-button" onClick={this.addYeast}>Hefe zufügen</button>
                     </div>
+
+                    <div className="table-section">
+                        <h3>Weitere Zutaten</h3>
+                        <div className="table-wrapper" style={{overflowX: 'auto', maxHeight: '180px'}}>
+                            <table className="ingredient-table" style={{width: '100%', borderCollapse: 'collapse'}}>
+                                <thead style={{position: 'sticky', top: 0, background: COLOR_WHITE, zIndex: 2}}>
+                                <tr>
+                                    <th>Zutat</th>
+                                    <th>Menge</th>
+                                    <th>Einheit</th>
+                                    <th>Phase</th>
+                                    <th>Zeit</th>
+                                    <th>Zeiteinheit</th>
+                                    <th>Hinweis</th>
+                                    <th className="action-column">Entfernen</th>
+                                </tr>
+                                </thead>
+                                <tbody>
+                                {additionalIngredientsDTO?.map((aStep, aIndex) => (
+                                    <tr key={aIndex}>
+                                        <td>
+                                            <select
+                                                name="name"
+                                                value={aStep.name || ''}
+                                                onChange={(e) => this.handleAdditionalIngredientChange(e.target.value, "name", aIndex)}
+                                            >
+                                                <option value="">Zutat</option>
+                                                {additionalIngredients.map((aIngredient) => (
+                                                    <option key={aIngredient.id} value={aIngredient.name}>
+                                                        {aIngredient.name}
+                                                    </option>
+                                                ))}
+                                            </select>
+                                        </td>
+                                        <td>
+                                            <input type="number" min={0} name="quantity" value={aStep.quantity}
+                                                   onChange={(e) => this.handleAdditionalIngredientChange(e.target.value, "quantity", aIndex)} />
+                                        </td>
+                                        <td>
+                                            <input type="text" name="unit" value={aStep.unit}
+                                                   onChange={(e) => this.handleAdditionalIngredientChange(e.target.value, "unit", aIndex)} />
+                                        </td>
+                                        <td>
+                                            <select name="phase" value={aStep.phase}
+                                                    onChange={(e) => this.handleAdditionalIngredientChange(e.target.value, "phase", aIndex)}>
+                                                <option value={AdditionalIngredientPhase.MASH}>Maische</option>
+                                                <option value={AdditionalIngredientPhase.BOIL}>Kochen</option>
+                                                <option value={AdditionalIngredientPhase.WHIRLPOOL}>Whirlpool</option>
+                                                <option value={AdditionalIngredientPhase.FERMENTATION}>Gärung</option>
+                                                <option value={AdditionalIngredientPhase.MATURATION}>Reifung</option>
+                                                <option value={AdditionalIngredientPhase.PACKAGING}>Abfüllung</option>
+                                            </select>
+                                        </td>
+                                        <td>
+                                            <input type="number" min={1} name="time" value={aStep.time ?? ''}
+                                                   onChange={(e) => this.handleAdditionalIngredientChange(e.target.value, "time", aIndex)} />
+                                        </td>
+                                        <td>
+                                            <select name="timeUnit" value={aStep.timeUnit ?? AdditionalIngredientTimeUnit.DAYS}
+                                                    onChange={(e) => this.handleAdditionalIngredientChange(e.target.value, "timeUnit", aIndex)}>
+                                                <option value={AdditionalIngredientTimeUnit.MINUTES}>Minuten</option>
+                                                <option value={AdditionalIngredientTimeUnit.HOURS}>Stunden</option>
+                                                <option value={AdditionalIngredientTimeUnit.DAYS}>Tage</option>
+                                            </select>
+                                        </td>
+                                        <td>
+                                            <input type="text" name="description" value={aStep.description ?? ''}
+                                                   onChange={(e) => this.handleAdditionalIngredientChange(e.target.value, "description", aIndex)} />
+                                        </td>
+                                        <td className="action-column">
+                                            <button type="button" className="cancel-btn" onClick={() => this.removeAdditionalIngredient(aIndex)} title="Löschen">
+                                                <span role="img" aria-label="Löschen" style={{ fontSize: 22, verticalAlign: 'middle', display: 'inline-block', position: 'relative', top: '3px' }}>🗑️</span>
+                                            </button>
+                                        </td>
+                                    </tr>
+                                ))}
+                                </tbody>
+                            </table>
+                        </div>
+                        <button type="button" className="add-button" onClick={this.addAdditionalIngredient}>Hinzufügen</button>
+                    </div>
                 </div>
 
                 <button className="finish-btn submit-button" type="submit">
@@ -924,6 +1107,7 @@ const mapStateToProps = (state: any) => ({
     malts: state.maltsReducer.malts,
     hops: state.hopsReducer.hops,
     yeasts: state.yeastReducer.yeasts,
+    additionalIngredients: state.additionalIngredientsReducer.additionalIngredients || [],
     isSubmitSuccessful: state.beerDataReducer.isSubmitSuccessful,
     message: state.beerDataReducer.message,
     messageType: state.beerDataReducer.type,
@@ -937,6 +1121,7 @@ const mapDispatchToProps = (dispatch: any) => ({
     getMalt: (isFetching: boolean) => dispatch(MaltsActions.getMalts(isFetching)),
     getHop: (isFetching: boolean) => dispatch(HopsActions.getHops(isFetching)),
     getYeast: (isFetching: boolean) => dispatch(YeastActions.getYeasts(isFetching)),
+    getAdditionalIngredients: (isFetching: boolean) => dispatch(AdditionalIngredientsActions.getAdditionalIngredients(isFetching)),
     saveBeerFormState: (formState: any) => dispatch(BeerActions.saveBeerFormState(formState)),
     importBeer: (file: File) => dispatch(BeerActions.importBeer(file)),
 });

--- a/src/containers/DatabaseOverview/IngredientsFormPage.tsx
+++ b/src/containers/DatabaseOverview/IngredientsFormPage.tsx
@@ -27,6 +27,8 @@ import './IngredientsFormPage.css';
 import { MaltsActions } from "../../actions/malt.actions";
 import { HopsActions } from "../../actions/hops.actions";
 import { YeastActions } from "../../actions/yeast.actions";
+import {AdditionalIngredientsActions} from "../../actions/additionalIngredients.actions";
+import {AdditionalIngredient} from "../../model/AdditionalIngredient";
 
 
 class IngredientsFormPage extends React.Component<any, any> {
@@ -42,7 +44,10 @@ class IngredientsFormPage extends React.Component<any, any> {
             newYeast: {},
             showNewMaltRow: false,
             showNewHopRow: false,
-            showNewYeastRow: false
+            showNewYeastRow: false,
+            newAdditionalIngredient: { name: "", description: "" },
+            showNewAdditionalIngredientRow: false,
+            additionalIngredientError: ""
         };
     }
 
@@ -50,6 +55,7 @@ class IngredientsFormPage extends React.Component<any, any> {
         this.props.getMalt(true);
         this.props.getHop(true);
         this.props.getYeast(true);
+        this.props.getAdditionalIngredients(true);
     }
 
     componentDidUpdate() {
@@ -98,12 +104,34 @@ class IngredientsFormPage extends React.Component<any, any> {
         }
     };
 
+    handleAddAdditionalIngredient = () => {
+        const { newAdditionalIngredient } = this.state;
+        const aTrimmedName = (newAdditionalIngredient.name || "").trim();
+
+        if (!aTrimmedName) {
+            // Name darf nicht leer sein, damit kein ungültiger API-Request gesendet wird.
+            this.setState({ additionalIngredientError: "Name ist erforderlich." });
+            return;
+        }
+
+        this.props.submitNewAdditionalIngredient({
+            name: aTrimmedName,
+            description: newAdditionalIngredient.description || ""
+        });
+
+        this.setState({
+            newAdditionalIngredient: { name: "", description: "" },
+            showNewAdditionalIngredientRow: false,
+            additionalIngredientError: ""
+        });
+    };
+
 
     render() {
-        const { malts, hops, yeasts } = this.props;
+        const { malts, hops, yeasts, additionalIngredients } = this.props;
         const {
-            newMalt, newHop, newYeast,
-            showNewMaltRow, showNewHopRow, showNewYeastRow
+            newMalt, newHop, newYeast, newAdditionalIngredient,
+            showNewMaltRow, showNewHopRow, showNewYeastRow, showNewAdditionalIngredientRow, additionalIngredientError
         } = this.state;
 
 
@@ -365,6 +393,73 @@ class IngredientsFormPage extends React.Component<any, any> {
                         </AccordionDetails>
                     </Accordion>
 
+                    {/* ----------------------------------- WEITERE ZUTATEN ----------------------------------- */}
+                    <Accordion sx={{ backgroundColor: COLOR_BREW_BG }}>
+                        <AccordionSummary
+                            sx={{ backgroundColor: COLOR_ACCENT, borderRadius: "0 0 10px 10px" }}
+                            expandIcon={<ExpandMoreIcon />}
+                        >
+                            <Typography>Weitere Zutaten</Typography>
+                        </AccordionSummary>
+
+                        <AccordionDetails sx={{ backgroundColor: COLOR_BREW_BG }}>
+                            <div className="filter-container">
+                                <button className="finish-btn" onClick={() => this.setState({ showNewAdditionalIngredientRow: true, additionalIngredientError: "" })}>
+                                    Neue Zutat
+                                </button>
+                                <button className="finish-btn" onClick={() => this.props.getAdditionalIngredients(true)}>
+                                    Aktualisieren
+                                </button>
+                            </div>
+
+                            <TableContainer className="FinishedBrewsTable" sx={{ maxHeight: 400 }}>
+                                <Table stickyHeader>
+                                    <TableHead>
+                                        <TableRow>
+                                            <TableCell>Name</TableCell>
+                                            <TableCell>Beschreibung</TableCell>
+                                            <TableCell>Aktion</TableCell>
+                                        </TableRow>
+                                    </TableHead>
+
+                                    <TableBody>
+                                        {showNewAdditionalIngredientRow && (
+                                            <TableRow>
+                                                <TableCell>
+                                                    <input className="table-edit-field"
+                                                           value={newAdditionalIngredient.name || ""}
+                                                           onChange={e => this.setState({ newAdditionalIngredient: { ...newAdditionalIngredient, name: e.target.value }, additionalIngredientError: "" })}
+                                                    />
+                                                    {additionalIngredientError && <div style={{ color: '#d32f2f', fontSize: '0.8rem' }}>{additionalIngredientError}</div>}
+                                                </TableCell>
+                                                <TableCell>
+                                                    <input className="table-edit-field"
+                                                           value={newAdditionalIngredient.description || ""}
+                                                           onChange={e => this.setState({ newAdditionalIngredient: { ...newAdditionalIngredient, description: e.target.value } })}
+                                                    />
+                                                </TableCell>
+                                                <TableCell>
+                                                    <div className="action-buttons">
+                                                        <button className="finish-btn" onClick={this.handleAddAdditionalIngredient}>Hinzufügen</button>
+                                                        <button className="cancel-btn" onClick={() => this.setState({ showNewAdditionalIngredientRow: false, additionalIngredientError: "" })}>✖️</button>
+                                                    </div>
+                                                </TableCell>
+                                            </TableRow>
+                                        )}
+
+                                        {additionalIngredients.map((aIngredient: AdditionalIngredient) => (
+                                            <TableRow key={aIngredient.id}>
+                                                <TableCell>{aIngredient.name}</TableCell>
+                                                <TableCell>{aIngredient.description}</TableCell>
+                                                <TableCell />
+                                            </TableRow>
+                                        ))}
+                                    </TableBody>
+                                </Table>
+                            </TableContainer>
+                        </AccordionDetails>
+                    </Accordion>
+
                 </div>
             </SimpleBar>
         );
@@ -378,7 +473,8 @@ class IngredientsFormPage extends React.Component<any, any> {
 const mapStateToProps = (state: any) => ({
     malts: state.maltsReducer.malts || [],
     hops: state.hopsReducer.hops || [],
-    yeasts: state.yeastReducer.yeasts || []
+    yeasts: state.yeastReducer.yeasts || [],
+    additionalIngredients: state.additionalIngredientsReducer.additionalIngredients || []
 });
 
 const mapDispatchToProps = (dispatch: any) => ({
@@ -387,7 +483,9 @@ const mapDispatchToProps = (dispatch: any) => ({
     getYeast: (isFetching: boolean) => dispatch(YeastActions.getYeasts(isFetching)),
     submitNewMalt: (malt: Malts) => dispatch(MaltsActions.submitNewMalt(malt)),
     submitNewHop: (hop: Hops) => dispatch(HopsActions.submitNewHop(hop)),
-    submitNewYeast: (yeast: Yeasts) => dispatch(YeastActions.submitNewYeast(yeast))
+    submitNewYeast: (yeast: Yeasts) => dispatch(YeastActions.submitNewYeast(yeast)),
+    getAdditionalIngredients: (isFetching: boolean) => dispatch(AdditionalIngredientsActions.getAdditionalIngredients(isFetching)),
+    submitNewAdditionalIngredient: (aIngredient: { name: string; description?: string }) => dispatch(AdditionalIngredientsActions.submitNewAdditionalIngredient(aIngredient))
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(IngredientsFormPage);

--- a/src/epics/additionalIngredientsEpic.ts
+++ b/src/epics/additionalIngredientsEpic.ts
@@ -1,0 +1,56 @@
+import {ofType} from "redux-observable";
+import {ApplicationActions} from "../actions/actions";
+import {catchError, mergeMap} from "rxjs/operators";
+import {from} from "rxjs";
+import {AdditionalIngredientsActions} from "../actions/additionalIngredients.actions";
+import {AdditionalIngredientRepository} from "../repositorys/AdditionalIngredientRepository";
+import {AdditionalIngredient} from "../model/AdditionalIngredient";
+
+export const getAdditionalIngredientsEpic = (action$: any) =>
+    action$.pipe(
+        ofType(AdditionalIngredientsActions.ActionTypes.GET_ADDITIONAL_INGREDIENTS),
+        mergeMap(() =>
+            from(AdditionalIngredientRepository.getAdditionalIngredients()).pipe(
+                mergeMap((aIngredients: AdditionalIngredient[]) => from([
+                    AdditionalIngredientsActions.getAdditionalIngredientsSuccess(aIngredients)
+                ])),
+                catchError((aError: Error) =>
+                    from([
+                        ApplicationActions.openErrorDialog(
+                            true,
+                            "Weitere Zutaten Fehler",
+                            "Get AdditionalIngredients: " + aError.message
+                        )
+                    ])
+                )
+            )
+        )
+    );
+
+export const submitNewAdditionalIngredientEpic = (action$: any) =>
+    action$.pipe(
+        ofType(AdditionalIngredientsActions.ActionTypes.SUBMIT_NEW_ADDITIONAL_INGREDIENT),
+        mergeMap((aAction: any) =>
+            from(AdditionalIngredientRepository.submitAdditionalIngredient(aAction.payload.ingredient)).pipe(
+                // Nach erfolgreichem Anlegen laden wir die Liste neu, damit der State sicher aktuell ist.
+                mergeMap(() => from([
+                    AdditionalIngredientsActions.submitNewAdditionalIngredientSuccess(),
+                    AdditionalIngredientsActions.getAdditionalIngredients(true)
+                ])),
+                catchError((aError: Error) =>
+                    from([
+                        ApplicationActions.openErrorDialog(
+                            true,
+                            "Weitere Zutaten Fehler",
+                            "Submit AdditionalIngredient: " + aError.message
+                        )
+                    ])
+                )
+            )
+        )
+    );
+
+export const additionalIngredientsEpic = [
+    getAdditionalIngredientsEpic,
+    submitNewAdditionalIngredientEpic
+]

--- a/src/model/AdditionalIngredient.ts
+++ b/src/model/AdditionalIngredient.ts
@@ -1,0 +1,10 @@
+export interface AdditionalIngredient {
+    id: string;
+    name: string;
+    description?: string;
+}
+
+export interface AdditionalIngredientCreatePayload {
+    name: string;
+    description?: string;
+}

--- a/src/model/Beer.ts
+++ b/src/model/Beer.ts
@@ -49,6 +49,32 @@ export interface FermentationMaturation {
     yeast: Yeast[];
 }
 
+export enum AdditionalIngredientPhase {
+    MASH = "MASH",
+    BOIL = "BOIL",
+    WHIRLPOOL = "WHIRLPOOL",
+    FERMENTATION = "FERMENTATION",
+    MATURATION = "MATURATION",
+    PACKAGING = "PACKAGING"
+}
+
+export enum AdditionalIngredientTimeUnit {
+    MINUTES = "MINUTES",
+    HOURS = "HOURS",
+    DAYS = "DAYS"
+}
+
+export interface BeerAdditionalIngredient {
+    id?: string | number;
+    name?: string;
+    quantity: number;
+    unit: string;
+    phase: AdditionalIngredientPhase;
+    time?: number;
+    timeUnit?: AdditionalIngredientTimeUnit;
+    description?: string;
+}
+
 export interface Beer {
     id: string;
     name: string;
@@ -67,4 +93,5 @@ export interface Beer {
     malts: Malt[];
     wortBoiling: WortBoiling;
     fermentationMaturation: FermentationMaturation;
+    additionalIngredients?: BeerAdditionalIngredient[];
 }

--- a/src/model/BeerDTO.ts
+++ b/src/model/BeerDTO.ts
@@ -2,6 +2,7 @@ import { MashingType } from '../enums/eMashingType';
 import { RestExecutionMode } from '../enums/eRestExecutionMode';
 import { HopTimeUnit } from '../enums/eHopTimeUnit';
 import { HopUsage } from '../enums/eHopUsage';
+import {AdditionalIngredientPhase, AdditionalIngredientTimeUnit} from "./Beer";
 export interface FermentationStepsDTO {
     type: string;
     temperature: number;
@@ -41,6 +42,17 @@ export interface FermentationMaturationDTO {
     yeast: YeastDTO[];
 }
 
+export interface AdditionalIngredientDTO {
+    id?: string | number;
+    name?: string;
+    quantity: number;
+    unit: string;
+    phase: AdditionalIngredientPhase;
+    time?: number;
+    timeUnit?: AdditionalIngredientTimeUnit;
+    description?: string;
+}
+
 export interface BeerDTO {
     id: string;
     name: string;
@@ -59,4 +71,5 @@ export interface BeerDTO {
     malts: MaltDTO[];
     wortBoiling: WortBoilingDTO | null
     fermentationMaturation: FermentationMaturationDTO | null;
+    additionalIngredients?: AdditionalIngredientDTO[];
 }

--- a/src/reducers/additionalIngredientsReducer.ts
+++ b/src/reducers/additionalIngredientsReducer.ts
@@ -1,0 +1,31 @@
+import {AdditionalIngredient} from "../model/AdditionalIngredient";
+import {AdditionalIngredientsActions} from "../actions/additionalIngredients.actions";
+import AllAdditionalIngredientsActions = AdditionalIngredientsActions.AllAdditionalIngredientsActions;
+
+export interface AdditionalIngredientsReducerState {
+    additionalIngredients: AdditionalIngredient[] | undefined
+    isFetching: boolean,
+    isSubmitAdditionalIngredientSuccessful: boolean | undefined,
+}
+
+export const initialAdditionalIngredientsState: AdditionalIngredientsReducerState = {
+    additionalIngredients: undefined,
+    isFetching: false,
+    isSubmitAdditionalIngredientSuccessful: true,
+}
+
+export const additionalIngredientsReducer = (aState: AdditionalIngredientsReducerState = initialAdditionalIngredientsState, aAction: AllAdditionalIngredientsActions) => {
+    switch (aAction.type) {
+        case AdditionalIngredientsActions.ActionTypes.GET_ADDITIONAL_INGREDIENTS: {
+            return {...aState, isFetching: aAction.payload.isFetching};
+        }
+        case AdditionalIngredientsActions.ActionTypes.GET_ADDITIONAL_INGREDIENTS_SUCCESS: {
+            return {...aState, additionalIngredients: aAction.payload.additionalIngredients};
+        }
+        case AdditionalIngredientsActions.ActionTypes.SUBMIT_NEW_ADDITIONAL_INGREDIENT_SUCCESS: {
+            return {...aState, isSubmitAdditionalIngredientSuccessful: true};
+        }
+        default:
+            return aState;
+    }
+}

--- a/src/reducers/rootReducer.ts
+++ b/src/reducers/rootReducer.ts
@@ -5,6 +5,7 @@ import { productionReducer, ProductionReducerState, initialProductionState } fro
 import { hopsReducer, HopsReducerState, initialHopsState } from './hopsReducer';
 import {maltsReducer, MaltsReducerState, initialMaltsState} from './maltsReducer';
 import {yeastReducer, YeastReducerState, initialYeastState} from './yeastReducer';
+import {additionalIngredientsReducer, AdditionalIngredientsReducerState, initialAdditionalIngredientsState} from './additionalIngredientsReducer';
 
 export const rootReducer = combineReducers({
     applicationReducer: applicationReducer,
@@ -12,9 +13,10 @@ export const rootReducer = combineReducers({
     productionReducer: productionReducer,
     hopsReducer: hopsReducer,
     maltsReducer: maltsReducer,
-    yeastReducer: yeastReducer
+    yeastReducer: yeastReducer,
+    additionalIngredientsReducer: additionalIngredientsReducer
 
 });
 
-export type { ApplicationReducerState, BeerDataReducerState, ProductionReducerState, HopsReducerState, MaltsReducerState, YeastReducerState };
-export { initialApplicationState, initialBeerState, initialProductionState ,initialHopsState, initialMaltsState, initialYeastState};
+export type { ApplicationReducerState, BeerDataReducerState, ProductionReducerState, HopsReducerState, MaltsReducerState, YeastReducerState, AdditionalIngredientsReducerState };
+export { initialApplicationState, initialBeerState, initialProductionState ,initialHopsState, initialMaltsState, initialYeastState, initialAdditionalIngredientsState};

--- a/src/repositorys/AdditionalIngredientRepository.ts
+++ b/src/repositorys/AdditionalIngredientRepository.ts
@@ -1,0 +1,12 @@
+import {BaseRepository} from "./BaseRepository";
+import {AdditionalIngredient, AdditionalIngredientCreatePayload} from "../model/AdditionalIngredient";
+
+export class AdditionalIngredientRepository extends BaseRepository {
+    static getAdditionalIngredients(): Promise<AdditionalIngredient[]> {
+        return this.get<AdditionalIngredient[]>("additionalingredients");
+    }
+
+    static submitAdditionalIngredient(aIngredient: AdditionalIngredientCreatePayload): Promise<void> {
+        return this.post("additionalingredient", aIngredient);
+    }
+}

--- a/src/store.ts
+++ b/src/store.ts
@@ -7,10 +7,11 @@ import { productionEpics } from './epics/productionEpics';
 import { hopsEpic} from "./epics/hopsEpic";
 import { maltsEpic} from "./epics/maltsEpic";
 import {yeastEpic} from "./epics/yeastEpic";
+import {additionalIngredientsEpic} from "./epics/additionalIngredientsEpic";
 
 const epicMiddleware = createEpicMiddleware();
 
-const rootEpic = combineEpics(...beerEpics, ...productionEpics, ...hopsEpic, ...maltsEpic, ...yeastEpic);
+const rootEpic = combineEpics(...beerEpics, ...productionEpics, ...hopsEpic, ...maltsEpic, ...yeastEpic, ...additionalIngredientsEpic);
 
 // Erstellen Sie den Store mit der Middleware
 const store = configureStore({


### PR DESCRIPTION
### Motivation

- Introduce first-class support for additional (adjunct) ingredients so recipes can include arbitrary extra ingredients with phase, quantity, time and description metadata.
- Persist and manage additional ingredients in the DB and allow CRUD-like creation and selection from the UI and recipe editor.
- Keep import/export and backward compatibility by normalizing missing fields and preserving additional ingredient arrays in `BeerDTO`.

### Description

- Added a new model and payload types in `src/model/AdditionalIngredient.ts` and expanded `Beer`/`BeerDTO` types with `BeerAdditionalIngredient`/`AdditionalIngredientDTO` plus enums `AdditionalIngredientPhase` and `AdditionalIngredientTimeUnit` in `src/model/Beer.ts` and `src/model/BeerDTO.ts`.
- Implemented Redux actions (`src/actions/additionalIngredients.actions.ts`), reducer (`src/reducers/additionalIngredientsReducer.ts`) and wired the reducer into `rootReducer.ts`.
- Added epics for fetching and submitting additional ingredients (`src/epics/additionalIngredientsEpic.ts`) and registered them in the root epic in `src/store.ts`.
- Implemented `AdditionalIngredientRepository` methods for API interaction in `src/repositorys/AdditionalIngredientRepository.ts`.
- Integrated UI: added CRUD-ish UI to the database ingredient page (`IngredientsFormPage.tsx`) to list and create additional ingredients and wired dispatchers; extended the beer editor (`BeerForm.tsx`) to allow selecting/adding additional ingredients, normalization, validation, state handling, and including them in submitted `BeerDTO` objects.

### Testing

- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a032afd7258832fa698a0404ae9f5be)