### PR TITLE
Add delete support for malts, hops, yeasts and additional ingredients

### DIFF
--- a/src/actions/additionalIngredients.actions.ts
+++ b/src/actions/additionalIngredients.actions.ts
@@ -5,7 +5,8 @@ export namespace AdditionalIngredientsActions {
         GET_ADDITIONAL_INGREDIENTS = 'AdditionalIngredientsActions.GET_ADDITIONAL_INGREDIENTS',
         GET_ADDITIONAL_INGREDIENTS_SUCCESS = 'AdditionalIngredientsActions.GET_ADDITIONAL_INGREDIENTS_SUCCESS',
         SUBMIT_NEW_ADDITIONAL_INGREDIENT = 'AdditionalIngredientsActions.SUBMIT_NEW_ADDITIONAL_INGREDIENT',
-        SUBMIT_NEW_ADDITIONAL_INGREDIENT_SUCCESS = 'AdditionalIngredientsActions.SUBMIT_NEW_ADDITIONAL_INGREDIENT_SUCCESS'
+        SUBMIT_NEW_ADDITIONAL_INGREDIENT_SUCCESS = 'AdditionalIngredientsActions.SUBMIT_NEW_ADDITIONAL_INGREDIENT_SUCCESS',
+        DELETE_ADDITIONAL_INGREDIENT_BY_ID = 'AdditionalIngredientsActions.DELETE_ADDITIONAL_INGREDIENT_BY_ID'
     }
 
     export interface GetAdditionalIngredients {
@@ -33,11 +34,19 @@ export namespace AdditionalIngredientsActions {
         readonly type: ActionTypes.SUBMIT_NEW_ADDITIONAL_INGREDIENT_SUCCESS
     }
 
+    export interface DeleteAdditionalIngredientById {
+        readonly type: ActionTypes.DELETE_ADDITIONAL_INGREDIENT_BY_ID
+        payload: {
+            ingredientId: string
+        }
+    }
+
     export type AllAdditionalIngredientsActions =
         GetAdditionalIngredients |
         GetAdditionalIngredientsSuccess |
         SubmitNewAdditionalIngredient |
-        SubmitNewAdditionalIngredientSuccess
+        SubmitNewAdditionalIngredientSuccess |
+        DeleteAdditionalIngredientById
 
     export function getAdditionalIngredients(aIsFetching: boolean): GetAdditionalIngredients {
         return {
@@ -63,6 +72,13 @@ export namespace AdditionalIngredientsActions {
     export function submitNewAdditionalIngredientSuccess(): SubmitNewAdditionalIngredientSuccess {
         return {
             type: ActionTypes.SUBMIT_NEW_ADDITIONAL_INGREDIENT_SUCCESS
+        }
+    }
+
+    export function deleteAdditionalIngredientById(aId: string): DeleteAdditionalIngredientById {
+        return {
+            type: ActionTypes.DELETE_ADDITIONAL_INGREDIENT_BY_ID,
+            payload: {ingredientId: aId}
         }
     }
 }

--- a/src/actions/yeast.actions.ts
+++ b/src/actions/yeast.actions.ts
@@ -85,4 +85,11 @@ export namespace YeastActions{
             payload: {unknownYeasts}
         }
     }
+
+    export function deleteYeastById(aYeastId: string): DeleteYeastById {
+        return {
+            type: ActionTypes.DELETE_YEAST_BY_ID,
+            payload: {yeastId: aYeastId}
+        }
+    }
 }

--- a/src/containers/DatabaseOverview/IngredientsFormPage.tsx
+++ b/src/containers/DatabaseOverview/IngredientsFormPage.tsx
@@ -149,6 +149,22 @@ class IngredientsFormPage extends React.Component<any, any> {
         });
     };
 
+    handleDeleteMalt = (aMalt: Malts) => {
+        this.props.deleteMaltById(String(aMalt.id));
+    };
+
+    handleDeleteHop = (aHop: Hops) => {
+        this.props.deleteHopById(String(aHop.id));
+    };
+
+    handleDeleteYeast = (aYeast: Yeasts) => {
+        this.props.deleteYeastById(String(aYeast.id));
+    };
+
+    handleDeleteAdditionalIngredient = (aIngredient: AdditionalIngredient) => {
+        this.props.deleteAdditionalIngredientById(String(aIngredient.id));
+    };
+
     renderMaltContent = () => {
         const { malts } = this.props;
         const { newMalt, showNewMaltRow } = this.state;
@@ -187,7 +203,7 @@ class IngredientsFormPage extends React.Component<any, any> {
                                     <TableCell>{m.name}</TableCell>
                                     <TableCell>{m.description}</TableCell>
                                     <TableCell>{m.ebc}</TableCell>
-                                    <TableCell className="action-cell"><div className="action-buttons"><button className="cancel-btn">🗑️</button></div></TableCell>
+                                    <TableCell className="action-cell"><div className="action-buttons"><button className="cancel-btn" onClick={() => this.handleDeleteMalt(m)}>🗑️</button></div></TableCell>
                                 </TableRow>
                             ))}
                         </TableBody>
@@ -238,7 +254,7 @@ class IngredientsFormPage extends React.Component<any, any> {
                                     <TableCell>{h.alpha}</TableCell>
                                     <TableCell>{h.type}</TableCell>
                                     <TableCell>{h.description}</TableCell>
-                                    <TableCell className="action-cell"><div className="action-buttons"><button className="cancel-btn">🗑️</button></div></TableCell>
+                                    <TableCell className="action-cell"><div className="action-buttons"><button className="cancel-btn" onClick={() => this.handleDeleteHop(h)}>🗑️</button></div></TableCell>
                                 </TableRow>
                             ))}
                         </TableBody>
@@ -289,7 +305,7 @@ class IngredientsFormPage extends React.Component<any, any> {
                                     <TableCell>{y.type}</TableCell>
                                     <TableCell>{y.temperature}</TableCell>
                                     <TableCell>{y.evg}</TableCell>
-                                    <TableCell className="action-cell"><div className="action-buttons"><button className="cancel-btn">🗑️</button></div></TableCell>
+                                    <TableCell className="action-cell"><div className="action-buttons"><button className="cancel-btn" onClick={() => this.handleDeleteYeast(y)}>🗑️</button></div></TableCell>
                                 </TableRow>
                             ))}
                         </TableBody>
@@ -338,7 +354,7 @@ class IngredientsFormPage extends React.Component<any, any> {
                                 <TableRow key={aIngredient.id}>
                                     <TableCell>{aIngredient.name}</TableCell>
                                     <TableCell>{aIngredient.description}</TableCell>
-                                    <TableCell className="action-cell"><div className="action-buttons"><button className="cancel-btn">🗑️</button></div></TableCell>
+                                    <TableCell className="action-cell"><div className="action-buttons"><button className="cancel-btn" onClick={() => this.handleDeleteAdditionalIngredient(aIngredient)}>🗑️</button></div></TableCell>
                                 </TableRow>
                             ))}
                         </TableBody>
@@ -382,8 +398,12 @@ const mapDispatchToProps = (dispatch: any) => ({
     submitNewMalt: (malt: Malts) => dispatch(MaltsActions.submitNewMalt(malt)),
     submitNewHop: (hop: Hops) => dispatch(HopsActions.submitNewHop(hop)),
     submitNewYeast: (yeast: Yeasts) => dispatch(YeastActions.submitNewYeast(yeast)),
+    deleteMaltById: (aId: string) => dispatch(MaltsActions.deleteMaltsById(aId)),
+    deleteHopById: (aId: string) => dispatch(HopsActions.deleteHopById(aId)),
+    deleteYeastById: (aId: string) => dispatch(YeastActions.deleteYeastById(aId)),
     getAdditionalIngredients: (isFetching: boolean) => dispatch(AdditionalIngredientsActions.getAdditionalIngredients(isFetching)),
-    submitNewAdditionalIngredient: (aIngredient: { name: string; description?: string }) => dispatch(AdditionalIngredientsActions.submitNewAdditionalIngredient(aIngredient))
+    submitNewAdditionalIngredient: (aIngredient: { name: string; description?: string }) => dispatch(AdditionalIngredientsActions.submitNewAdditionalIngredient(aIngredient)),
+    deleteAdditionalIngredientById: (aId: string) => dispatch(AdditionalIngredientsActions.deleteAdditionalIngredientById(aId))
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(IngredientsFormPage);

--- a/src/epics/additionalIngredientsEpic.ts
+++ b/src/epics/additionalIngredientsEpic.ts
@@ -50,7 +50,29 @@ export const submitNewAdditionalIngredientEpic = (action$: any) =>
         )
     );
 
+export const deleteAdditionalIngredientByIdEpic = (action$: any) =>
+    action$.pipe(
+        ofType(AdditionalIngredientsActions.ActionTypes.DELETE_ADDITIONAL_INGREDIENT_BY_ID),
+        mergeMap((aAction: any) =>
+            from(AdditionalIngredientRepository.deleteAdditionalIngredientById(aAction.payload.ingredientId)).pipe(
+                mergeMap(() => from([
+                    AdditionalIngredientsActions.getAdditionalIngredients(true)
+                ])),
+                catchError((aError: Error) =>
+                    from([
+                        ApplicationActions.openErrorDialog(
+                            true,
+                            "Weitere Zutaten Fehler",
+                            "Delete AdditionalIngredient: " + aError.message
+                        )
+                    ])
+                )
+            )
+        )
+    );
+
 export const additionalIngredientsEpic = [
     getAdditionalIngredientsEpic,
-    submitNewAdditionalIngredientEpic
+    submitNewAdditionalIngredientEpic,
+    deleteAdditionalIngredientByIdEpic
 ]

--- a/src/epics/hopsEpic.ts
+++ b/src/epics/hopsEpic.ts
@@ -49,7 +49,31 @@ export const submitNewHopEpic = (action$: any) =>
         )
     );
 
+export const deleteHopByIdEpic = (action$: any) =>
+    action$.pipe(
+        ofType(HopsActions.ActionTypes.DELETE_HOPS_BY_ID),
+        mergeMap((aAction: any) =>
+            from(HopRepository.deleteHopById(aAction.payload.hopsId)).pipe(
+                mergeMap(() =>
+                    from([
+                        HopsActions.getHops(true)
+                    ])
+                ),
+                catchError((aError: Error) =>
+                    from([
+                        ApplicationActions.openErrorDialog(
+                            true,
+                            "Hopfen fehler",
+                            "Delete Hopfen: " + aError.message
+                        )
+                    ])
+                )
+            )
+        )
+    );
+
 export const hopsEpic = [
     getHopsEpic,
-    submitNewHopEpic
+    submitNewHopEpic,
+    deleteHopByIdEpic
 ]

--- a/src/epics/maltsEpic.ts
+++ b/src/epics/maltsEpic.ts
@@ -48,7 +48,31 @@ export const submitNewMaltEpic = (action$: any) =>
         )
     );
 
+export const deleteMaltByIdEpic = (action$: any) =>
+    action$.pipe(
+        ofType(MaltsActions.ActionTypes.DELETE_MALTS_BY_ID),
+        mergeMap((aAction: any) =>
+            from(MaltRepository.deleteMaltById(aAction.payload.maltsId)).pipe(
+                mergeMap(() =>
+                    from([
+                        MaltsActions.getMalts(true)
+                    ])
+                ),
+                catchError((aError: Error) =>
+                    from([
+                        ApplicationActions.openErrorDialog(
+                            true,
+                            "Malz fehler",
+                            "Delete Malz: " + aError.message
+                        )
+                    ])
+                )
+            )
+        )
+    );
+
 export const maltsEpic = [
     getMaltsEpic,
-    submitNewMaltEpic
+    submitNewMaltEpic,
+    deleteMaltByIdEpic
 ]

--- a/src/epics/yeastEpic.ts
+++ b/src/epics/yeastEpic.ts
@@ -49,7 +49,31 @@ export const submitNewYeastEpic = (action$: any) =>
         )
     );
 
+export const deleteYeastByIdEpic = (action$: any) =>
+    action$.pipe(
+        ofType(YeastActions.ActionTypes.DELETE_YEAST_BY_ID),
+        mergeMap((aAction: any) =>
+            from(YeastRepository.deleteYeastById(aAction.payload.yeastId)).pipe(
+                mergeMap(() =>
+                    from([
+                        YeastActions.getYeasts(true)
+                    ])
+                ),
+                catchError((aError: Error) =>
+                    from([
+                        ApplicationActions.openErrorDialog(
+                            true,
+                            "Hefe fehler",
+                            "Delete Hefe: " + aError.message
+                        )
+                    ])
+                )
+            )
+        )
+    );
+
 export const yeastEpic =[
     getYeastsEpic,
-    submitNewYeastEpic
+    submitNewYeastEpic,
+    deleteYeastByIdEpic
 ]

--- a/src/repositorys/AdditionalIngredientRepository.ts
+++ b/src/repositorys/AdditionalIngredientRepository.ts
@@ -9,4 +9,8 @@ export class AdditionalIngredientRepository extends BaseRepository {
     static submitAdditionalIngredient(aIngredient: AdditionalIngredientCreatePayload): Promise<void> {
         return this.post("additionalingredient", aIngredient);
     }
+
+    static deleteAdditionalIngredientById(aId: string): Promise<void> {
+        return this.delete(`additionalingredient/${aId}`);
+    }
 }

--- a/src/repositorys/HopRepository.ts
+++ b/src/repositorys/HopRepository.ts
@@ -11,4 +11,8 @@ export class HopRepository extends BaseRepository {
     static submitHop(aHop: Hops): Promise<void> {
         return this.post("hop", aHop);
     }
+
+    static deleteHopById(aId: string): Promise<void> {
+        return this.delete(`hop/${aId}`);
+    }
 }

--- a/src/repositorys/MaltRepository.ts
+++ b/src/repositorys/MaltRepository.ts
@@ -10,4 +10,8 @@ export class MaltRepository extends BaseRepository {
     static submitMalt(aMalt: Malts): Promise<void> {
         return this.post("malt", aMalt);
     }
+
+    static deleteMaltById(aId: string): Promise<void> {
+        return this.delete(`malt/${aId}`);
+    }
 }

--- a/src/repositorys/YeastRepository.ts
+++ b/src/repositorys/YeastRepository.ts
@@ -11,4 +11,8 @@ export class YeastRepository extends BaseRepository {
     static submitYeast(aYeast: Yeasts): Promise<void> {
         return this.post("yeast", aYeast);
     }
+
+    static deleteYeastById(aId: string): Promise<void> {
+        return this.delete(`yeast/${aId}`);
+    }
 }


### PR DESCRIPTION
### Motivation
- Provide UI and Redux support to remove individual ingredients (malts, hops, yeasts, additional ingredients) from the database and refresh lists afterwards.
- Surface server-side delete errors via the existing application error dialog so failures are visible to users.

### Description
- Added delete action type and `deleteAdditionalIngredientById` action creator in `additionalIngredients.actions.ts` and a `deleteYeastById` action creator in `yeast.actions.ts` to represent deletion requests.
- Implemented delete handler functions in `IngredientsFormPage.tsx` and wired delete buttons for malts, hops, yeasts and additional ingredients to call the corresponding action creators via `mapDispatchToProps`.
- Added `delete...ById` methods to repositories: `AdditionalIngredientRepository.deleteAdditionalIngredientById`, `HopRepository.deleteHopById`, `MaltRepository.deleteMaltById`, and `YeastRepository.deleteYeastById` which call the API `DELETE` endpoints.
- Implemented epics `deleteAdditionalIngredientByIdEpic`, `deleteHopByIdEpic`, `deleteMaltByIdEpic`, and `deleteYeastByIdEpic` which perform the repository delete calls, dispatch a list-refresh action on success (e.g. `getMalts(true)`), and open an error dialog on failure.

### Testing
- Ran TypeScript compilation with `yarn build` which completed successfully.
- Executed the test suite with `yarn test` (unit tests) and all tests passed.
- Ran linters with `yarn lint` with no new lint errors introduced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a035a6eb908832f9b7bb6a662aad0a1)