### PR TITLE
Treat 'Einmaischen' as fixed step in production mapping and add tests

### DIFF
--- a/src/utils/productionRecipe.test.ts
+++ b/src/utils/productionRecipe.test.ts
@@ -61,6 +61,42 @@ describe('productionRecipe mapping', () => {
     expect(result.error).toContain('Zeitgesteuerte Rast');
   });
 
+  it('allows Einmaischen with time=0 as fixed process step', () => {
+    const result = mapBeerToBrewingData(makeBeer({ fermentation: [
+      { type: 'Einmaischen', temperature: 52, time: 0 },
+      { type: 'Rast 1', temperature: 64, time: 40, executionMode: RestExecutionMode.TIMED },
+      { type: 'Abmaischen', temperature: 78, time: 10 }
+    ] }));
+
+    expect(result.ok).toBe(true);
+    const mashIn = result.brewingData?.Rasten.find((s) => s.type === 'Einmaischen');
+    expect(mashIn).toEqual(expect.objectContaining({ executionMode: RestExecutionMode.TIMED, time: 0 }));
+  });
+
+  it('allows Einmaischen with missing time as fixed process step', () => {
+    const result = mapBeerToBrewingData(makeBeer({ fermentation: [
+      { type: 'Einmaischen', temperature: 52 },
+      { type: 'Rast 1', temperature: 64, time: 40, executionMode: RestExecutionMode.TIMED },
+      { type: 'Abmaischen', temperature: 78, time: 10 }
+    ] }));
+
+    expect(result.ok).toBe(true);
+    const mashIn = result.brewingData?.Rasten.find((s) => s.type === 'Einmaischen');
+    expect(mashIn).toEqual(expect.objectContaining({ executionMode: RestExecutionMode.TIMED }));
+    expect(mashIn?.time).toBeUndefined();
+  });
+
+  it('still fails when Einmaischen temperature is invalid', () => {
+    const result = mapBeerToBrewingData(makeBeer({ fermentation: [
+      { type: 'Einmaischen', temperature: 0 },
+      { type: 'Rast 1', temperature: 64, time: 40, executionMode: RestExecutionMode.TIMED },
+      { type: 'Abmaischen', temperature: 78, time: 10 }
+    ] }));
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain('Einmaischen/Abmaischen Temperatur fehlt oder ist ungültig');
+  });
+
 
   it('keeps imported CONFIRMATION_HOLD without time through production mapping', () => {
     const result = mapBeerToBrewingData(makeBeer({ fermentation: [
@@ -84,5 +120,16 @@ describe('productionRecipe mapping', () => {
 
     expect(result.ok).toBe(false);
     expect(result.error).toContain('Zeitgesteuerte Rast');
+  });
+
+  it('keeps Abmaischen legacy behavior unchanged (time is still required in TIMED flow)', () => {
+    const result = mapBeerToBrewingData(makeBeer({ fermentation: [
+      { type: 'Einmaischen', temperature: 52 },
+      { type: 'Rast 1', temperature: 64, time: 40, executionMode: RestExecutionMode.TIMED },
+      { type: 'Abmaischen', temperature: 78, time: 0 }
+    ] }));
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain('Zeitgesteuerte Rast "Abmaischen" benötigt Zeit > 0.');
   });
 });

--- a/src/utils/productionRecipe.ts
+++ b/src/utils/productionRecipe.ts
@@ -29,6 +29,15 @@ export function normalizeFermentationStepsForProduction(steps: FermentationSteps
       continue;
     }
 
+    // Einmaischen ist ein fester Prozessschritt und keine normale zeitgesteuerte Rast.
+    if (step.type === 'Einmaischen') {
+      normalized.push({
+        ...step,
+        executionMode
+      });
+      continue;
+    }
+
     if (!isValidTimedDuration(step.time)) {
       return { ok: false, error: `Zeitgesteuerte Rast "${step.type}" benötigt Zeit > 0.` };
     }


### PR DESCRIPTION
### Motivation

- Treat the special fermentation step `Einmaischen` as a fixed process step during production mapping so it is not rejected when `time` is `0` or missing, while preserving existing validation for other timed rests.

### Description

- Special-case `Einmaischen` in `normalizeFermentationStepsForProduction` so it is preserved with its `executionMode` and does not require a positive `time` value.
- Retain the `CONFIRMATION_HOLD` handling that strips `time` and the existing timed-duration validation that requires `time > 0` for normal rests.
- Add unit tests in `src/utils/productionRecipe.test.ts` to cover allowing `Einmaischen` with `time = 0` and missing `time`, ensuring invalid `Einmaischen` temperature still fails, and asserting legacy behavior for `Abmaischen` remains unchanged.

### Testing

- Ran the updated unit tests for `src/utils/productionRecipe.test.ts` with the test suite, and the new and existing tests completed successfully.
- The changes are covered by the added tests which verify both acceptance and failure cases for `Einmaischen` handling.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0375e52138832f9b4c1d6fbdadcbe4)