### PR TITLE
Replace alerts/confirms with configurable ModalDialog and wire up validation/confirm/error dialogs

### DIFF
--- a/src/components/ModalDialog/ModalDialog.tsx
+++ b/src/components/ModalDialog/ModalDialog.tsx
@@ -11,10 +11,14 @@ export enum DialogType {
 
 interface ModalDialogProps {
     onConfirm: (content: string) => void;
+    onCancel?: () => void;
     type: DialogType;
     open: boolean;
     content: string;
     header: string;
+    confirmLabel?: string;
+    cancelLabel?: string;
+    showCancelButton?: boolean;
 };
 
 interface ModalDialogState {
@@ -42,11 +46,18 @@ class ModalDialog extends React.Component<ModalDialogProps, ModalDialogState> {
 
         onConfirm(content);
     };
+
+    handleCancel = () => {
+        const {onCancel} = this.props;
+        if (onCancel) {
+            onCancel();
+        }
+    };
     render() {
-        const {content, header, open, type} = this.props;
+        const {content, header, open, type, confirmLabel, cancelLabel, showCancelButton} = this.props;
 
         return (
-            <Dialog open={open} maxWidth={'md'} onClose={this.handleClose}>
+            <Dialog open={open} maxWidth={'md'} onClose={showCancelButton ? this.handleCancel : this.handleClose}>
                 <DialogTitle className={type}>
                     {header}
                 </DialogTitle>
@@ -54,8 +65,13 @@ class ModalDialog extends React.Component<ModalDialogProps, ModalDialogState> {
                     <p>{this.contentWithLineBreaks(content)}</p>
                 </DialogContent>
                 <DialogActions>
+                    {showCancelButton && (
+                        <Button onClick={this.handleCancel} color="primary">
+                            {cancelLabel ?? "Abbrechen"}
+                        </Button>
+                    )}
                     <Button onClick={this.handleClose} color="primary">
-                        Ok
+                        {confirmLabel ?? "Ok"}
                     </Button>
                 </DialogActions>
 

--- a/src/containers/DatabaseOverview/BeerForm.tsx
+++ b/src/containers/DatabaseOverview/BeerForm.tsx
@@ -21,6 +21,7 @@ import {YeastActions} from "../../actions/yeast.actions";
 import {AdditionalIngredientsActions} from "../../actions/additionalIngredients.actions";
 import {AdditionalIngredient} from "../../model/AdditionalIngredient";
 import { COLOR_WHITE, COLOR_BREW_BG, COLOR_ACCENT, BORDER_TRANSPARENT, COLOR_DARK_BG, COLOR_BORDER_INPUT_ALT } from '../../colors';
+import ModalDialog, {DialogType} from "../../components/ModalDialog/ModalDialog";
 
 interface BeerFormProps {
     onSubmitBeer: (beer: BeerDTO) => void;
@@ -65,6 +66,8 @@ interface BeerFormState {
     missingMalts?: string[];
     missingHops?: string[];
     missingYeasts?: string[];
+    showValidationDialog: boolean;
+    validationDialogMessage: string;
 }
 
 class BeerForm extends React.Component<BeerFormProps, BeerFormState> {
@@ -99,6 +102,8 @@ class BeerForm extends React.Component<BeerFormProps, BeerFormState> {
             yeastsDTO: [{ id: '', name: '', quantity: 0 }],
             additionalIngredientsDTO: [],
             isSubmitSuccessful: false,
+            showValidationDialog: false,
+            validationDialogMessage: '',
         };
 
         // Wenn ein gespeicherter Formularstatus existiert, verwenden wir diesen, ansonsten den Standardstatus
@@ -342,7 +347,7 @@ class BeerForm extends React.Component<BeerFormProps, BeerFormState> {
             additionalIngredientsDTO,
         } = this.state;
         if (!this.validateFermentationSteps(fermentationSteps)) {
-            alert('Bitte prüfe den Maischeplan: Zeitgesteuerte Rasten benötigen Zeit > 0, Halte-Rasten nur Temperatur.');
+            this.openValidationDialog('Bitte prüfe den Maischeplan: Zeitgesteuerte Rasten benötigen Zeit > 0, Halte-Rasten nur Temperatur.');
             return;
         }
 
@@ -357,7 +362,7 @@ class BeerForm extends React.Component<BeerFormProps, BeerFormState> {
 
         const normalizedHops = hopsDTO.map((aHop) => normalizeHopDto(aHop));
         if (!normalizedHops.every((aHop) => validateHopDto(aHop))) {
-            alert('Bitte prüfe die Hopfengaben: Menge und Zeit müssen > 0 sein. Kochhopfen nutzt Minuten, Hopfen stopfen Stunden oder Tage.');
+            this.openValidationDialog('Bitte prüfe die Hopfengaben: Menge und Zeit müssen > 0 sein. Kochhopfen nutzt Minuten, Hopfen stopfen Stunden oder Tage.');
             return;
         }
 
@@ -388,7 +393,7 @@ class BeerForm extends React.Component<BeerFormProps, BeerFormState> {
             .filter((y): y is YeastDTO => y !== undefined);
 
         if (!this.validateAdditionalIngredients(additionalIngredientsDTO)) {
-            alert('Bitte prüfe weitere Zutaten: Zutat (ID/Name), Menge > 0, Einheit und gültige Phase sind erforderlich. Zeit darf nur > 0 gesetzt werden.');
+            this.openValidationDialog('Bitte prüfe weitere Zutaten: Zutat (ID/Name), Menge > 0, Einheit und gültige Phase sind erforderlich. Zeit darf nur > 0 gesetzt werden.');
             return;
         }
 
@@ -416,6 +421,14 @@ class BeerForm extends React.Component<BeerFormProps, BeerFormState> {
 
         console.log(beer);
         this.props.onSubmitBeer(beer);
+    };
+
+    openValidationDialog = (message: string) => {
+        this.setState({showValidationDialog: true, validationDialogMessage: message});
+    };
+
+    closeValidationDialog = () => {
+        this.setState({showValidationDialog: false, validationDialogMessage: ''});
     };
 
     resetForm = () => {
@@ -1086,8 +1099,16 @@ class BeerForm extends React.Component<BeerFormProps, BeerFormState> {
     };
 
     render() {
+        const {showValidationDialog, validationDialogMessage} = this.state;
         return (
             <div className='containerBeerForm'>
+                <ModalDialog
+                    type={DialogType.ERROR}
+                    open={showValidationDialog}
+                    content={validationDialogMessage}
+                    header={"Validierungsfehler"}
+                    onConfirm={this.closeValidationDialog}
+                />
                 <div style={{ height: '870px', display: 'flex', flexDirection: 'column' }}>
                     <div style={{ border: `1px solid ${BORDER_TRANSPARENT}`, borderRadius: '10px', overflow: 'hidden', height: '100%', display: 'flex', flexDirection: 'column' }}>
                         <div style={{ backgroundColor: COLOR_ACCENT, padding: '12px 16px', borderRadius: '10px 10px 0 0', display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>

--- a/src/containers/MainView/BeerRecipes/Table.tsx
+++ b/src/containers/MainView/BeerRecipes/Table.tsx
@@ -6,6 +6,7 @@ import {connect} from "react-redux";
 import {BeerActions} from "../../../actions/actions";
 import {WaterHeatingTimeCalculator, cookingTimeOptions} from "../../../utils/WaterHeatingTimeCalculator";
 import {MashingType} from "../../../enums/eMashingType";
+import ModalDialog, {DialogType} from "../../../components/ModalDialog/ModalDialog";
 import setSelectedBeer = BeerActions.setSelectedBeer;
 
 export interface BeerTableProps {
@@ -23,6 +24,7 @@ export interface BeerTableProps {
 interface BeerTableState {
     sortConfig: SortConfig;
     selectedBeerId: string | null;
+    beerPendingDelete?: Beer;
 }
 
 
@@ -36,7 +38,7 @@ export class BeerTableComponent extends React.Component<BeerTableProps, BeerTabl
         super(props);
 
         this.state = {
-            sortConfig: {key: 'name', direction: 'asc'}, selectedBeerId: null
+            sortConfig: {key: 'name', direction: 'asc'}, selectedBeerId: null, beerPendingDelete: undefined
         };
     }
 
@@ -96,19 +98,26 @@ export class BeerTableComponent extends React.Component<BeerTableProps, BeerTabl
     };
 
     handleDeleteBeer = (aBeer: Beer) => {
-        const aBeerNamePart = aBeer.name ? ` „${aBeer.name}“` : '';
-        const aShouldDelete = window.confirm(`Möchtest du das Rezept${aBeerNamePart} wirklich löschen?`);
+        this.setState({beerPendingDelete: aBeer});
+    }
 
-        if (!aShouldDelete) {
-            return;
-        }
+    confirmDeleteBeer = () => {
+        const {beerPendingDelete} = this.state;
+        if (!beerPendingDelete) return;
 
-        this.props.deleteBeer(aBeer.id);
+        this.props.deleteBeer(beerPendingDelete.id);
+        this.setState({beerPendingDelete: undefined});
+    }
+
+    cancelDeleteBeer = () => {
+        this.setState({beerPendingDelete: undefined});
     }
 
     render() {
         const {beers, beerToBrew, isPollingRunning} = this.props;
-        const {sortConfig, selectedBeerId} = this.state;
+        const {sortConfig, selectedBeerId, beerPendingDelete} = this.state;
+        const aBeerNamePart = beerPendingDelete?.name ? ` „${beerPendingDelete.name}“` : '';
+        const aDeleteMessage = `Möchtest du das Rezept${aBeerNamePart} wirklich löschen?`;
         if (beers.length > 0) {
             const sortedData = [...beers].sort((a, b) => {
                 const {key, direction} = sortConfig;
@@ -125,6 +134,17 @@ export class BeerTableComponent extends React.Component<BeerTableProps, BeerTabl
 
             return (
                 <>
+                    <ModalDialog
+                        type={DialogType.CONFIRM}
+                        open={!!beerPendingDelete}
+                        header={"Löschen bestätigen"}
+                        content={aDeleteMessage}
+                        onConfirm={this.confirmDeleteBeer}
+                        onCancel={this.cancelDeleteBeer}
+                        confirmLabel={"Löschen"}
+                        cancelLabel={"Abbrechen"}
+                        showCancelButton={true}
+                    />
                     <TableContainer component={Paper} className="Table">
                         <Table className="Table">
                             <TableHead className="table-header">

--- a/src/containers/Production/Production.tsx
+++ b/src/containers/Production/Production.tsx
@@ -76,6 +76,7 @@ interface ProductionState {
     hopName: string
     showHopsDialog: boolean
     showErrorDialog: boolean
+    errorDialogContent: string
     showFinishDialog: boolean
     brewingFinished: boolean
     indexOfCurrentStep: number;
@@ -114,6 +115,7 @@ class Production extends React.Component<ProductionProps, ProductionState> {
             hopName: '',
             showHopsDialog: false,
             showErrorDialog: false,
+            errorDialogContent: '',
             showFinishDialog: false,
             brewingFinished: false,
             indexOfCurrentStep: 0,
@@ -303,7 +305,10 @@ class Production extends React.Component<ProductionProps, ProductionState> {
         const {selectedBeer, sendBrewingData} = this.props;
         const result = mapBeerToBrewingData(selectedBeer);
         if (!result.ok || !result.brewingData) {
-            alert(result.error ?? 'Rezeptdaten sind für den Start ungültig.');
+            this.setState({
+                showErrorDialog: true,
+                errorDialogContent: result.error ?? 'Rezeptdaten sind für den Start ungültig.'
+            });
             return;
         }
         this.setState({brewingIsRunning: true});
@@ -554,8 +559,8 @@ class Production extends React.Component<ProductionProps, ProductionState> {
         this.setState({showHopsDialog: false});
     }
 
-    confirmErrorDialog() {
-
+    confirmErrorDialog = () => {
+        this.setState({showErrorDialog: false, errorDialogContent: ''});
     }
 
 
@@ -593,9 +598,9 @@ class Production extends React.Component<ProductionProps, ProductionState> {
     }
 
     renderErrorDialog() {
-        const {showErrorDialog} = this.state
+        const {showErrorDialog, errorDialogContent} = this.state
         const {isBackenAvailable} = this.props
-        const contentText = 'Die Brau-Steuerung ist nicht erreichbar\n\n' + isBackenAvailable.statusText
+        const contentText = errorDialogContent || ('Die Brau-Steuerung ist nicht erreichbar\n\n' + isBackenAvailable.statusText)
         return (<div>
             <ModalDialog onConfirm={this.confirmErrorDialog} type={DialogType.ERROR} open={showErrorDialog}
                          content={contentText} header={"Fehler!"}></ModalDialog>


### PR DESCRIPTION
### Motivation
- Replace ad-hoc `alert`/`confirm` browser dialogs with a reusable, configurable `ModalDialog` component to provide consistent UX and localized labels.
- Surface validation and runtime errors in the UI via modals instead of blocking browser dialogs.
- Add a confirm/cancel modal for destructive actions to avoid accidental deletes.

### Description
- Extended `ModalDialog` to accept optional `onCancel`, `confirmLabel`, `cancelLabel`, and `showCancelButton` props and added `handleCancel` behavior and line-break-safe content rendering.
- Updated `BeerForm` to show an error `ModalDialog` for validation errors by adding `showValidationDialog` and `validationDialogMessage` state plus `openValidationDialog`/`closeValidationDialog`, and replaced inline `alert` calls with `openValidationDialog` usages.
- Updated the recipes `Table` to use `ModalDialog` for delete confirmation by adding `beerPendingDelete` state and `confirmDeleteBeer`/`cancelDeleteBeer` handlers and rendering a `DialogType.CONFIRM` modal with custom labels.
- Updated `Production` to set and show an error dialog message via `errorDialogContent` state and `confirmErrorDialog` handler instead of using `alert`, and made `renderErrorDialog` use the dynamic error message.

### Testing
- Project TypeScript compilation was verified with `yarn build` and completed successfully.
- Existing automated unit tests were executed with `yarn test` and completed without failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0377af3cf0832f89dc06244d950194)