### PR TITLE
Exclude Einmaischen/Abmaischen/Kochen from Rasten in production payload

### DIFF
--- a/src/utils/productionRecipe.test.ts
+++ b/src/utils/productionRecipe.test.ts
@@ -17,10 +17,11 @@ const makeBeer = (overrides?: Partial<Beer>): Beer => ({
   cookingTime: 60,
   cookingTemperatur: 100,
   fermentation: [
-    { type: 'Einmaischen', temperature: 52, time: 10 },
+    { type: 'Einmaischen', temperature: 52, time: 0 },
     { type: 'Rast 1', temperature: 64, time: 40, executionMode: RestExecutionMode.TIMED },
-    { type: 'Dickmaische führen', temperature: 66, time: 0, executionMode: RestExecutionMode.CONFIRMATION_HOLD },
-    { type: 'Abmaischen', temperature: 78, time: 10 }
+    { type: 'Dickmaische führen', temperature: 66, executionMode: RestExecutionMode.CONFIRMATION_HOLD },
+    { type: 'Kochen', temperature: 100, time: 60 },
+    { type: 'Abmaischen', temperature: 78, time: 0 }
   ],
   malts: [],
   wortBoiling: { totalTime: 60, hops: [] },
@@ -29,146 +30,96 @@ const makeBeer = (overrides?: Partial<Beer>): Beer => ({
 });
 
 describe('productionRecipe mapping', () => {
-  it('keeps executionMode in /Recipe/ payload and strips time for CONFIRMATION_HOLD', () => {
+  it('filters fixed process steps from Rasten and keeps top-level mash/cooking fields', () => {
     const result = mapBeerToBrewingData(makeBeer());
 
     expect(result.ok).toBe(true);
-    const decoction = result.brewingData?.Rasten.find((s) => s.type === 'Dickmaische führen');
-    expect(decoction).toEqual(expect.objectContaining({ executionMode: RestExecutionMode.CONFIRMATION_HOLD }));
-    expect(decoction).not.toHaveProperty('time');
+    expect(result.brewingData?.MashupTemperature).toBe(52);
+    expect(result.brewingData?.MashdownTemperature).toBe(78);
+    expect(result.brewingData?.CookingTime).toBe(60);
+    expect(result.brewingData?.CookingTemperature).toBe(100);
+
+    const stepTypes = result.brewingData?.Rasten.map((step) => step.type) ?? [];
+    expect(stepTypes).not.toContain('Einmaischen');
+    expect(stepTypes).not.toContain('Abmaischen');
+    expect(stepTypes).not.toContain('Kochen');
+    expect(stepTypes.filter((type) => type === 'Einmaischen')).toHaveLength(0);
+    expect(stepTypes.filter((type) => type === 'Abmaischen')).toHaveLength(0);
+    expect(stepTypes.filter((type) => type === 'Kochen')).toHaveLength(0);
   });
 
-  it('normalizes missing executionMode to TIMED for production payload', () => {
-    const result = mapBeerToBrewingData(makeBeer({ fermentation: [
-      { type: 'Einmaischen', temperature: 52, time: 10 },
-      { type: 'Rast 1', temperature: 64, time: 40 },
-      { type: 'Abmaischen', temperature: 78, time: 10 }
-    ] }));
+  it('keeps real timed rests with executionMode TIMED and requires time > 0', () => {
+    const validResult = mapBeerToBrewingData(makeBeer({
+      fermentation: [
+        { type: 'Einmaischen', temperature: 52, time: 0 },
+        { type: 'Rast 2', temperature: 67, time: 20, executionMode: RestExecutionMode.TIMED },
+        { type: 'Abmaischen', temperature: 78, time: 0 }
+      ]
+    }));
 
-    expect(result.ok).toBe(true);
-    const rest = result.brewingData?.Rasten.find((s) => s.type === 'Rast 1');
-    expect(rest).toEqual(expect.objectContaining({ executionMode: RestExecutionMode.TIMED, time: 40 }));
+    expect(validResult.ok).toBe(true);
+    expect(validResult.brewingData?.Rasten).toEqual([
+      expect.objectContaining({ type: 'Rast 2', executionMode: RestExecutionMode.TIMED, time: 20 })
+    ]);
+
+    const invalidResult = mapBeerToBrewingData(makeBeer({
+      fermentation: [
+        { type: 'Einmaischen', temperature: 52, time: 0 },
+        { type: 'Rast 2', temperature: 67, time: 0, executionMode: RestExecutionMode.TIMED },
+        { type: 'Abmaischen', temperature: 78, time: 0 }
+      ]
+    }));
+
+    expect(invalidResult.ok).toBe(false);
+    expect(invalidResult.error).toContain('Zeitgesteuerte Rast');
   });
 
-  it('blocks TIMED rest with missing/invalid time before sending', () => {
-    const result = mapBeerToBrewingData(makeBeer({ fermentation: [
-      { type: 'Einmaischen', temperature: 52, time: 10 },
-      { type: 'Rast 1', temperature: 64, executionMode: RestExecutionMode.TIMED },
-      { type: 'Abmaischen', temperature: 78, time: 10 }
-    ] }));
-
-    expect(result.ok).toBe(false);
-    expect(result.error).toContain('Zeitgesteuerte Rast');
-  });
-
-  it('allows Einmaischen with time=0 as fixed process step', () => {
+  it('keeps CONFIRMATION_HOLD steps in Rasten without requiring time', () => {
     const result = mapBeerToBrewingData(makeBeer({ fermentation: [
       { type: 'Einmaischen', temperature: 52, time: 0 },
-      { type: 'Rast 1', temperature: 64, time: 40, executionMode: RestExecutionMode.TIMED },
-      { type: 'Abmaischen', temperature: 78, time: 10 }
-    ] }));
-
-    expect(result.ok).toBe(true);
-    const mashIn = result.brewingData?.Rasten.find((s) => s.type === 'Einmaischen');
-    expect(mashIn).toEqual(expect.objectContaining({ executionMode: RestExecutionMode.TIMED, time: 0 }));
-  });
-
-  it('allows Einmaischen with missing time as fixed process step', () => {
-    const result = mapBeerToBrewingData(makeBeer({ fermentation: [
-      { type: 'Einmaischen', temperature: 52 },
-      { type: 'Rast 1', temperature: 64, time: 40, executionMode: RestExecutionMode.TIMED },
-      { type: 'Abmaischen', temperature: 78, time: 10 }
-    ] }));
-
-    expect(result.ok).toBe(true);
-    const mashIn = result.brewingData?.Rasten.find((s) => s.type === 'Einmaischen');
-    expect(mashIn).toEqual(expect.objectContaining({ executionMode: RestExecutionMode.TIMED }));
-    expect(mashIn?.time).toBeUndefined();
-  });
-
-  it('allows Abmaischen with time=0 as fixed process step', () => {
-    const result = mapBeerToBrewingData(makeBeer({ fermentation: [
-      { type: 'Einmaischen', temperature: 52, time: 10 },
-      { type: 'Rast 1', temperature: 64, time: 40, executionMode: RestExecutionMode.TIMED },
-      { type: 'Abmaischen', temperature: 78, time: 0 }
-    ] }));
-
-    expect(result.ok).toBe(true);
-    const mashOut = result.brewingData?.Rasten.find((s) => s.type === 'Abmaischen');
-    expect(mashOut).toEqual(expect.objectContaining({ executionMode: RestExecutionMode.TIMED, time: 0 }));
-  });
-
-  it('allows Abmaischen with missing time as fixed process step', () => {
-    const result = mapBeerToBrewingData(makeBeer({ fermentation: [
-      { type: 'Einmaischen', temperature: 52, time: 10 },
-      { type: 'Rast 1', temperature: 64, time: 40, executionMode: RestExecutionMode.TIMED },
-      { type: 'Abmaischen', temperature: 78 }
-    ] }));
-
-    expect(result.ok).toBe(true);
-    const mashOut = result.brewingData?.Rasten.find((s) => s.type === 'Abmaischen');
-    expect(mashOut).toEqual(expect.objectContaining({ executionMode: RestExecutionMode.TIMED }));
-    expect(mashOut?.time).toBeUndefined();
-  });
-
-  it('still fails when Einmaischen temperature is invalid', () => {
-    const result = mapBeerToBrewingData(makeBeer({ fermentation: [
-      { type: 'Einmaischen', temperature: 0 },
-      { type: 'Rast 1', temperature: 64, time: 40, executionMode: RestExecutionMode.TIMED },
-      { type: 'Abmaischen', temperature: 78, time: 10 }
-    ] }));
-
-    expect(result.ok).toBe(false);
-    expect(result.error).toContain('Einmaischen/Abmaischen Temperatur fehlt oder ist ungültig');
-  });
-
-  it('still fails when Abmaischen temperature is invalid', () => {
-    const result = mapBeerToBrewingData(makeBeer({ fermentation: [
-      { type: 'Einmaischen', temperature: 52, time: 10 },
-      { type: 'Rast 1', temperature: 64, time: 40, executionMode: RestExecutionMode.TIMED },
-      { type: 'Abmaischen', temperature: 0 }
-    ] }));
-
-    expect(result.ok).toBe(false);
-    expect(result.error).toContain('Einmaischen/Abmaischen Temperatur fehlt oder ist ungültig');
-  });
-
-
-  it('keeps imported CONFIRMATION_HOLD without time through production mapping', () => {
-    const result = mapBeerToBrewingData(makeBeer({ fermentation: [
-      { type: 'Einmaischen', temperature: 52, time: 10 },
       { type: 'Dickmaische führen', temperature: 66, executionMode: RestExecutionMode.CONFIRMATION_HOLD },
-      { type: 'Abmaischen', temperature: 78, time: 10 }
-    ] }));
-
-    expect(result.ok).toBe(true);
-    const hold = result.brewingData?.Rasten.find((s) => s.type === 'Dickmaische führen');
-    expect(hold).toEqual(expect.objectContaining({ executionMode: RestExecutionMode.CONFIRMATION_HOLD }));
-    expect(hold).not.toHaveProperty('time');
-  });
-
-  it('does not infer CONFIRMATION_HOLD from time=0', () => {
-    const result = mapBeerToBrewingData(makeBeer({ fermentation: [
-      { type: 'Einmaischen', temperature: 52, time: 10 },
-      { type: 'Rast 1', temperature: 64, time: 0 },
-      { type: 'Abmaischen', temperature: 78, time: 10 }
-    ] }));
-
-    expect(result.ok).toBe(false);
-    expect(result.error).toContain('Zeitgesteuerte Rast');
-  });
-
-  it('does not convert Einmaischen/Abmaischen to CONFIRMATION_HOLD', () => {
-    const result = mapBeerToBrewingData(makeBeer({ fermentation: [
-      { type: 'Einmaischen', temperature: 52 },
-      { type: 'Rast 1', temperature: 64, time: 40, executionMode: RestExecutionMode.TIMED },
       { type: 'Abmaischen', temperature: 78, time: 0 }
     ] }));
 
     expect(result.ok).toBe(true);
-    const mashIn = result.brewingData?.Rasten.find((s) => s.type === 'Einmaischen');
-    const mashOut = result.brewingData?.Rasten.find((s) => s.type === 'Abmaischen');
-    expect(mashIn?.executionMode).toBe(RestExecutionMode.TIMED);
-    expect(mashOut?.executionMode).toBe(RestExecutionMode.TIMED);
+    expect(result.brewingData?.Rasten).toEqual([
+      expect.objectContaining({ type: 'Dickmaische führen', executionMode: RestExecutionMode.CONFIRMATION_HOLD })
+    ]);
+    expect(result.brewingData?.Rasten[0]).not.toHaveProperty('time');
+  });
+
+  it('rejects missing or invalid cooking fields', () => {
+    const missingCookingTemp = mapBeerToBrewingData(makeBeer({ cookingTemperatur: null as unknown as number }));
+    expect(missingCookingTemp.ok).toBe(false);
+    expect(missingCookingTemp.error).toContain('Kochtemperatur');
+
+    const invalidCookingTime = mapBeerToBrewingData(makeBeer({ cookingTime: 0 }));
+    expect(invalidCookingTime.ok).toBe(false);
+    expect(invalidCookingTime.error).toContain('Kochzeit');
+  });
+
+  it('accepts the example contract shape with only real rests in Rasten', () => {
+    const result = mapBeerToBrewingData(makeBeer({
+      fermentation: [
+        { type: 'Einmaischen', temperature: 48, time: 0, executionMode: RestExecutionMode.TIMED },
+        { type: 'Rast1', temperature: 63, time: 40, executionMode: RestExecutionMode.TIMED },
+        { type: 'Dickmaische', temperature: 68, executionMode: RestExecutionMode.CONFIRMATION_HOLD },
+        { type: 'Abmaischen', temperature: 78, time: 0, executionMode: RestExecutionMode.TIMED }
+      ],
+      cookingTime: 70,
+      cookingTemperatur: 100
+    }));
+
+    expect(result.ok).toBe(true);
+    expect(result.brewingData).toEqual({
+      MashupTemperature: 48,
+      MashdownTemperature: 78,
+      CookingTime: 70,
+      CookingTemperature: 100,
+      Rasten: [
+        { type: 'Rast1', temperature: 63, time: 40, executionMode: RestExecutionMode.TIMED },
+        { type: 'Dickmaische', temperature: 68, executionMode: RestExecutionMode.CONFIRMATION_HOLD }
+      ]
+    });
   });
 });

--- a/src/utils/productionRecipe.ts
+++ b/src/utils/productionRecipe.ts
@@ -14,7 +14,7 @@ export interface ProductionRecipeNormalizationResult {
 
 export function normalizeFermentationStepsForProduction(steps: FermentationSteps[]): ProductionRecipeNormalizationResult {
   const normalized: FermentationSteps[] = [];
-  const fixedProcessStepTypes = new Set(['Einmaischen', 'Abmaischen']);
+  const fixedProcessStepTypes = new Set(['Einmaischen', 'Abmaischen', 'Kochen']);
 
   for (const step of steps ?? []) {
     const executionMode = step.executionMode ?? RestExecutionMode.TIMED;
@@ -30,12 +30,8 @@ export function normalizeFermentationStepsForProduction(steps: FermentationSteps
       continue;
     }
 
-    // Ein-/Abmaischen sind feste Prozessschritte und keine normalen zeitgesteuerten Rasten.
+    // Ein-/Abmaischen/Kochen sind feste Prozessschritte über Top-Level-Felder und dürfen nicht als normale Rasten gesendet werden.
     if (fixedProcessStepTypes.has(step.type)) {
-      normalized.push({
-        ...step,
-        executionMode
-      });
       continue;
     }
 
@@ -59,6 +55,12 @@ export function mapBeerToBrewingData(beer: Beer): ProductionRecipeNormalizationR
 
   if (!ein || !aus || !isValidTemperature(ein.temperature) || !isValidTemperature(aus.temperature)) {
     return { ok: false, error: 'Einmaischen/Abmaischen Temperatur fehlt oder ist ungültig.' };
+  }
+  if (!isValidTimedDuration(beer.cookingTime)) {
+    return { ok: false, error: 'Kochzeit fehlt oder ist ungültig.' };
+  }
+  if (!isValidTemperature(beer.cookingTemperatur)) {
+    return { ok: false, error: 'Kochtemperatur fehlt oder ist ungültig.' };
   }
 
   const normalizedStepsResult = normalizeFermentationStepsForProduction(beer.fermentation);


### PR DESCRIPTION
### Motivation
- The brewing controller expects fixed process steps (mash-in, mash-out, boil) as top-level fields and only real rests/confirmation-holds in `Rasten`, so the UI must stop sending `Einmaischen`, `Abmaischen` and `Kochen` inside `Rasten` to avoid contract mismatch. 

### Description
- Filtered fixed-step types `Einmaischen`, `Abmaischen`, and `Kochen` out of `Rasten` during normalization and added a German comment explaining that these fixed steps are represented by top-level fields and must not be sent as normal rests. 
- Preserved `CONFIRMATION_HOLD` entries (strip `time` but keep `executionMode`) and enforce that TIMED rests require `time > 0`. 
- Kept top-level mapping for process fields and added validation to require `MashupTemperature`, `MashdownTemperature`, `CookingTime` and a non-null `CookingTemperature` before building the production payload. 
- Files changed: `src/utils/productionRecipe.ts` and `src/utils/productionRecipe.test.ts` (focused unit tests added to cover filtering and validation behavior). 

### Testing
- Added unit tests in `src/utils/productionRecipe.test.ts` covering: exclusion of `Einmaischen`/`Abmaischen`/`Kochen` from `Rasten`, preservation of `MashupTemperature`/`MashdownTemperature`/`CookingTime`/`CookingTemperature`, TIMED-rest validation (`time > 0`), `CONFIRMATION_HOLD` preservation without `time`, and acceptance of the example contract shape. 
- Ran `npm test -- --runInBand src/utils/productionRecipe.test.ts` in the current environment and the run failed because `react-scripts` is not available here, so tests were added but not executed in this environment. 
- No other automated tests were run as part of this change due to the environment limitation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04c6707b00832fa791b294e439b269)