### PR TITLE
Add frontend application version page and build-time version injection

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,0 +1,26 @@
+module.exports = function(aGrunt) {
+  aGrunt.registerTask('eslint', 'Run the CRA ESLint checks.', function() {
+    const done = this.async();
+    aGrunt.util.spawn({
+      cmd: process.platform === 'win32' ? 'node_modules/.bin/eslint.cmd' : 'node_modules/.bin/eslint',
+      args: ['src', '--ext', '.ts,.tsx'],
+      opts: {stdio: 'inherit'},
+    }, function(aError) {
+      done(!aError);
+    });
+  });
+
+  aGrunt.registerTask('jest', 'Run Jest once through react-scripts.', function() {
+    const done = this.async();
+    aGrunt.util.spawn({
+      cmd: process.platform === 'win32' ? 'node_modules/.bin/react-scripts.cmd' : 'node_modules/.bin/react-scripts',
+      args: ['test', '--watchAll=false'],
+      opts: {
+        stdio: 'inherit',
+        env: {...process.env, CI: 'true'},
+      },
+    }, function(aError) {
+      done(!aError);
+    });
+  });
+};

--- a/docs/codex/app-context.md
+++ b/docs/codex/app-context.md
@@ -89,3 +89,7 @@ Scripts from `package.json`:
 - `npm run deploy`: copy existing build to the same server path.
 - Storybook scripts are present, but package script names use older `start-storybook` / `build-storybook` commands while Storybook 7 dependencies are installed. Needs verification.
 
+
+## Application version
+
+The desktop UI has a `Version` view in the header information area. The page displays the frontend build version from `REACT_APP_VERSION`, injected before `react-scripts` runs. `scripts/resolve-app-version.js` prefers explicit CI variables (`BRAUHAUS_APP_VERSION`, `REACT_APP_VERSION`, `APP_VERSION`, `BUILD_BUILDNUMBER`, or an Azure `refs/tags/*` source branch), then `git describe --tags --always --dirty`, and finally `unknown` when Git metadata is unavailable.

--- a/docs/codex/app-version.md
+++ b/docs/codex/app-version.md
@@ -1,0 +1,14 @@
+# Application version page
+
+The React UI shows its frontend version on the `Version` page, available from the desktop header information button.
+
+The value is resolved before `react-scripts` starts the Webpack build. Browser code does not call Git. The build wrapper in `scripts/build-with-version.js` injects the resolved value through `REACT_APP_VERSION`, which Create React App passes to Webpack's compile-time environment replacement.
+
+Version priority:
+
+1. Explicit CI/build variables: `BRAUHAUS_APP_VERSION`, `REACT_APP_VERSION`, `APP_VERSION`, or `BUILD_BUILDNUMBER`.
+2. Azure DevOps tag builds via `BUILD_SOURCEBRANCH=refs/tags/<tag>`.
+3. Local Git metadata from `git describe --tags --always --dirty`.
+4. `unknown` when no explicit version or Git metadata is available.
+
+For release builds, prefer setting `BRAUHAUS_APP_VERSION` to the release tag. Git metadata is a local-development fallback and the build remains usable from exported source archives.

--- a/package.json
+++ b/package.json
@@ -59,11 +59,11 @@
     "web-vitals": "^2.1.4"
   },
   "scripts": {
-    "start": "react-scripts start",
-    "build": "react-scripts build",
+    "start": "node scripts/build-with-version.js start",
+    "build": "node scripts/build-with-version.js build",
     "build-deploy": "npm run build && scp -r build/* boris@192.168.178.72:/srv/sites/braumeister",
     "deploy": "scp -r build/* boris@192.168.178.72:/srv/sites/braumeister",
-    "test": "react-scripts test",
+    "test": "node scripts/build-with-version.js test",
     "eject": "react-scripts eject",
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook"

--- a/scripts/build-with-version.js
+++ b/scripts/build-with-version.js
@@ -1,0 +1,14 @@
+const { spawnSync } = require('child_process');
+const { resolveAppVersion } = require('./resolve-app-version');
+
+const script = process.argv[2] || 'build';
+const appVersion = resolveAppVersion(process.env);
+const result = spawnSync(process.platform === 'win32' ? 'node_modules/.bin/react-scripts.cmd' : 'node_modules/.bin/react-scripts', [script], {
+  stdio: 'inherit',
+  env: {
+    ...process.env,
+    REACT_APP_VERSION: appVersion,
+  },
+});
+
+process.exit(result.status === null ? 1 : result.status);

--- a/scripts/resolve-app-version.js
+++ b/scripts/resolve-app-version.js
@@ -1,0 +1,47 @@
+const { execFileSync } = require('child_process');
+
+const explicitVariables = [
+  'BRAUHAUS_APP_VERSION',
+  'REACT_APP_VERSION',
+  'APP_VERSION',
+  'BUILD_BUILDNUMBER',
+];
+
+function cleanVersion(aVersion) {
+  if (!aVersion || typeof aVersion !== 'string') return undefined;
+  const trimmedVersion = aVersion.trim();
+  return trimmedVersion.length > 0 ? trimmedVersion : undefined;
+}
+
+function getAzureTagVersion(aEnv) {
+  const sourceBranch = cleanVersion(aEnv.BUILD_SOURCEBRANCH);
+  if (sourceBranch && sourceBranch.startsWith('refs/tags/')) {
+    return sourceBranch.substring('refs/tags/'.length);
+  }
+  return undefined;
+}
+
+function getExplicitVersion(aEnv) {
+  for (const variableName of explicitVariables) {
+    const value = cleanVersion(aEnv[variableName]);
+    if (value) return value;
+  }
+  return getAzureTagVersion(aEnv);
+}
+
+function getGitVersion() {
+  try {
+    return cleanVersion(execFileSync('git', ['describe', '--tags', '--always', '--dirty'], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }));
+  } catch (error) {
+    return undefined;
+  }
+}
+
+function resolveAppVersion(aEnv = process.env) {
+  return getExplicitVersion(aEnv) || getGitVersion() || 'unknown';
+}
+
+module.exports = { resolveAppVersion };

--- a/src/containers/MainView/Header/Header.css
+++ b/src/containers/MainView/Header/Header.css
@@ -139,3 +139,10 @@ h1 {
   color: var(--color-orange-dark);
   filter: none;
 }
+
+.icons-container button.icon {
+  font-size: 1.4rem;
+  font-weight: 800;
+  line-height: 1;
+  cursor: pointer;
+}

--- a/src/containers/MainView/Header/Header.test.tsx
+++ b/src/containers/MainView/Header/Header.test.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import {render, screen, fireEvent} from '@testing-library/react';
+import {Header} from './Header';
+import {Views} from '../../../enums/eViews';
+
+describe('Header navigation', () => {
+    it('keeps existing settings navigation and adds version navigation', (): void => {
+        const setViewState = jest.fn();
+        render(
+            <Header
+                setViewState={setViewState}
+                currentView={Views.MAIN}
+                removeAllMessages={jest.fn()}
+                backendStatus={true}
+                messages={[]}
+            />
+        );
+
+        fireEvent.click(screen.getByLabelText('Einstellungen'));
+        fireEvent.click(screen.getByLabelText('Version'));
+
+        expect(setViewState).toHaveBeenCalledWith(Views.SETTINGS);
+        expect(setViewState).toHaveBeenCalledWith(Views.VERSION);
+    });
+});

--- a/src/containers/MainView/Header/Header.tsx
+++ b/src/containers/MainView/Header/Header.tsx
@@ -21,7 +21,7 @@ interface HeaderState {
     currentDate: string;
 }
 
-class Header extends React.Component<HeaderProps, HeaderState> {
+export class Header extends React.Component<HeaderProps, HeaderState> {
     private timer: NodeJS.Timer | undefined;
 
     constructor(props: HeaderProps) {
@@ -125,6 +125,15 @@ class Header extends React.Component<HeaderProps, HeaderState> {
                         role="button"
                         aria-label="Einstellungen"
                     />
+                    <button
+                        type="button"
+                        className={this.getTabClassName(Views.VERSION)}
+                        onClick={() => this.handleIconClick(Views.VERSION)}
+                        title="Version"
+                        aria-label="Version"
+                    >
+                        i
+                    </button>
                 </div>
                 <div className="header-status">
                   <div className="status-display-wrapper">

--- a/src/containers/Version/VersionPage.css
+++ b/src/containers/Version/VersionPage.css
@@ -1,0 +1,54 @@
+.version-page {
+  padding: 1.5rem 2rem;
+  color: var(--color-black);
+}
+
+.version-card {
+  background: var(--color-white);
+  border: 1px solid var(--color-input-border);
+  border-radius: 1rem;
+  box-shadow: 0 2px 6px var(--shadow-card-light);
+  padding: 1rem;
+  max-width: 34rem;
+}
+
+.version-eyebrow {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-weight: 700;
+  color: var(--color-orange-dark);
+  margin: 0 0 0.25rem 0;
+}
+
+.version-card h2 {
+  margin: 0;
+  font-size: 1.5rem;
+}
+
+.version-description {
+  color: var(--color-gray-very-dark);
+  margin: 0.5rem 0 1rem 0;
+}
+
+.version-value-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding-top: 0.75rem;
+  border-top: 1px solid var(--color-input-border);
+}
+
+.version-label {
+  font-weight: 700;
+}
+
+.version-value {
+  background: var(--color-input-bg2);
+  border: 1px solid var(--color-input-border);
+  border-radius: 999px;
+  font-family: monospace;
+  font-weight: 700;
+  padding: 0.45rem 0.75rem;
+}

--- a/src/containers/Version/VersionPage.test.tsx
+++ b/src/containers/Version/VersionPage.test.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import {render, screen} from '@testing-library/react';
+import VersionPage from './VersionPage';
+
+describe('VersionPage', () => {
+    it('renders the supplied frontend version', (): void => {
+        render(<VersionPage version="v2.0.0" />);
+
+        expect(screen.getByRole('heading', {name: 'Version'})).toBeInTheDocument();
+        expect(screen.getByTestId('application-version')).toHaveTextContent('v2.0.0');
+    });
+
+    it('renders the fallback value for an empty supplied version', (): void => {
+        render(<VersionPage version="" />);
+
+        expect(screen.getByTestId('application-version')).toHaveTextContent('unknown');
+    });
+});

--- a/src/containers/Version/VersionPage.tsx
+++ b/src/containers/Version/VersionPage.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import './VersionPage.css';
+import {getApplicationVersion} from '../../utils/version/appVersion';
+
+interface VersionPageProps {
+    version?: string;
+}
+
+class VersionPage extends React.Component<VersionPageProps> {
+    getVersion = (): string => {
+        const {version} = this.props;
+        if (version === undefined || version.trim().length === 0) {
+            return getApplicationVersion();
+        }
+
+        return version;
+    }
+
+    render(): React.ReactNode {
+        return (
+            <div className="version-page">
+                <section className="version-card">
+                    <p className="version-eyebrow">Anwendungsinformationen</p>
+                    <h2>Version</h2>
+                    <p className="version-description">
+                        Die angezeigte Version wurde beim Erstellen der Anwendung in das Frontend eingebunden.
+                    </p>
+                    <div className="version-value-row">
+                        <span className="version-label">Frontend-Version</span>
+                        <span className="version-value" data-testid="application-version">{this.getVersion()}</span>
+                    </div>
+                </section>
+            </div>
+        );
+    }
+}
+
+export default VersionPage;

--- a/src/containers/index.test.tsx
+++ b/src/containers/index.test.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import {render, screen} from '@testing-library/react';
+import {Index} from './index';
+import {Views} from '../enums/eViews';
+import {BrewingStatus} from '../model/brewingStatus.types';
+
+describe('Index view routing', () => {
+    it('points the version view to the version page', (): void => {
+        render(
+            <Index
+                viewState={Views.VERSION}
+                brewingStatus={{} as BrewingStatus}
+                confirm={jest.fn()}
+                checkIsBackenAvailable={jest.fn()}
+                webSocketConnect={jest.fn()}
+            />
+        );
+
+        expect(screen.getByRole('heading', {name: 'Version'})).toBeInTheDocument();
+    });
+});

--- a/src/containers/index.tsx
+++ b/src/containers/index.tsx
@@ -14,6 +14,7 @@ import FinishedBrewsTable from "./MainView/FinishBrewsBeers/FinishedBrewsTable";
 import BrewingCalculations from "./BrewingCalculations/BrewingCalculations";
 import IngredientsFormPage from "./DatabaseOverview/IngredientsFormPage";
 import SettingsPage from "./Settings/SettingsPage";
+import VersionPage from "./Version/VersionPage";
 import {getBrewingStatusLabel, shouldShowConfirmButton, shouldShowWaitingDialog} from "../utils/brewingStatus/selectors";
 
 interface indexMainProps {
@@ -24,7 +25,7 @@ interface indexMainProps {
     webSocketConnect: () => void;
 }
 
-class Index extends React.Component<indexMainProps> {
+export class Index extends React.Component<indexMainProps> {
     constructor(props: indexMainProps) {
         super(props);
     }
@@ -112,6 +113,7 @@ class Index extends React.Component<indexMainProps> {
                     {viewState === Views.FINISHED_BREWS && <FinishedBrewsTable></FinishedBrewsTable>}
                 </SimpleBar>
                 {viewState === Views.BREWING_CALCULATIONS && <BrewingCalculations />}
+                {viewState === Views.VERSION && <VersionPage />}
             </div>
 
         );

--- a/src/enums/eViews.ts
+++ b/src/enums/eViews.ts
@@ -6,4 +6,5 @@ export enum Views {
     BREWING_CALCULATIONS = 4,
     INGREDIENTS = 5,
     SETTINGS = 6,
+    VERSION = 7,
 }

--- a/src/react-app-env.d.ts
+++ b/src/react-app-env.d.ts
@@ -1,1 +1,7 @@
 /// <reference types="react-scripts" />
+
+declare namespace NodeJS {
+    interface ProcessEnv {
+        REACT_APP_VERSION?: string;
+    }
+}

--- a/src/utils/version/appVersion.test.ts
+++ b/src/utils/version/appVersion.test.ts
@@ -1,0 +1,21 @@
+import {getApplicationVersion} from './appVersion';
+
+describe('getApplicationVersion', () => {
+    const originalVersion = process.env.REACT_APP_VERSION;
+
+    afterEach((): void => {
+        process.env.REACT_APP_VERSION = originalVersion;
+    });
+
+    it('returns the injected application version', (): void => {
+        process.env.REACT_APP_VERSION = 'v1.2.3';
+
+        expect(getApplicationVersion()).toBe('v1.2.3');
+    });
+
+    it('falls back to unknown when no version is injected', (): void => {
+        delete process.env.REACT_APP_VERSION;
+
+        expect(getApplicationVersion()).toBe('unknown');
+    });
+});

--- a/src/utils/version/appVersion.ts
+++ b/src/utils/version/appVersion.ts
@@ -1,0 +1,10 @@
+const fallbackVersion = 'unknown';
+
+export function getApplicationVersion(): string {
+    const version = process.env.REACT_APP_VERSION;
+    if (version === undefined || version.trim().length === 0) {
+        return fallbackVersion;
+    }
+
+    return version;
+}


### PR DESCRIPTION
### Motivation

- Expose the frontend application version in the UI using the Git tag used for the build while avoiding any runtime Git access. 
- Resolve the version at build time with a CI-first priority and inject it into the bundle so the running app can display the version reliably. 
- Reuse the project navigation pattern (Redux-driven view state) and existing styling conventions.

### Description

- Added `scripts/resolve-app-version.js` which resolves the version from explicit CI/build env vars (`BRAUHAUS_APP_VERSION`, `REACT_APP_VERSION`, `APP_VERSION`, `BUILD_BUILDNUMBER`), then Azure tag branch (`BUILD_SOURCEBRANCH`), then `git describe --tags --always --dirty`, and finally falls back to `unknown`.
- Added `scripts/build-with-version.js` and updated `package.json` `start`, `build`, and `test` scripts to run a wrapper that injects `REACT_APP_VERSION` into the environment before `react-scripts` runs.
- Introduced `src/utils/version/appVersion.ts` and TypeScript env declaration in `src/react-app-env.d.ts` to access the injected `REACT_APP_VERSION` with a safe `unknown` fallback.
- Implemented a new class-component page `src/containers/Version/VersionPage.tsx` with styling `VersionPage.css` and registered it in the existing desktop view model by adding `Views.VERSION` and wiring the page into `src/containers/index.tsx` and a header navigation button in `Header.tsx`.
- Added unit tests for the resolver and UI behavior: `src/utils/version/appVersion.test.ts`, `src/containers/Version/VersionPage.test.tsx`, `src/containers/index.test.tsx`, and `src/containers/MainView/Header/Header.test.tsx`.
- Updated documentation in `docs/codex/app-version.md` and appended a short note to `docs/codex/app-context.md` describing the version source and CI override variables.
- Added a `Gruntfile.js` that defines `eslint` and `jest` tasks to match the repository's expected validation commands (`grunt eslint --force` and `grunt jest --force`).

### Testing

- Executed the version resolver smoke check with Node: `node -e "const {resolveAppVersion}=require('./scripts/resolve-app-version'); if(resolveAppVersion({BRAUHAUS_APP_VERSION:'v1.2.3'}) !== 'v1.2.3') process.exit(1); if(resolveAppVersion({BUILD_SOURCEBRANCH:'refs/tags/v4.5.6'}) !== 'v4.5.6') process.exit(1); console.log('version resolver ok');"` which passed.
- Created unit tests for `getApplicationVersion` and the `VersionPage` and routing, but full test execution could not be completed in this environment because installing dependencies failed and `grunt` was not available; consequently `grunt eslint --force` and `grunt jest --force` were not executed here.
- Attempts made: `npm install` / `npm ci` (failed due to environment/registry/peer-dependency issues) and `grunt` commands (not installed), so automated Jest/ESLint runs were not completed in this environment; tests are present and should run in CI or a developer environment after dependencies are available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a50ae095e48832f8f52ef213a8449dd)