### PR TITLE
Add component version diagnostics page

### DIFF
--- a/docs/codex/app-version.md
+++ b/docs/codex/app-version.md
@@ -1,8 +1,16 @@
 # Application version page
 
-The React UI shows its frontend version on the `Version` page, available from the desktop header information button.
+The React UI shows version information on the `Version` page, available from the desktop header information button. This project uses Redux view-state navigation instead of URL routes, so the route identifier is `Views.VERSION`.
 
-The value is resolved before `react-scripts` starts the Webpack build. Browser code does not call Git. The build wrapper in `scripts/build-with-version.js` injects the resolved value through `REACT_APP_VERSION`, which Create React App passes to Webpack's compile-time environment replacement.
+The page displays three components:
+
+- `UI`: the frontend build version.
+- `Control`: the PI/control application diagnostic version.
+- `Database`: the database/backend application diagnostic version.
+
+## UI version injection
+
+The UI version is resolved before `react-scripts` starts the Webpack build. Browser code does not call Git. The build wrapper in `scripts/build-with-version.js` injects the resolved value through `REACT_APP_VERSION`, which Create React App passes to Webpack's compile-time environment replacement.
 
 Version priority:
 
@@ -12,3 +20,20 @@ Version priority:
 4. `unknown` when no explicit version or Git metadata is available.
 
 For release builds, prefer setting `BRAUHAUS_APP_VERSION` to the release tag. Git metadata is a local-development fallback and the build remains usable from exported source archives.
+
+## Diagnostic endpoints
+
+The version page loads backend diagnostics when the page opens. Requests are independent, so one unavailable service does not hide the other versions.
+
+- Control application: `GET /diag` through the configured control `BaseURL`.
+- Database application: `GET /diag` through the configured database `DatabaseURL` axios client.
+
+Expected successful or fallback response contract:
+
+```json
+{
+  "version": "v1.2.3"
+}
+```
+
+Only the `version` property is consumed. Missing, empty, or invalid diagnostic responses are displayed as `unknown`. A backend response of `{"version":"unknown"}` is displayed as `unknown` and is not treated as a request failure. Failed requests are displayed as `Unavailable`. Pending requests are displayed as `Loading…`.

--- a/src/containers/Version/VersionPage.css
+++ b/src/containers/Version/VersionPage.css
@@ -36,7 +36,7 @@
   align-items: center;
   justify-content: space-between;
   gap: 1rem;
-  padding-top: 0.75rem;
+  padding: 0.75rem 0;
   border-top: 1px solid var(--color-input-border);
 }
 
@@ -51,4 +51,8 @@
   font-family: monospace;
   font-weight: 700;
   padding: 0.45rem 0.75rem;
+}
+
+.version-value-loading {
+  color: var(--color-gray-very-dark);
 }

--- a/src/containers/Version/VersionPage.test.tsx
+++ b/src/containers/Version/VersionPage.test.tsx
@@ -1,18 +1,73 @@
 import React from 'react';
-import {render, screen} from '@testing-library/react';
+import {render, screen, waitFor} from '@testing-library/react';
 import VersionPage from './VersionPage';
 
 describe('VersionPage', () => {
-    it('renders the supplied frontend version', (): void => {
-        render(<VersionPage version="v2.0.0" />);
+    it('renders the supplied UI, control, and database versions', async (): Promise<void> => {
+        render(
+            <VersionPage
+                version="v2.0.0"
+                loadControlVersion={() => Promise.resolve('v1.2.3')}
+                loadDatabaseVersion={() => Promise.resolve('v1.1.0')}
+            />
+        );
 
         expect(screen.getByRole('heading', {name: 'Version'})).toBeInTheDocument();
         expect(screen.getByTestId('application-version')).toHaveTextContent('v2.0.0');
+        expect(await screen.findByTestId('control-version')).toHaveTextContent('v1.2.3');
+        expect(await screen.findByTestId('database-version')).toHaveTextContent('v1.1.0');
     });
 
-    it('renders the fallback value for an empty supplied version', (): void => {
-        render(<VersionPage version="" />);
+    it('renders the fallback value for an empty supplied UI version', (): void => {
+        render(
+            <VersionPage
+                version=""
+                loadControlVersion={() => Promise.resolve('v1.2.3')}
+                loadDatabaseVersion={() => Promise.resolve('v1.1.0')}
+            />
+        );
 
         expect(screen.getByTestId('application-version')).toHaveTextContent('unknown');
+    });
+
+    it('displays loading states while diagnostics are pending', (): void => {
+        render(
+            <VersionPage
+                version="v2.0.0"
+                loadControlVersion={() => new Promise<string>(() => {})}
+                loadDatabaseVersion={() => new Promise<string>(() => {})}
+            />
+        );
+
+        expect(screen.getByTestId('control-version')).toHaveTextContent('Loading…');
+        expect(screen.getByTestId('database-version')).toHaveTextContent('Loading…');
+    });
+
+    it('displays backend unknown values without treating them as failures', async (): Promise<void> => {
+        render(
+            <VersionPage
+                version="v2.0.0"
+                loadControlVersion={() => Promise.resolve('unknown')}
+                loadDatabaseVersion={() => Promise.resolve('unknown')}
+            />
+        );
+
+        expect(await screen.findByTestId('control-version')).toHaveTextContent('unknown');
+        expect(await screen.findByTestId('database-version')).toHaveTextContent('unknown');
+    });
+
+    it('keeps successful results visible when one request fails', async (): Promise<void> => {
+        render(
+            <VersionPage
+                version="v2.0.0"
+                loadControlVersion={() => Promise.reject(new Error('offline'))}
+                loadDatabaseVersion={() => Promise.resolve('v1.1.0')}
+            />
+        );
+
+        await waitFor((): void => {
+            expect(screen.getByTestId('control-version')).toHaveTextContent('Unavailable');
+            expect(screen.getByTestId('database-version')).toHaveTextContent('v1.1.0');
+        });
     });
 });

--- a/src/containers/Version/VersionPage.tsx
+++ b/src/containers/Version/VersionPage.tsx
@@ -1,12 +1,40 @@
 import React from 'react';
 import './VersionPage.css';
 import {getApplicationVersion} from '../../utils/version/appVersion';
+import {ComponentVersionService} from '../../utils/version/componentVersions';
+
+const unavailableVersion = 'Unavailable';
+const loadingVersion = 'Loading…';
 
 interface VersionPageProps {
     version?: string;
+    loadControlVersion?: () => Promise<string>;
+    loadDatabaseVersion?: () => Promise<string>;
 }
 
-class VersionPage extends React.Component<VersionPageProps> {
+interface VersionPageState {
+    controlVersion: string;
+    databaseVersion: string;
+    isControlLoading: boolean;
+    isDatabaseLoading: boolean;
+}
+
+class VersionPage extends React.Component<VersionPageProps, VersionPageState> {
+    constructor(aProps: VersionPageProps) {
+        super(aProps);
+        this.state = {
+            controlVersion: loadingVersion,
+            databaseVersion: loadingVersion,
+            isControlLoading: true,
+            isDatabaseLoading: true,
+        };
+    }
+
+    componentDidMount(): void {
+        this.loadControlVersion();
+        this.loadDatabaseVersion();
+    }
+
     getVersion = (): string => {
         const {version} = this.props;
         if (version === undefined || version.trim().length === 0) {
@@ -16,19 +44,55 @@ class VersionPage extends React.Component<VersionPageProps> {
         return version;
     }
 
+    private loadControlVersion = (): void => {
+        const loader = this.props.loadControlVersion || ComponentVersionService.getControlVersion;
+        loader()
+            .then((aVersion: string): void => {
+                this.setState({controlVersion: aVersion, isControlLoading: false});
+            })
+            .catch((): void => {
+                this.setState({controlVersion: unavailableVersion, isControlLoading: false});
+            });
+    }
+
+    private loadDatabaseVersion = (): void => {
+        const loader = this.props.loadDatabaseVersion || ComponentVersionService.getDatabaseVersion;
+        loader()
+            .then((aVersion: string): void => {
+                this.setState({databaseVersion: aVersion, isDatabaseLoading: false});
+            })
+            .catch((): void => {
+                this.setState({databaseVersion: unavailableVersion, isDatabaseLoading: false});
+            });
+    }
+
+    private renderVersionRow(aLabel: string, aValue: string, aTestId: string, aIsLoading: boolean): React.ReactNode {
+        return (
+            <div className="version-value-row">
+                <span className="version-label">{aLabel}</span>
+                <span
+                    className={`version-value ${aIsLoading ? 'version-value-loading' : ''}`}
+                    data-testid={aTestId}
+                >
+                    {aValue}
+                </span>
+            </div>
+        );
+    }
+
     render(): React.ReactNode {
+        const {controlVersion, databaseVersion, isControlLoading, isDatabaseLoading} = this.state;
         return (
             <div className="version-page">
                 <section className="version-card">
                     <p className="version-eyebrow">Anwendungsinformationen</p>
                     <h2>Version</h2>
                     <p className="version-description">
-                        Die angezeigte Version wurde beim Erstellen der Anwendung in das Frontend eingebunden.
+                        Versionsinformationen für die Benutzeroberfläche, die Steuerung und die Datenbankanwendung.
                     </p>
-                    <div className="version-value-row">
-                        <span className="version-label">Frontend-Version</span>
-                        <span className="version-value" data-testid="application-version">{this.getVersion()}</span>
-                    </div>
+                    {this.renderVersionRow('UI', this.getVersion(), 'application-version', false)}
+                    {this.renderVersionRow('Control', controlVersion, 'control-version', isControlLoading)}
+                    {this.renderVersionRow('Database', databaseVersion, 'database-version', isDatabaseLoading)}
                 </section>
             </div>
         );

--- a/src/model/DiagnosticResponse.test.ts
+++ b/src/model/DiagnosticResponse.test.ts
@@ -1,0 +1,13 @@
+import {normalizeDiagnosticVersion} from './DiagnosticResponse';
+
+describe('normalizeDiagnosticVersion', () => {
+    it('returns a valid diagnostic version', (): void => {
+        expect(normalizeDiagnosticVersion({version: 'v1.2.3'})).toBe('v1.2.3');
+    });
+
+    it('handles invalid diagnostic responses safely', (): void => {
+        expect(normalizeDiagnosticVersion({})).toBe('unknown');
+        expect(normalizeDiagnosticVersion({version: ''})).toBe('unknown');
+        expect(normalizeDiagnosticVersion(null)).toBe('unknown');
+    });
+});

--- a/src/model/DiagnosticResponse.ts
+++ b/src/model/DiagnosticResponse.ts
@@ -1,0 +1,16 @@
+export interface IDiagnosticResponse {
+    version: string;
+}
+
+export const UNKNOWN_VERSION = 'unknown';
+
+export function normalizeDiagnosticVersion(aResponse: unknown): string {
+    if (typeof aResponse === 'object' && aResponse !== null) {
+        const candidate = (aResponse as Partial<IDiagnosticResponse>).version;
+        if (typeof candidate === 'string' && candidate.trim().length > 0) {
+            return candidate;
+        }
+    }
+
+    return UNKNOWN_VERSION;
+}

--- a/src/repositorys/DatabaseDiagnosticRepository.test.ts
+++ b/src/repositorys/DatabaseDiagnosticRepository.test.ts
@@ -1,0 +1,32 @@
+import {api} from './BaseRepository';
+import {DatabaseDiagnosticRepository} from './DatabaseDiagnosticRepository';
+
+jest.mock('./BaseRepository', () => {
+    const get = jest.fn();
+    return {
+        api: {get},
+        BaseRepository: class {
+            protected static async get<T>(aUrl: string): Promise<T> {
+                const response = await get(aUrl);
+                return response.data;
+            }
+        },
+    };
+});
+
+const mockedApi = api as unknown as { get: jest.Mock };
+
+describe('DatabaseDiagnosticRepository', () => {
+    beforeEach((): void => {
+        mockedApi.get.mockReset();
+    });
+
+    it('loads database diagnostics from GET diag', async (): Promise<void> => {
+        mockedApi.get.mockResolvedValueOnce({data: {version: 'v1.1.0'}});
+
+        const result = await DatabaseDiagnosticRepository.getDiagnosticVersion();
+
+        expect(result).toBe('v1.1.0');
+        expect(mockedApi.get).toHaveBeenCalledWith('diag');
+    });
+});

--- a/src/repositorys/DatabaseDiagnosticRepository.ts
+++ b/src/repositorys/DatabaseDiagnosticRepository.ts
@@ -1,0 +1,9 @@
+import {IDiagnosticResponse, normalizeDiagnosticVersion} from '../model/DiagnosticResponse';
+import {BaseRepository} from './BaseRepository';
+
+export class DatabaseDiagnosticRepository extends BaseRepository {
+    static async getDiagnosticVersion(): Promise<string> {
+        const response = await this.get<IDiagnosticResponse>('diag');
+        return normalizeDiagnosticVersion(response);
+    }
+}

--- a/src/repositorys/ProductionRepository.test.ts
+++ b/src/repositorys/ProductionRepository.test.ts
@@ -55,6 +55,17 @@ describe('ProductionRepository API method/path usage', () => {
     expect(mockedAxios.get).not.toHaveBeenCalledWith(expect.stringContaining('/Command/next'));
   });
 
+
+
+  it('loads control diagnostics from GET /diag', async () => {
+    mockedAxios.get.mockResolvedValueOnce({ status: 200, data: { version: 'v1.2.3' }, statusText: 'OK' } as any);
+
+    const result = await ProductionRepository.getDiagnosticVersion();
+
+    expect(result).toBe('v1.2.3');
+    expect(mockedAxios.get).toHaveBeenCalledWith(expect.stringContaining('/diag'));
+  });
+
   it('keeps safe reads on GET', async () => {
     mockedAxios.get.mockResolvedValueOnce({ status: 200, data: { liters: 3, openClose: true }, statusText: 'OK' } as any);
     await ProductionRepository.getWaterStatus();

--- a/src/repositorys/ProductionRepository.ts
+++ b/src/repositorys/ProductionRepository.ts
@@ -10,6 +10,7 @@ import {normalizeBrewingStatus} from "../utils/brewingStatus/normalizeBrewingSta
 import {ConfirmStates} from "../enums/eConfirmStates";
 import {WaterStatus} from "../components/Controlls/WaterControll/WaterControl";
 import {BackendAvailable} from "../reducers/productionReducer";
+import {IDiagnosticResponse, normalizeDiagnosticVersion} from "../model/DiagnosticResponse";
 
 const DEFAULT_WATER_STATUS: WaterStatus = { liters: 0, openClose: false };
 
@@ -57,6 +58,10 @@ export class ProductionRepository {
 
     static async getBrewingStatus(): Promise<{ available: BackendAvailable, brewingStatus: BrewingStatus | undefined }> {
        return await this._doGetBrewingStatus();
+    }
+
+    static async getDiagnosticVersion(): Promise<string> {
+        return await this._doGetDiagnosticVersion();
     }
 
     static async toggleHeater(aIsTurnOn: ToggleState) {
@@ -153,6 +158,11 @@ export class ProductionRepository {
             // Rückgabe statt dispatch
             return { available, brewingStatus: undefined };
         }
+    }
+
+    private static async _doGetDiagnosticVersion(): Promise<string> {
+        const response = await axios.get<IDiagnosticResponse>(BaseURL + 'diag');
+        return normalizeDiagnosticVersion(response.data);
     }
 
     private static async _doSendBrewingData(aBrewingData: BrewingData) {

--- a/src/utils/version/componentVersions.ts
+++ b/src/utils/version/componentVersions.ts
@@ -1,0 +1,17 @@
+import {DatabaseDiagnosticRepository} from '../../repositorys/DatabaseDiagnosticRepository';
+import {ProductionRepository} from '../../repositorys/ProductionRepository';
+
+export interface IComponentVersions {
+    control: string;
+    database: string;
+}
+
+export class ComponentVersionService {
+    static async getControlVersion(): Promise<string> {
+        return await ProductionRepository.getDiagnosticVersion();
+    }
+
+    static async getDatabaseVersion(): Promise<string> {
+        return await DatabaseDiagnosticRepository.getDiagnosticVersion();
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide a single UI page that reports the versions of all three components (UI, Control, Database) for diagnostics and support.
- Reuse existing client infrastructure and the established build-time UI version injection instead of introducing new runtime Git access.
- Preserve the project conventions: class components, Redux view-state navigation (`Views.VERSION`), and repository-style API clients.

### Description
- Extend the existing Version page to show three rows: `UI`, `Control`, and `Database`, with independent loading, success, `unknown`, and `Unavailable` states implemented as page-local state. (file: `src/containers/Version/VersionPage.tsx` and CSS update.)
- Add a typed diagnostic model and normalization function `IDiagnosticResponse` / `normalizeDiagnosticVersion` to defensively handle missing/invalid responses and return `unknown`. (file: `src/model/DiagnosticResponse.ts`)
- Add a `DatabaseDiagnosticRepository` that reuses `BaseRepository` and the database `api` client to call `GET diag`, and extend `ProductionRepository` with a typed `GET /diag` method using `BaseURL`. (files: `src/repositorys/DatabaseDiagnosticRepository.ts`, `src/repositorys/ProductionRepository.ts`)
- Add a small service `ComponentVersionService` to keep API logic out of presentational rendering and to delegate to the repositories. (file: `src/utils/version/componentVersions.ts`)
- Update documentation to explain the route (`Views.VERSION`), the UI version injection mechanism (`REACT_APP_VERSION` set by `scripts/build-with-version.js`), the diagnostic endpoints used (`GET /diag` on each component), the expected response contract, and the display semantics for `unknown`/loading/unavailable. (file: `docs/codex/app-version.md`)
- Add unit tests for the Version page, the diagnostic normalization, and repository diagnostic calls. (files: `src/containers/Version/VersionPage.test.tsx`, `src/model/DiagnosticResponse.test.ts`, `src/repositorys/DatabaseDiagnosticRepository.test.ts`, updates to `src/repositorys/ProductionRepository.test.ts`)

### Testing
- Added Jest unit tests covering UI rendering of UI/control/database versions, loading state, backend `unknown`, independent failure handling, and diagnostic normalization; tests were added but not executed in this environment. (tests: `src/containers/Version/VersionPage.test.tsx`, `src/model/DiagnosticResponse.test.ts`, `src/repositorys/DatabaseDiagnosticRepository.test.ts`.)
- `git diff --check` passed with no whitespace errors.
- Attempts to run the repository test and lint commands (`grunt eslint --force` and `grunt jest --force`) could not be executed because `grunt` was not available in the environment; `npm install` to restore tooling also failed due to a `403 Forbidden` error fetching an npm package, so automated test execution could not complete here.
- Repository changes were committed locally and are ready for CI to run `grunt eslint --force` and `grunt jest --force` (or the project CI) to validate the new tests and lints in the normal build environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a50be408df4832fa363915a90c39738)