### PR TITLE
Use 99 °C fallback for missing cooking temperature

### DIFF
--- a/docs/codex/data-flow.md
+++ b/docs/codex/data-flow.md
@@ -19,7 +19,7 @@ Needs verification: backend ordering of `GET beers`, because the UI treats the l
 ## Production start flow
 
 - Production view reads `beerDataReducer.beerToBrew` as `selectedBeer`.
-- `mapBeerToBrewingData(selectedBeer)` extracts Einmaischen and Abmaischen temperatures, cooking temperature/time, and normalized timed/confirmation rests.
+- `mapBeerToBrewingData(selectedBeer)` extracts Einmaischen and Abmaischen temperatures, cooking temperature/time, and normalized timed/confirmation rests. Missing or invalid top-level cooking temperature is replaced with `99` °C in the UI mapping before sending control data.
 - On success, `SEND_BREWING_DATA` posts `BrewingData` to `POST Recipe/` and expects HTTP 201.
 - If successful, UI posts `Command/StartBrewing:""` and then begins status polling.
 

--- a/docs/codex/domain-model.md
+++ b/docs/codex/domain-model.md
@@ -17,11 +17,11 @@ The PI/control payload is:
 
 - `MashdownTemperature`: from recipe step `Abmaischen.temperature`.
 - `MashupTemperature`: from recipe step `Einmaischen.temperature`.
-- `CookingTemperature`: from `beer.cookingTemperatur`.
+- `CookingTemperature`: from `beer.cookingTemperatur`, with UI fallback `99` °C only when the stored cooking temperature is missing or invalid.
 - `CookingTime`: from `beer.cookingTime`.
 - `Rasten`: normalized fermentation steps excluding fixed process step types `Einmaischen`, `Abmaischen`, and `Kochen`, unless a step uses `executionMode: CONFIRMATION_HOLD`.
 
-Validation rejects missing/non-positive temperatures and timed rests without `time > 0`.
+Validation rejects missing/non-positive mash-in, mash-out, and rest temperatures and timed rests without `time > 0`; missing/invalid top-level cooking temperature is not rejected and maps to the UI fallback `99` °C.
 
 ## Brewing runtime status
 

--- a/src/utils/productionRecipe.test.ts
+++ b/src/utils/productionRecipe.test.ts
@@ -88,10 +88,14 @@ describe('productionRecipe mapping', () => {
     expect(result.brewingData?.Rasten[0]).not.toHaveProperty('time');
   });
 
-  it('rejects missing or invalid cooking fields', () => {
+  it('uses 99 °C as fallback for missing or invalid cooking temperature only', () => {
     const missingCookingTemp = mapBeerToBrewingData(makeBeer({ cookingTemperatur: null as unknown as number }));
-    expect(missingCookingTemp.ok).toBe(false);
-    expect(missingCookingTemp.error).toContain('Kochtemperatur');
+    expect(missingCookingTemp.ok).toBe(true);
+    expect(missingCookingTemp.brewingData?.CookingTemperature).toBe(99);
+
+    const invalidCookingTemp = mapBeerToBrewingData(makeBeer({ cookingTemperatur: 0 }));
+    expect(invalidCookingTemp.ok).toBe(true);
+    expect(invalidCookingTemp.brewingData?.CookingTemperature).toBe(99);
 
     const invalidCookingTime = mapBeerToBrewingData(makeBeer({ cookingTime: 0 }));
     expect(invalidCookingTime.ok).toBe(false);

--- a/src/utils/productionRecipe.ts
+++ b/src/utils/productionRecipe.ts
@@ -4,6 +4,7 @@ import { RestExecutionMode } from '../enums/eRestExecutionMode';
 
 const isValidTemperature = (value: unknown) => typeof value === 'number' && Number.isFinite(value) && value > 0;
 const isValidTimedDuration = (value: unknown) => typeof value === 'number' && Number.isFinite(value) && value > 0;
+const FALLBACK_COOKING_TEMPERATURE_CELSIUS = 99;
 
 export interface ProductionRecipeNormalizationResult {
   ok: boolean;
@@ -59,9 +60,9 @@ export function mapBeerToBrewingData(beer: Beer): ProductionRecipeNormalizationR
   if (!isValidTimedDuration(beer.cookingTime)) {
     return { ok: false, error: 'Kochzeit fehlt oder ist ungültig.' };
   }
-  if (!isValidTemperature(beer.cookingTemperatur)) {
-    return { ok: false, error: 'Kochtemperatur fehlt oder ist ungültig.' };
-  }
+  const cookingTemperature = isValidTemperature(beer.cookingTemperatur)
+    ? beer.cookingTemperatur
+    : FALLBACK_COOKING_TEMPERATURE_CELSIUS;
 
   const normalizedStepsResult = normalizeFermentationStepsForProduction(beer.fermentation);
   if (!normalizedStepsResult.ok) return normalizedStepsResult;
@@ -71,7 +72,7 @@ export function mapBeerToBrewingData(beer: Beer): ProductionRecipeNormalizationR
     brewingData: {
       MashdownTemperature: aus.temperature,
       MashupTemperature: ein.temperature,
-      CookingTemperature: beer.cookingTemperatur,
+      CookingTemperature: cookingTemperature,
       CookingTime: beer.cookingTime,
       Rasten: normalizedStepsResult.fermentationSteps ?? []
     }


### PR DESCRIPTION
### Motivation

- Avoid showing an error dialog or rejecting the production start when the top-level cooking temperature is missing or invalid by providing a safe UI-side default value. 
- Preserve existing validation for mash-in/mash-out/rest temperatures and cooking time so other recipe validations remain strict. 
- Document the UI behavior so the production mapping contract is explicit for cross-repo compatibility checks.

### Description

- Added `FALLBACK_COOKING_TEMPERATURE_CELSIUS = 99` and changed `mapBeerToBrewingData` in `src/utils/productionRecipe.ts` to use the fallback when `beer.cookingTemperatur` is missing or invalid instead of returning an error. 
- Kept cooking-time and mash in/out temperature validations unchanged so only the top-level cooking temperature is treated with a fallback. 
- Updated the unit test in `src/utils/productionRecipe.test.ts` to assert that missing/invalid `cookingTemperatur` maps to `99` °C and that an invalid `cookingTime` still fails. 
- Updated Codex context docs `docs/codex/domain-model.md` and `docs/codex/data-flow.md` to record the UI-side `99` °C fallback behavior.

### Testing

- Ran `git diff --check` to validate whitespace and basic diff hygiene which passed. 
- Updated the unit test `src/utils/productionRecipe.test.ts` to cover the fallback behavior, but running `npm test -- --runTestsByPath src/utils/productionRecipe.test.ts --watchAll=false` was blocked by missing project dependencies and environment setup. 
- Attempted `npm ci` to install dependencies but it failed due to registry access errors (`403` for `@types/react`), so automated test execution could not be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a50e2e41fa4832f909905bbc522c3f4)