### PR TITLE
Invoke sendBrewingData when starting brewing process

### DIFF
--- a/src/containers/Production/Production.tsx
+++ b/src/containers/Production/Production.tsx
@@ -315,6 +315,7 @@ class Production extends React.Component<ProductionProps, ProductionState> {
         }
         this.setState({brewingIsRunning: true});
         console.log('Starting brewing with data:', result.brewingData);
+        sendBrewingData(result.brewingData);
     }
 
     startPolling = () => {


### PR DESCRIPTION
### Motivation

- Ensure the brewing process actually sends the prepared brewing payload to the backend by calling the provided `sendBrewingData` prop after mapping the selected beer to brewing data.

### Description

- Add a call to `sendBrewingData(result.brewingData)` inside `startBrewing` after validation and setting `brewingIsRunning` to `true` so the mapped payload is transmitted.

### Testing

- Ran the project's unit test suite with `yarn test` and the tests passed. 
- Ran TypeScript compilation with `tsc --noEmit` and it completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a50e6f1da5c832f8ccc51fcc0d7daa3)