### PR TITLE
Fix ProcessList active step mapping

### DIFF
--- a/src/containers/Production/ProcessList/ProcessList.test.tsx
+++ b/src/containers/Production/ProcessList/ProcessList.test.tsx
@@ -1,0 +1,116 @@
+import React from 'react';
+import {render, screen} from '@testing-library/react';
+import '@testing-library/jest-dom';
+import {Beer} from '../../../model/Beer';
+import {createProcessSteps, getActiveProcessStepIndex, ProcessList} from './ProcessList';
+
+const selectedBeer = {
+    id: 'beer-1',
+    name: 'Testbier',
+    type: 'Ale',
+    color: 'gold',
+    alcohol: 5,
+    originalwort: 12,
+    bitterness: 20,
+    description: '',
+    rating: 0,
+    mashVolume: 20,
+    spargeVolume: 10,
+    cookingTime: 60,
+    cookingTemperatur: 100,
+    fermentation: [
+        {type: 'Einmaischen', temperature: 57},
+        {type: 'Rast 1', temperature: 63, time: 900},
+        {type: 'Rast 2', temperature: 68, time: 900},
+        {type: 'Rast 3', temperature: 72, time: 900},
+        {type: 'Abmaischen', temperature: 78},
+    ],
+    malts: [],
+    wortBoiling: {totalTime: 60, hops: []},
+    fermentationMaturation: {fermentationTemperature: 20, carbonation: 5, yeast: []},
+} as Beer;
+
+const getActiveStepText = (controlStepIndex: number) => {
+    const {container} = render(<ProcessList selectedBeer={selectedBeer} currentStepIndex={controlStepIndex} />);
+    return container.querySelector('li.active')?.textContent;
+};
+
+describe('ProcessList current-step mapping', () => {
+    it('builds visible process rows with 1-based control indices only on recipe steps', () => {
+        expect(createProcessSteps(selectedBeer).map(step => `${step.controlStepIndex ?? '-'}:${step.name}`)).toEqual([
+            '-:Aufheizen für Einmaischen -> 57°C',
+            '1:Einmaischen',
+            '-:Aufheizen für Rast 1 -> 63°C',
+            '2:Rast 1',
+            '-:Aufheizen für Rast 2 -> 68°C',
+            '3:Rast 2',
+            '-:Aufheizen für Rast 3 -> 72°C',
+            '4:Rast 3',
+            '-:Jod Probe',
+            '-:Aufheizen für Abmaischen -> 78°C',
+            '5:Abmaischen',
+            '-:Aufheizen auf Kochen',
+            '6:Kochen',
+        ]);
+    });
+
+    it.each([
+        [1, 'Einmaischen'],
+        [2, 'Rast 1'],
+        [3, 'Rast 2'],
+        [4, 'Rast 3'],
+    ])('marks control step %i as %s', (controlStepIndex, expectedStep) => {
+        expect(getActiveStepText(controlStepIndex)).toContain(expectedStep);
+    });
+
+    it('keeps heating and timer-running modes on the same list entry because mode is not part of the mapping', () => {
+        const steps = createProcessSteps(selectedBeer);
+        const rast1HeatingIndex = getActiveProcessStepIndex(steps, 2);
+        const rast1TimerRunningIndex = getActiveProcessStepIndex(steps, 2);
+        const rast2HeatingIndex = getActiveProcessStepIndex(steps, 3);
+        const rast2TimerRunningIndex = getActiveProcessStepIndex(steps, 3);
+        const rast3HeatingIndex = getActiveProcessStepIndex(steps, 4);
+
+        expect(steps[rast1HeatingIndex].name).toBe('Rast 1');
+        expect(rast1TimerRunningIndex).toBe(rast1HeatingIndex);
+        expect(steps[rast2HeatingIndex].name).toBe('Rast 2');
+        expect(rast2TimerRunningIndex).toBe(rast2HeatingIndex);
+        expect(steps[rast3HeatingIndex].name).toBe('Rast 3');
+    });
+
+    it('does not treat the 1-based control index as the 0-based React array index', () => {
+        const steps = createProcessSteps(selectedBeer);
+
+        expect(getActiveProcessStepIndex(steps, 4)).toBe(7);
+        expect(steps[4].name).not.toBe('Rast 3');
+    });
+
+    it('updates the active marker when the reported control step changes', () => {
+        const {container, rerender} = render(<ProcessList selectedBeer={selectedBeer} currentStepIndex={2} />);
+        expect(container.querySelector('li.active')).toHaveTextContent('Rast 1');
+
+        rerender(<ProcessList selectedBeer={selectedBeer} currentStepIndex={2} />);
+        expect(container.querySelector('li.active')).toHaveTextContent('Rast 1');
+
+        rerender(<ProcessList selectedBeer={selectedBeer} currentStepIndex={3} />);
+        expect(container.querySelector('li.active')).toHaveTextContent('Rast 2');
+
+        rerender(<ProcessList selectedBeer={selectedBeer} currentStepIndex={3} />);
+        expect(container.querySelector('li.active')).toHaveTextContent('Rast 2');
+
+        rerender(<ProcessList selectedBeer={selectedBeer} currentStepIndex={4} />);
+        expect(container.querySelector('li.active')).toHaveTextContent('Rast 3');
+        expect(container.querySelector('li.active')).not.toHaveTextContent('Rast 2');
+    });
+
+    it('renders all expected rows', () => {
+        render(<ProcessList selectedBeer={selectedBeer} currentStepIndex={1} />);
+
+        expect(screen.getAllByText(/Einmaischen/).length).toBeGreaterThan(0);
+        expect(screen.getAllByText(/Rast 1/).length).toBeGreaterThan(0);
+        expect(screen.getAllByText(/Rast 2/).length).toBeGreaterThan(0);
+        expect(screen.getAllByText(/Rast 3/).length).toBeGreaterThan(0);
+        expect(screen.getAllByText(/Abmaischen/).length).toBeGreaterThan(0);
+        expect(screen.getAllByText(/Kochen/).length).toBeGreaterThan(0);
+    });
+});

--- a/src/containers/Production/ProcessList/ProcessList.tsx
+++ b/src/containers/Production/ProcessList/ProcessList.tsx
@@ -7,11 +7,18 @@ import {RestExecutionMode} from "../../../enums/eRestExecutionMode";
 
 export interface ProcessStep {
     name: string;
+    /**
+     * 1-based index reported by the PI control in brewingStatus.currentStep.index.
+     * Display-only helper rows, e.g. heat-up rows, deliberately do not get a
+     * control step index and are therefore never highlighted as the active
+     * recipe step.
+     */
+    controlStepIndex?: number;
 }
 
 interface ProcessListProps {
     selectedBeer: Beer;
-    currentStepIndex: number; // 0-based
+    currentStepIndex: number; // 1-based PI-control currentStep.index
     onNextStep?: () => void;
 }
 
@@ -34,13 +41,13 @@ export class ProcessList extends React.Component<ProcessListProps, ProcessListSt
         this.simpleBarRef = React.createRef();
     }
 
-    // Welcher Index soll wirklich verwendet werden? (Test oder echter)
+    // Welcher UI-Array-Index soll wirklich verwendet werden? (Test oder echter)
     get effectiveStepIndex(): number {
-        return this.state.testStepIndex ?? this.props.currentStepIndex;
+        return this.state.testStepIndex ?? getActiveProcessStepIndex(createProcessSteps(this.props.selectedBeer), this.props.currentStepIndex);
     }
 
     componentDidUpdate(prevProps: ProcessListProps, prevState: ProcessListState) {
-        const prevIndex = prevState.testStepIndex ?? prevProps.currentStepIndex;
+        const prevIndex = prevState.testStepIndex ?? getActiveProcessStepIndex(createProcessSteps(prevProps.selectedBeer), prevProps.currentStepIndex);
         const newIndex = this.effectiveStepIndex;
 
         if (
@@ -71,7 +78,7 @@ export class ProcessList extends React.Component<ProcessListProps, ProcessListSt
         const steps = createProcessSteps(this.props.selectedBeer);
 
         this.setState(prev => {
-            const baseIndex = prev.testStepIndex ?? this.props.currentStepIndex;
+            const baseIndex = prev.testStepIndex ?? getActiveProcessStepIndex(steps, this.props.currentStepIndex);
             const next = baseIndex + 1;
             return { testStepIndex: next >= steps.length ? 0 : next };
         });
@@ -148,12 +155,13 @@ export function createProcessSteps(selectedBeer: Beer): ProcessStep[] {
     }
 
     const fermentation = selectedBeer.fermentation;
+    let controlStepIndex = 1;
 
     // Einmaischen
     const einmaischen = fermentation.find(step => step.type === 'Einmaischen');
     if (einmaischen) {
         processSteps.push({ name: `Aufheizen für Einmaischen -> ${einmaischen.temperature}°C` });
-        processSteps.push({ name: 'Einmaischen' });
+        processSteps.push({ name: 'Einmaischen', controlStepIndex: controlStepIndex++ });
     }
 
     let lastRastIndex = -1;
@@ -164,7 +172,7 @@ export function createProcessSteps(selectedBeer: Beer): ProcessStep[] {
         const isConfirmationHold = (step.executionMode ?? RestExecutionMode.TIMED) === RestExecutionMode.CONFIRMATION_HOLD;
         if (isRastName || isConfirmationHold) {
             processSteps.push({ name: `Aufheizen für ${step.type} -> ${step.temperature}°C` });
-            processSteps.push({ name: step.type });
+            processSteps.push({ name: step.type, controlStepIndex: controlStepIndex++ });
             lastRastIndex = processSteps.length - 1;
         }
     });
@@ -178,12 +186,17 @@ export function createProcessSteps(selectedBeer: Beer): ProcessStep[] {
     const abmaischen = fermentation.find(step => step.type === 'Abmaischen');
     if (abmaischen) {
         processSteps.push({ name: `Aufheizen für Abmaischen -> ${abmaischen.temperature}°C` });
-        processSteps.push({ name: 'Abmaischen' });
+        processSteps.push({ name: 'Abmaischen', controlStepIndex: controlStepIndex++ });
     }
 
     // Kochen
     processSteps.push({ name: 'Aufheizen auf Kochen' });
-    processSteps.push({ name: 'Kochen' });
+    processSteps.push({ name: 'Kochen', controlStepIndex: controlStepIndex++ });
 
     return processSteps;
+}
+
+export function getActiveProcessStepIndex(processSteps: ProcessStep[], currentControlStepIndex: number): number {
+    const activeIndex = processSteps.findIndex(step => step.controlStepIndex === currentControlStepIndex);
+    return activeIndex >= 0 ? activeIndex : 0;
 }


### PR DESCRIPTION
### Motivation
- The UI highlighted the wrong active process step because it compared the PI-control `currentStep.index` directly to the React array index while the control index is 1-based and the UI list contains additional display-only rows (e.g. heat-up, Jod Probe). 
- The mode transitions (`HEATING` ↔ `TIMER_RUNNING`) of the same recipe step must not cause a different list entry to be selected. 

### Description
- Add an optional `controlStepIndex` to `ProcessStep` and assign 1-based control indices only to real recipe steps while leaving display-only helper rows unindexed in `createProcessSteps(...)`. 
- Introduce `getActiveProcessStepIndex(processSteps, currentControlStepIndex)` to translate the PI control's 1-based `currentStep.index` into the 0-based UI array index used for highlighting and scrolling. 
- Replace direct comparisons of the incoming `currentStepIndex` with the derived UI index by updating `effectiveStepIndex`, `componentDidUpdate` and the test-step advancement logic. 
- Files changed: `src/containers/Production/ProcessList/ProcessList.tsx`; tests added: `src/containers/Production/ProcessList/ProcessList.test.tsx`. 

### Testing
- Added unit tests in `src/containers/Production/ProcessList/ProcessList.test.tsx` exercising Einmaischen, Rast 1/2/3, the 1-based control → 0-based UI mapping, mode-stable highlighting, and status-sequence updates. 
- Attempted to run `npm test -- --watchAll=false --runTestsByPath src/containers/Production/ProcessList/ProcessList.test.tsx`, but test execution failed in this environment (exit code 1) because dependency installation and `react-scripts` execution could not be completed. 
- `npm ci` initially failed due to peer-dependency conflicts; `npm ci --legacy-peer-deps` / installation attempts were performed in this environment but full test runs remained unsuccessful for environment/dependency reasons. 
- Static checks during staging (`git diff --cached --check`) showed no errors and the new/modified files are included for CI to run the test suite in a properly provisioned environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5295f3c7f4832fb2bad3fbbf24826e)