### PR TITLE
ProcessList: add mode-aware control-step mapping and tests

### DIFF
--- a/src/containers/Production/ProcessList/ProcessList.test.tsx
+++ b/src/containers/Production/ProcessList/ProcessList.test.tsx
@@ -1,0 +1,148 @@
+import React from 'react';
+import {render, screen} from '@testing-library/react';
+import '@testing-library/jest-dom';
+import {Beer} from '../../../model/Beer';
+import {ProcessMode, ProcessPhase} from '../../../model/brewingStatus.types';
+import {createProcessSteps, CurrentProcessStep, getActiveProcessStepIndex, ProcessList} from './ProcessList';
+
+const selectedBeer = {
+    id: 'beer-1',
+    name: 'Testbier',
+    type: 'Ale',
+    color: 'gold',
+    alcohol: 5,
+    originalwort: 12,
+    bitterness: 20,
+    description: '',
+    rating: 0,
+    mashVolume: 20,
+    spargeVolume: 10,
+    cookingTime: 60,
+    cookingTemperatur: 100,
+    fermentation: [
+        {type: 'Einmaischen', temperature: 57},
+        {type: 'Rast 1', temperature: 63, time: 900},
+        {type: 'Rast 2', temperature: 68, time: 900},
+        {type: 'Rast 3', temperature: 72, time: 900},
+        {type: 'Abmaischen', temperature: 78},
+    ],
+    malts: [],
+    wortBoiling: {totalTime: 60, hops: []},
+    fermentationMaturation: {fermentationTemperature: 20, carbonation: 5, yeast: []},
+} as Beer;
+
+const makeCurrentStep = (index: number, mode: ProcessMode, name: string): CurrentProcessStep => ({
+    index,
+    phase: ProcessPhase.RAST,
+    mode,
+    name,
+});
+
+const getActiveItems = (container: HTMLElement) => Array.from(container.querySelectorAll('li.active'));
+
+const getActiveStepText = (currentStep: CurrentProcessStep) => {
+    const {container} = render(<ProcessList selectedBeer={selectedBeer} currentStep={currentStep} />);
+    return container.querySelector('li.active')?.textContent;
+};
+
+describe('ProcessList current-step mapping', () => {
+    it('builds visible process rows with shared 1-based control indices for rest heat-up and rest process rows', () => {
+        expect(createProcessSteps(selectedBeer).map(step => `${step.controlStepIndex ?? '-'}:${step.name}`)).toEqual([
+            '-:Aufheizen für Einmaischen -> 57°C',
+            '1:Einmaischen',
+            '2:Aufheizen für Rast 1 -> 63°C',
+            '2:Rast 1',
+            '3:Aufheizen für Rast 2 -> 68°C',
+            '3:Rast 2',
+            '4:Aufheizen für Rast 3 -> 72°C',
+            '4:Rast 3',
+            '-:Jod Probe',
+            '-:Aufheizen für Abmaischen -> 78°C',
+            '5:Abmaischen',
+            '-:Aufheizen auf Kochen',
+            '6:Kochen',
+        ]);
+    });
+
+    it.each([
+        [1, 'Einmaischen'],
+        [2, 'Rast 1'],
+        [3, 'Rast 2'],
+        [4, 'Rast 3'],
+    ])('marks control step %i as %s', (controlStepIndex, expectedStep) => {
+        expect(getActiveStepText({index: controlStepIndex, phase: ProcessPhase.RAST, mode: ProcessMode.TIMER_RUNNING, name: expectedStep})).toContain(expectedStep);
+    });
+
+    it('uses the mode to choose between the heat-up row and the running rest row for the same control index', () => {
+        const steps = createProcessSteps(selectedBeer);
+        const rast2RunningIndex = getActiveProcessStepIndex(steps, makeCurrentStep(3, ProcessMode.TIMER_RUNNING, 'Rast 2'));
+        const rast3HeatingIndex = getActiveProcessStepIndex(steps, makeCurrentStep(4, ProcessMode.HEATING, 'Rast 3'));
+        const rast3RunningIndex = getActiveProcessStepIndex(steps, makeCurrentStep(4, ProcessMode.TIMER_RUNNING, 'Rast 3'));
+
+        expect(steps[rast2RunningIndex].name).toBe('Rast 2');
+        expect(steps[rast3HeatingIndex].name).toContain('Aufheizen für Rast 3');
+        expect(steps[rast3RunningIndex].name).toBe('Rast 3');
+        expect(rast3RunningIndex).not.toBe(rast3HeatingIndex);
+    });
+
+    it('does not treat the 1-based control index as the 0-based React array index', () => {
+        const steps = createProcessSteps(selectedBeer);
+
+        expect(getActiveProcessStepIndex(steps, makeCurrentStep(4, ProcessMode.TIMER_RUNNING, 'Rast 3'))).toBe(7);
+        expect(steps[4].name).not.toBe('Rast 3');
+    });
+
+    it('updates the active marker when the reported control step changes', () => {
+        const {container, rerender} = render(<ProcessList selectedBeer={selectedBeer} currentStep={makeCurrentStep(2, ProcessMode.TIMER_RUNNING, 'Rast 1')} />);
+        expect(container.querySelector('li.active')).toHaveTextContent('Rast 1');
+        expect(getActiveItems(container)).toHaveLength(1);
+
+        rerender(<ProcessList selectedBeer={selectedBeer} currentStep={makeCurrentStep(2, ProcessMode.TIMER_RUNNING, 'Rast 1')} />);
+        expect(container.querySelector('li.active')).toHaveTextContent('Rast 1');
+
+        rerender(<ProcessList selectedBeer={selectedBeer} currentStep={makeCurrentStep(3, ProcessMode.TIMER_RUNNING, 'Rast 2')} />);
+        expect(container.querySelector('li.active')).toHaveTextContent('Rast 2');
+
+        rerender(<ProcessList selectedBeer={selectedBeer} currentStep={makeCurrentStep(4, ProcessMode.HEATING, 'Rast 3')} />);
+        expect(container.querySelector('li.active')).toHaveTextContent('Aufheizen für Rast 3');
+        expect(container.querySelector('li.active')).not.toHaveTextContent(/^8\.\s+Rast 3$/);
+        expect(getActiveItems(container)).toHaveLength(1);
+
+        rerender(<ProcessList selectedBeer={selectedBeer} currentStep={makeCurrentStep(4, ProcessMode.TIMER_RUNNING, 'Rast 3')} />);
+        expect(container.querySelector('li.active')).toHaveTextContent(/^8\.\s+Rast 3$/);
+        expect(container.querySelector('li.active')).not.toHaveTextContent('Aufheizen für Rast 3');
+        expect(container.querySelector('li.active')).not.toHaveTextContent('Rast 2');
+        expect(getActiveItems(container)).toHaveLength(1);
+    });
+
+    it('moves the active marker when only the mode changes and the control index stays the same', () => {
+        const {container, rerender} = render(<ProcessList selectedBeer={selectedBeer} currentStep={makeCurrentStep(4, ProcessMode.HEATING, 'Rast 3')} />);
+        expect(container.querySelector('li.active')).toHaveTextContent('Aufheizen für Rast 3');
+        expect(getActiveItems(container)).toHaveLength(1);
+
+        rerender(<ProcessList selectedBeer={selectedBeer} currentStep={makeCurrentStep(4, ProcessMode.TIMER_RUNNING, 'Rast 3')} />);
+        expect(container.querySelector('li.active')).toHaveTextContent(/^8\.\s+Rast 3$/);
+        expect(container.querySelector('li.active')).not.toHaveTextContent('Aufheizen für Rast 3');
+        expect(getActiveItems(container)).toHaveLength(1);
+    });
+
+    it('keeps non-rest phases mapped to their existing process rows', () => {
+        const steps = createProcessSteps(selectedBeer);
+
+        expect(steps[getActiveProcessStepIndex(steps, {index: 1, phase: ProcessPhase.MASHING_IN, mode: ProcessMode.HEATING, name: 'Einmaischen'})].name).toBe('Einmaischen');
+        expect(steps[getActiveProcessStepIndex(steps, {index: 5, phase: ProcessPhase.MASHING_OUT, mode: ProcessMode.HEATING, name: 'Abmaischen'})].name).toBe('Abmaischen');
+        expect(steps[getActiveProcessStepIndex(steps, {index: 6, phase: ProcessPhase.COOKING, mode: ProcessMode.HEATING, name: 'Kochen'})].name).toBe('Kochen');
+        expect(steps[getActiveProcessStepIndex(steps, {index: 4, phase: ProcessPhase.RAST, mode: ProcessMode.WAITING, name: 'Rast 3'})].name).toBe('Rast 3');
+    });
+
+    it('renders all expected rows', () => {
+        render(<ProcessList selectedBeer={selectedBeer} currentStep={{index: 1, phase: ProcessPhase.MASHING_IN, mode: ProcessMode.HEATING, name: 'Einmaischen'}} />);
+
+        expect(screen.getAllByText(/Einmaischen/).length).toBeGreaterThan(0);
+        expect(screen.getAllByText(/Rast 1/).length).toBeGreaterThan(0);
+        expect(screen.getAllByText(/Rast 2/).length).toBeGreaterThan(0);
+        expect(screen.getAllByText(/Rast 3/).length).toBeGreaterThan(0);
+        expect(screen.getAllByText(/Abmaischen/).length).toBeGreaterThan(0);
+        expect(screen.getAllByText(/Kochen/).length).toBeGreaterThan(0);
+    });
+});

--- a/src/containers/Production/ProcessList/ProcessList.tsx
+++ b/src/containers/Production/ProcessList/ProcessList.tsx
@@ -4,14 +4,36 @@ import 'simplebar-react/dist/simplebar.min.css';
 import './ProcessList.css';
 import {Beer, FermentationSteps} from "../../../model/Beer";
 import {RestExecutionMode} from "../../../enums/eRestExecutionMode";
+import {ProcessMode, ProcessPhase} from "../../../model/brewingStatus.types";
+
+export enum ProcessListEntryType {
+    HEATING = "HEATING",
+    PROCESS = "PROCESS",
+    DISPLAY = "DISPLAY"
+}
+
+export interface CurrentProcessStep {
+    index?: number;
+    phase?: ProcessPhase;
+    mode?: ProcessMode;
+    name?: string;
+}
 
 export interface ProcessStep {
     name: string;
+    /**
+     * 1-based index reported by the PI control in brewingStatus.currentStep.index.
+     * Heating and process rows for the same recipe step can share this index;
+     * entryType/phase then decide which UI row is active for the current mode.
+     */
+    controlStepIndex?: number;
+    phase?: ProcessPhase;
+    entryType: ProcessListEntryType;
 }
 
-interface ProcessListProps {
+export interface ProcessListProps {
     selectedBeer: Beer;
-    currentStepIndex: number; // 0-based
+    currentStep: CurrentProcessStep;
     onNextStep?: () => void;
 }
 
@@ -34,13 +56,13 @@ export class ProcessList extends React.Component<ProcessListProps, ProcessListSt
         this.simpleBarRef = React.createRef();
     }
 
-    // Welcher Index soll wirklich verwendet werden? (Test oder echter)
+    // Welcher UI-Array-Index soll wirklich verwendet werden? (Test oder echter)
     get effectiveStepIndex(): number {
-        return this.state.testStepIndex ?? this.props.currentStepIndex;
+        return this.state.testStepIndex ?? getActiveProcessStepIndex(createProcessSteps(this.props.selectedBeer), this.props.currentStep);
     }
 
     componentDidUpdate(prevProps: ProcessListProps, prevState: ProcessListState) {
-        const prevIndex = prevState.testStepIndex ?? prevProps.currentStepIndex;
+        const prevIndex = prevState.testStepIndex ?? getActiveProcessStepIndex(createProcessSteps(prevProps.selectedBeer), prevProps.currentStep);
         const newIndex = this.effectiveStepIndex;
 
         if (
@@ -71,7 +93,7 @@ export class ProcessList extends React.Component<ProcessListProps, ProcessListSt
         const steps = createProcessSteps(this.props.selectedBeer);
 
         this.setState(prev => {
-            const baseIndex = prev.testStepIndex ?? this.props.currentStepIndex;
+            const baseIndex = prev.testStepIndex ?? getActiveProcessStepIndex(steps, this.props.currentStep);
             const next = baseIndex + 1;
             return { testStepIndex: next >= steps.length ? 0 : next };
         });
@@ -148,12 +170,13 @@ export function createProcessSteps(selectedBeer: Beer): ProcessStep[] {
     }
 
     const fermentation = selectedBeer.fermentation;
+    let controlStepIndex = 1;
 
     // Einmaischen
     const einmaischen = fermentation.find(step => step.type === 'Einmaischen');
     if (einmaischen) {
-        processSteps.push({ name: `Aufheizen für Einmaischen -> ${einmaischen.temperature}°C` });
-        processSteps.push({ name: 'Einmaischen' });
+        processSteps.push({ name: `Aufheizen für Einmaischen -> ${einmaischen.temperature}°C`, entryType: ProcessListEntryType.HEATING });
+        processSteps.push({ name: 'Einmaischen', controlStepIndex: controlStepIndex++, phase: ProcessPhase.MASHING_IN, entryType: ProcessListEntryType.PROCESS });
     }
 
     let lastRastIndex = -1;
@@ -163,27 +186,56 @@ export function createProcessSteps(selectedBeer: Beer): ProcessStep[] {
         const isRastName = /^Rast\s*\d+$/i.test(step.type);
         const isConfirmationHold = (step.executionMode ?? RestExecutionMode.TIMED) === RestExecutionMode.CONFIRMATION_HOLD;
         if (isRastName || isConfirmationHold) {
-            processSteps.push({ name: `Aufheizen für ${step.type} -> ${step.temperature}°C` });
-            processSteps.push({ name: step.type });
+            processSteps.push({ name: `Aufheizen für ${step.type} -> ${step.temperature}°C`, controlStepIndex, phase: ProcessPhase.RAST, entryType: ProcessListEntryType.HEATING });
+            processSteps.push({ name: step.type, controlStepIndex: controlStepIndex++, phase: ProcessPhase.RAST, entryType: ProcessListEntryType.PROCESS });
             lastRastIndex = processSteps.length - 1;
         }
     });
 
     // Jod-Probe nach letzter Rast
     if (lastRastIndex !== -1) {
-        processSteps.splice(lastRastIndex + 1, 0, { name: 'Jod Probe' });
+        processSteps.splice(lastRastIndex + 1, 0, { name: 'Jod Probe', entryType: ProcessListEntryType.DISPLAY });
     }
 
     // Abmaischen
     const abmaischen = fermentation.find(step => step.type === 'Abmaischen');
     if (abmaischen) {
-        processSteps.push({ name: `Aufheizen für Abmaischen -> ${abmaischen.temperature}°C` });
-        processSteps.push({ name: 'Abmaischen' });
+        processSteps.push({ name: `Aufheizen für Abmaischen -> ${abmaischen.temperature}°C`, entryType: ProcessListEntryType.HEATING });
+        processSteps.push({ name: 'Abmaischen', controlStepIndex: controlStepIndex++, phase: ProcessPhase.MASHING_OUT, entryType: ProcessListEntryType.PROCESS });
     }
 
     // Kochen
-    processSteps.push({ name: 'Aufheizen auf Kochen' });
-    processSteps.push({ name: 'Kochen' });
+    processSteps.push({ name: 'Aufheizen auf Kochen', entryType: ProcessListEntryType.HEATING });
+    processSteps.push({ name: 'Kochen', controlStepIndex: controlStepIndex++, phase: ProcessPhase.COOKING, entryType: ProcessListEntryType.PROCESS });
 
     return processSteps;
+}
+
+export function getActiveProcessStepIndex(processSteps: ProcessStep[], currentStep: CurrentProcessStep): number {
+    const currentControlStepIndex = currentStep.index;
+    if (typeof currentControlStepIndex !== 'number') {
+        return 0;
+    }
+
+    const expectedEntryType =
+        currentStep.phase === ProcessPhase.RAST && currentStep.mode === ProcessMode.HEATING
+            ? ProcessListEntryType.HEATING
+            : ProcessListEntryType.PROCESS;
+
+    const activeIndex = processSteps.findIndex(step =>
+        step.controlStepIndex === currentControlStepIndex &&
+        step.entryType === expectedEntryType &&
+        (!step.phase || !currentStep.phase || step.phase === currentStep.phase)
+    );
+
+    if (activeIndex >= 0) {
+        return activeIndex;
+    }
+
+    const fallbackIndex = processSteps.findIndex(step =>
+        step.controlStepIndex === currentControlStepIndex &&
+        step.entryType === ProcessListEntryType.PROCESS
+    );
+
+    return fallbackIndex >= 0 ? fallbackIndex : 0;
 }

--- a/src/containers/Production/Production.tsx
+++ b/src/containers/Production/Production.tsx
@@ -32,9 +32,7 @@ import {BackendAvailable} from "../../reducers/productionReducer";
 import {ProcessList, createProcessSteps} from "./ProcessList/ProcessList";
 import { dataCollector } from '../../utils/DataCollector/dataCollector';
 import {getBrewingStatusLabel} from "../../utils/brewingStatus/selectors";
-export interface ProcessStep {
-    name: string;
-}
+
 interface ProductionProps {
     selectedBeer: Beer;
     temperature: number;
@@ -622,10 +620,8 @@ class Production extends React.Component<ProductionProps, ProductionState> {
 
     renderProcessList() {
         const { selectedBeer, brewingStatus } = this.props;
-        // Fallback auf 0, falls brewingStatus oder brewingStatus.index nicht definiert ist
-        const currentStepIndex = brewingStatus && typeof brewingStatus.currentStep?.index === 'number' ? brewingStatus.currentStep.index : 0;
         return (
-            <ProcessList selectedBeer={selectedBeer} currentStepIndex={currentStepIndex} onNextStep={this.props.nextProcedureStep} />
+            <ProcessList selectedBeer={selectedBeer} currentStep={brewingStatus?.currentStep ?? {}} onNextStep={this.props.nextProcedureStep} />
         );
     }
 


### PR DESCRIPTION
### Motivation

- Make the UI mapping between PI-reported control step indices and the ProcessList rows deterministic and mode-aware so heating vs running-rest rows for the same recipe step can be selected correctly.  

### Description

- Introduce `ProcessListEntryType`, `CurrentProcessStep`, `createProcessSteps` enhancements and `controlStepIndex` to represent the 1-based control index on relevant rows and to tag rows with `entryType` and `phase`.  
- Implement `getActiveProcessStepIndex(processSteps, currentStep)` to pick the correct list index based on `currentStep.index`, `phase` and `mode` with a `PROCESS` fallback.  
- Change `ProcessList` to accept `currentStep: CurrentProcessStep` instead of a raw index, update `effectiveStepIndex` logic and update `componentDidUpdate` and `stepTestForward` to use `getActiveProcessStepIndex`.  
- Update `Production` to pass `brewingStatus?.currentStep ?? {}` into `ProcessList`.  
- Add a comprehensive test suite in `ProcessList.test.tsx` to validate control-index sharing, mode selection between heating vs running rows, correct array-index mapping, active marker updates on prop changes, and that all expected rows render.

### Testing

- Added `src/containers/Production/ProcessList/ProcessList.test.tsx` with multiple `@testing-library/react` tests exercising `createProcessSteps` and `getActiveProcessStepIndex` behavior.  
- Ran the unit test suite (`yarn test`) which includes the new `ProcessList` tests and they completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5295f3c7f4832fb2bad3fbbf24826e)