### PR TITLE
Fix ProcessList TypeScript errors and prop mismatch

### DIFF
--- a/src/containers/Production/ProcessList/ProcessList.tsx
+++ b/src/containers/Production/ProcessList/ProcessList.tsx
@@ -12,19 +12,6 @@ export enum ProcessListEntryType {
     DISPLAY = "DISPLAY"
 }
 
-export interface CurrentProcessStep {
-    index?: number;
-    phase?: ProcessPhase;
-    mode?: ProcessMode;
-    name?: string;
-}
-
-export enum ProcessListEntryType {
-    HEATING = "HEATING",
-    PROCESS = "PROCESS",
-    DISPLAY = "DISPLAY"
-}
-
 export interface ProcessListCurrentStep {
     index?: number;
     phase?: ProcessPhase;
@@ -34,6 +21,7 @@ export interface ProcessListCurrentStep {
 
 export interface ProcessListStep {
     name: string;
+    entryType?: ProcessListEntryType;
     /**
      * 1-based index reported by the PI control in brewingStatus.currentStep.index.
      * Display-only helper rows, e.g. heat-up rows, deliberately do not get a
@@ -223,7 +211,7 @@ export function createProcessSteps(selectedBeer: Beer): ProcessListStep[] {
     return processSteps;
 }
 
-export function getActiveProcessStepIndex(processSteps: ProcessStep[], currentControlStepIndex: number): number {
+export function getActiveProcessStepIndex(processSteps: ProcessListStep[], currentControlStepIndex: number): number {
     const activeIndex = processSteps.findIndex(step => step.controlStepIndex === currentControlStepIndex);
     return activeIndex >= 0 ? activeIndex : 0;
 }

--- a/src/containers/Production/Production.tsx
+++ b/src/containers/Production/Production.tsx
@@ -621,7 +621,7 @@ class Production extends React.Component<ProductionProps, ProductionState> {
     renderProcessList() {
         const { selectedBeer, brewingStatus } = this.props;
         return (
-            <ProcessList selectedBeer={selectedBeer} currentStep={brewingStatus?.currentStep ?? {}} onNextStep={this.props.nextProcedureStep} />
+            <ProcessList selectedBeer={selectedBeer} currentStepIndex={brewingStatus?.currentStep?.index ?? 0} onNextStep={this.props.nextProcedureStep} />
         );
     }
 


### PR DESCRIPTION
### Motivation
- Resolve TypeScript compilation errors caused by duplicated type declarations in the ProcessList component.
- Ensure the process-step generation and active-step lookup use consistent types so display-only rows (e.g. Jod Probe) are accepted.
- Align `Production` usage with the `ProcessList` prop contract by passing the PI control step index instead of the whole `currentStep` object.

### Description
- Removed the duplicate `ProcessListEntryType` enum and the obsolete `CurrentProcessStep` interface from `src/containers/Production/ProcessList/ProcessList.tsx`.
- Added `entryType?: ProcessListEntryType` to `ProcessListStep` so display-only entries can be represented (used for the inserted `Jod Probe` row).
- Fixed the helper signature from `ProcessStep[]` to `ProcessListStep[]` in `getActiveProcessStepIndex` to use the correct type.
- Updated `Production` to call `ProcessList` with `currentStepIndex={brewingStatus?.currentStep?.index ?? 0}` instead of passing `currentStep`, matching `ProcessListProps`.
- Modified files: `src/containers/Production/ProcessList/ProcessList.tsx` and `src/containers/Production/Production.tsx`.

### Testing
- Ran `git diff --check`, which reported no whitespace/patch errors.
- Attempted TypeScript check via `npx tsc --noEmit`, which could not complete due to deprecated `tsconfig` options and a system `tsc` version mismatch (TypeScript 6 diagnostics before project checking).
- Attempted local compile with `npm run build`, which exited with status `1` because project tooling (`react-scripts` / local build environment) could not be executed in this environment.
- Attempted dependency install with `npm ci`, which failed due to registry access returning HTTP 403 for `@types/react`, preventing a full install and project type-check/build.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a52a3892c70832f98848cd0c0e0d198)