### PR TITLE
Add recipe water-fill buttons (Hauptguss / Nachguss) to Production view

### DIFF
--- a/src/containers/Production/Production.css
+++ b/src/containers/Production/Production.css
@@ -248,3 +248,30 @@
 .GaugeContainer {
     padding: 1.1rem;
 }
+
+.recipeWaterButtons {
+    display: flex;
+    gap: 1rem;
+    justify-content: center;
+    margin-top: 0.75rem;
+}
+
+.recipeWaterBtn {
+    background-color: var(--color-surface-alt);
+    border: none;
+    border-radius: 0.5rem;
+    color: var(--color-white);
+    cursor: pointer;
+    font-size: 1rem;
+    min-width: 8rem;
+    padding: 0.5rem 1rem;
+}
+
+.recipeWaterBtn:hover:not(:disabled) {
+    background-color: var(--color-surface-alt-dark);
+}
+
+.recipeWaterBtn:disabled {
+    cursor: not-allowed;
+    opacity: 0.5;
+}

--- a/src/containers/Production/Production.test.tsx
+++ b/src/containers/Production/Production.test.tsx
@@ -1,0 +1,152 @@
+import React from 'react';
+import {render, screen, fireEvent, waitFor} from '@testing-library/react';
+import {Production} from './Production';
+import {Beer} from '../../model/Beer';
+import {ToggleState} from '../../enums/eToggleState';
+import {BrewingStatus, ProcessMode, ProcessPhase, ProcessState, WaitingFor} from '../../model/brewingStatus.types';
+
+const createBeer = (aMashVolume: number | undefined = 18, aSpargeVolume: number | undefined = 12, aId: string = '1'): Beer => ({
+    id: aId,
+    name: aId,
+    type: 'Pils',
+    color: 'Gold',
+    alcohol: 5,
+    originalwort: 12,
+    bitterness: 20,
+    description: '',
+    rating: 3,
+    mashVolume: aMashVolume as number,
+    spargeVolume: aSpargeVolume as number,
+    cookingTime: 60,
+    cookingTemperatur: 99,
+    fermentation: [],
+    malts: [],
+    wortBoiling: {hops: []},
+    fermentationMaturation: {yeast: []}
+});
+
+const createBrewingStatus = (aProcessState: ProcessState = ProcessState.ACTIVE): BrewingStatus => ({
+    elapsedTime: 0,
+    currentTime: 0,
+    process: {state: aProcessState},
+    currentStep: {
+        index: 0,
+        count: 0,
+        phase: ProcessPhase.NONE,
+        mode: ProcessMode.NONE,
+        name: '',
+        duration: 0,
+        elapsedTime: 0,
+        remainingTime: 0
+    },
+    temperature: {},
+    hardware: {},
+    waiting: {waitingFor: WaitingFor.NONE, canConfirm: false},
+    error: {}
+});
+
+const renderProduction = (aOverrides: Partial<React.ComponentProps<typeof Production>> = {}) => {
+    const props: React.ComponentProps<typeof Production> = {
+        selectedBeer: createBeer(),
+        temperature: 20,
+        currentAgitatorState: ToggleState.OFF,
+        currentAgitatorSpeed: 5,
+        agitatorSpeed: 5,
+        agitatorIsRunning: ToggleState.OFF,
+        getTemperatures: jest.fn(),
+        toggleAgitator: jest.fn(),
+        setAgitatorSpeed: jest.fn(),
+        startWaterFilling: jest.fn(),
+        isWaterFillingSuccessful: true,
+        isToggleAgitatorSuccess: true,
+        sendBrewingData: jest.fn(),
+        brewingStatus: createBrewingStatus(),
+        startPolling: jest.fn(),
+        stopPolling: jest.fn(),
+        isBackenAvailable: {isBackenAvailable: true, statusText: 'OK'},
+        waterStatus: {liters: 0, openClose: false},
+        addFinishedBrew: jest.fn(),
+        nextProcedureStep: jest.fn(),
+        ...aOverrides
+    };
+    return {props, ...render(<Production {...props} />)};
+};
+
+describe('Production recipe water filling', () => {
+    it('sends the recipe mash water volume when Hauptguss is clicked', () => {
+        const {props} = renderProduction({selectedBeer: createBeer(21, 9)});
+        fireEvent.click(screen.getByRole('button', {name: 'Hauptguss'}));
+        expect(props.startWaterFilling).toHaveBeenCalledWith(21);
+    });
+
+    it('sends the recipe sparge water volume when Nachguss is clicked', () => {
+        const {props} = renderProduction({selectedBeer: createBeer(21, 9)});
+        fireEvent.click(screen.getByRole('button', {name: 'Nachguss'}));
+        expect(props.startWaterFilling).toHaveBeenCalledWith(9);
+    });
+
+    it('disables both recipe water buttons while water filling is active', () => {
+        renderProduction({waterStatus: {liters: 3, openClose: true}});
+        expect(screen.getByRole('button', {name: 'Hauptguss'})).toBeDisabled();
+        expect(screen.getByRole('button', {name: 'Nachguss'})).toBeDisabled();
+    });
+
+    it('keeps Hauptguss disabled after completed mash water filling and leaves Nachguss available', () => {
+        const {rerender, props} = renderProduction({selectedBeer: createBeer(21, 9), waterStatus: {liters: 0, openClose: false}});
+        fireEvent.click(screen.getByRole('button', {name: 'Hauptguss'}));
+        rerender(<Production {...props} waterStatus={{liters: 2, openClose: true}} />);
+        rerender(<Production {...props} waterStatus={{liters: 21, openClose: false}} />);
+        expect(screen.getByRole('button', {name: 'Hauptguss'})).toBeDisabled();
+        expect(screen.getByRole('button', {name: 'Nachguss'})).not.toBeDisabled();
+    });
+
+    it('keeps Nachguss disabled after completed sparge water filling and leaves Hauptguss available', () => {
+        const {rerender, props} = renderProduction({selectedBeer: createBeer(21, 9), waterStatus: {liters: 0, openClose: false}});
+        fireEvent.click(screen.getByRole('button', {name: 'Nachguss'}));
+        rerender(<Production {...props} waterStatus={{liters: 2, openClose: true}} />);
+        rerender(<Production {...props} waterStatus={{liters: 9, openClose: false}} />);
+        expect(screen.getByRole('button', {name: 'Nachguss'})).toBeDisabled();
+        expect(screen.getByRole('button', {name: 'Hauptguss'})).not.toBeDisabled();
+    });
+
+    it('disables recipe water buttons with missing or invalid volumes', () => {
+        renderProduction({selectedBeer: createBeer(0, -1)});
+        expect(screen.getByRole('button', {name: 'Hauptguss'})).toBeDisabled();
+        expect(screen.getByRole('button', {name: 'Nachguss'})).toBeDisabled();
+    });
+
+    it('does not mark recipe water filling complete when the request fails before water starts', async () => {
+        const {rerender, props} = renderProduction({selectedBeer: createBeer(21, 9), waterStatus: {liters: 0, openClose: false}});
+        fireEvent.click(screen.getByRole('button', {name: 'Hauptguss'}));
+        rerender(<Production {...props} isWaterFillingSuccessful={false} waterStatus={{liters: 0, openClose: false}} />);
+        await waitFor(() => expect(screen.getByRole('button', {name: 'Hauptguss'})).not.toBeDisabled());
+    });
+
+    it('resets completed recipe water filling when the recipe changes', () => {
+        const {rerender, props} = renderProduction({selectedBeer: createBeer(21, 9, '1'), waterStatus: {liters: 0, openClose: false}});
+        fireEvent.click(screen.getByRole('button', {name: 'Hauptguss'}));
+        rerender(<Production {...props} waterStatus={{liters: 2, openClose: true}} />);
+        rerender(<Production {...props} waterStatus={{liters: 21, openClose: false}} />);
+        expect(screen.getByRole('button', {name: 'Hauptguss'})).toBeDisabled();
+        rerender(<Production {...props} selectedBeer={createBeer(22, 10, '2')} waterStatus={{liters: 0, openClose: false}} />);
+        expect(screen.getByRole('button', {name: 'Hauptguss'})).not.toBeDisabled();
+    });
+
+
+    it('resets completed recipe water filling when a new brew starts', () => {
+        const {rerender, props} = renderProduction({selectedBeer: createBeer(21, 9), waterStatus: {liters: 0, openClose: false}});
+        fireEvent.click(screen.getByRole('button', {name: 'Hauptguss'}));
+        rerender(<Production {...props} waterStatus={{liters: 2, openClose: true}} />);
+        rerender(<Production {...props} waterStatus={{liters: 21, openClose: false}} />);
+        expect(screen.getByRole('button', {name: 'Hauptguss'})).toBeDisabled();
+        fireEvent.click(screen.getByRole('button', {name: 'Start'}));
+        expect(screen.getByRole('button', {name: 'Hauptguss'})).not.toBeDisabled();
+    });
+
+    it('keeps the existing manual water filling control unchanged', () => {
+        const {props, container} = renderProduction({selectedBeer: createBeer(21, 9)});
+        const manualWaterSwitch = container.querySelector('.settingsRowWater input') as HTMLInputElement;
+        fireEvent.click(manualWaterSwitch);
+        expect(props.startWaterFilling).toHaveBeenCalledWith(0);
+    });
+});

--- a/src/containers/Production/Production.test.tsx
+++ b/src/containers/Production/Production.test.tsx
@@ -19,13 +19,16 @@ const createBeer = (aMashVolume: number | undefined = 18, aSpargeVolume: number 
     spargeVolume: aSpargeVolume as number,
     cookingTime: 60,
     cookingTemperatur: 99,
-    fermentation: [],
+    fermentation: [
+        {type: 'Einmaischen', temperature: 60},
+        {type: 'Abmaischen', temperature: 78}
+    ],
     malts: [],
     wortBoiling: {hops: []},
     fermentationMaturation: {yeast: []}
 });
 
-const createBrewingStatus = (aProcessState: ProcessState = ProcessState.ACTIVE): BrewingStatus => ({
+const createBrewingStatus = (aProcessState: ProcessState = ProcessState.IDLE): BrewingStatus => ({
     elapsedTime: 0,
     currentTime: 0,
     process: {state: aProcessState},
@@ -61,6 +64,7 @@ const renderProduction = (aOverrides: Partial<React.ComponentProps<typeof Produc
         isToggleAgitatorSuccess: true,
         sendBrewingData: jest.fn(),
         brewingStatus: createBrewingStatus(),
+        isPollingRunning: false,
         startPolling: jest.fn(),
         stopPolling: jest.fn(),
         isBackenAvailable: {isBackenAvailable: true, statusText: 'OK'},
@@ -71,6 +75,69 @@ const renderProduction = (aOverrides: Partial<React.ComponentProps<typeof Produc
     };
     return {props, ...render(<Production {...props} />)};
 };
+
+describe('Production start button', () => {
+
+    it('keeps the start button enabled when no brew is running', () => {
+        renderProduction({brewingStatus: createBrewingStatus(ProcessState.IDLE), isPollingRunning: false});
+        expect(screen.getByRole('button', {name: 'Start'})).not.toBeDisabled();
+    });
+
+    it('disables the start button while a brew is active', () => {
+        renderProduction({brewingStatus: createBrewingStatus(ProcessState.ACTIVE), isPollingRunning: false});
+        expect(screen.getByRole('button', {name: 'Start'})).toBeDisabled();
+    });
+
+    it('disables the start button while a start request is running', () => {
+        renderProduction({brewingStatus: createBrewingStatus(ProcessState.IDLE), isPollingRunning: true});
+        expect(screen.getByRole('button', {name: 'Start'})).toBeDisabled();
+    });
+
+    it('sends the brewing data only once for fast repeated start clicks', () => {
+        const {props} = renderProduction({brewingStatus: createBrewingStatus(ProcessState.IDLE), isPollingRunning: false});
+        const startButton = screen.getByRole('button', {name: 'Start'});
+        fireEvent.click(startButton);
+        fireEvent.click(startButton);
+        expect(props.sendBrewingData).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not send another start request when a brew is already active', () => {
+        const {props} = renderProduction({brewingStatus: createBrewingStatus(ProcessState.ACTIVE), isPollingRunning: false});
+        fireEvent.click(screen.getByRole('button', {name: 'Start'}));
+        expect(props.sendBrewingData).not.toHaveBeenCalled();
+    });
+
+    it('enables the start button again after finished, aborted, reset, or failed idle states', () => {
+        const {rerender, props} = renderProduction({brewingStatus: createBrewingStatus(ProcessState.ACTIVE), isPollingRunning: true});
+        expect(screen.getByRole('button', {name: 'Start'})).toBeDisabled();
+        rerender(<Production {...props} brewingStatus={createBrewingStatus(ProcessState.FINISHED)} isPollingRunning={false} />);
+        expect(screen.getByRole('button', {name: 'Start'})).not.toBeDisabled();
+        rerender(<Production {...props} brewingStatus={createBrewingStatus(ProcessState.ABORTED)} isPollingRunning={false} />);
+        expect(screen.getByRole('button', {name: 'Start'})).not.toBeDisabled();
+        rerender(<Production {...props} brewingStatus={createBrewingStatus(ProcessState.IDLE)} isPollingRunning={false} />);
+        expect(screen.getByRole('button', {name: 'Start'})).not.toBeDisabled();
+        rerender(<Production {...props} brewingStatus={createBrewingStatus(ProcessState.IDLE)} isPollingRunning={false} />);
+        expect(screen.getByRole('button', {name: 'Start'})).not.toBeDisabled();
+    });
+
+
+    it('enables the start button again after a failed start request without active control status', () => {
+        const {rerender, props} = renderProduction({brewingStatus: createBrewingStatus(ProcessState.IDLE), isPollingRunning: false});
+        fireEvent.click(screen.getByRole('button', {name: 'Start'}));
+        expect(screen.getByRole('button', {name: 'Start'})).toBeDisabled();
+        rerender(<Production {...props} brewingStatus={createBrewingStatus(ProcessState.IDLE)} isPollingRunning={true} />);
+        expect(screen.getByRole('button', {name: 'Start'})).toBeDisabled();
+        rerender(<Production {...props} brewingStatus={createBrewingStatus(ProcessState.IDLE)} isPollingRunning={false} />);
+        expect(screen.getByRole('button', {name: 'Start'})).not.toBeDisabled();
+    });
+
+    it('keeps the existing recipe transfer and start flow unchanged', () => {
+        const {props} = renderProduction({brewingStatus: createBrewingStatus(ProcessState.IDLE), isPollingRunning: false});
+        fireEvent.click(screen.getByRole('button', {name: 'Start'}));
+        expect(props.sendBrewingData).toHaveBeenCalledTimes(1);
+    });
+
+});
 
 describe('Production recipe water filling', () => {
     it('sends the recipe mash water volume when Hauptguss is clicked', () => {

--- a/src/containers/Production/Production.tsx
+++ b/src/containers/Production/Production.tsx
@@ -31,7 +31,7 @@ import {eBrewState} from "../../enums/eBrewState";
 import {BackendAvailable} from "../../reducers/productionReducer";
 import {ProcessList, createProcessSteps} from "./ProcessList/ProcessList";
 import { dataCollector } from '../../utils/DataCollector/dataCollector';
-import {getBrewingStatusLabel} from "../../utils/brewingStatus/selectors";
+import {getBrewingStatusLabel, isProcessActive} from "../../utils/brewingStatus/selectors";
 
 export interface ProductionProps {
     selectedBeer: Beer;
@@ -54,6 +54,7 @@ export interface ProductionProps {
     waterStatus: WaterStatus;
     addFinishedBrew: (finishedBrew: FinishedBrew) => void;
     nextProcedureStep: () => void;
+    isPollingRunning: boolean;
 }
 
 type RecipeWaterFill = 'mash' | 'sparge';
@@ -92,6 +93,7 @@ export class Production extends React.Component<ProductionProps, ProductionState
     private blinkIntervalMainSwitch: NodeJS.Timeout | null = null;
     private blinkIntervalWaterSwitch: NodeJS.Timeout | null = null;
     private timelineData: TimelineData[] = [];
+    private isBrewingStartRequestPending = false;
     private readonly MAX_AGITATOR_SPEED = 40;
     private readonly MAX_WATER_LEVEL = 70;
     private readonly MAX_INTERVAL_TIME = 10;
@@ -150,8 +152,15 @@ export class Production extends React.Component<ProductionProps, ProductionState
             this.resetRecipeWaterFillState({indexOfCurrentStep: 0});
         }
 
-        if (prevProps.brewingStatus?.process?.state !== brewingStatus?.process?.state && brewingStatus?.process?.state !== ProcessState.ACTIVE) {
+        const aBrewingProcessChangedToInactive = prevProps.brewingStatus?.process?.state !== brewingStatus?.process?.state && brewingStatus?.process?.state !== ProcessState.ACTIVE;
+        if (aBrewingProcessChangedToInactive) {
             this.resetRecipeWaterFillState();
+        }
+
+        const aStartRequestCompleted = prevProps.isPollingRunning && !this.props.isPollingRunning;
+        if ((this.state.brewingIsRunning || this.isBrewingStartRequestPending) && (aStartRequestCompleted || aBrewingProcessChangedToInactive)) {
+            this.isBrewingStartRequestPending = false;
+            this.setState({brewingIsRunning: false});
         }
 
         if (waterStatus?.openClose === true && !prevProps.waterStatus?.openClose) {
@@ -381,13 +390,28 @@ export class Production extends React.Component<ProductionProps, ProductionState
             this.setState({waterSwitchState: false});
         }
     }
-    startBrewing = () => {
+    isControlBrewingStartAvailable = (): boolean => {
+        const {brewingStatus, isPollingRunning} = this.props;
+        return !isPollingRunning && !isProcessActive(brewingStatus);
+    }
+
+    isStartButtonDisabled = (): boolean => {
+        const {selectedBeer} = this.props;
+        return isUndefined(selectedBeer) || this.state.brewingIsRunning || this.isBrewingStartRequestPending || !this.isControlBrewingStartAvailable();
+    }
+
+    startBrewing = (): void => {
         const {selectedBeer, sendBrewingData} = this.props;
+        if (this.isStartButtonDisabled()) {
+            return;
+        }
+        this.isBrewingStartRequestPending = true;
         this.resetRecipeWaterFillState();
         console.log('Starting brewing with data:', sendBrewingData);
         const result = mapBeerToBrewingData(selectedBeer);
         console.log('Starting brewing with data:', result);
         if (!result.ok || !result.brewingData) {
+            this.isBrewingStartRequestPending = false;
             this.setState({
                 showErrorDialog: true,
                 errorDialogContent: result.error ?? 'Rezeptdaten sind für den Start ungültig.'
@@ -559,10 +583,10 @@ export class Production extends React.Component<ProductionProps, ProductionState
                     <button className="recipeWaterBtn" disabled={spargeWaterDisabled} onClick={this.startSpargeWaterFilling}>Nachguss</button>
                 </div>
                 <div className="startBtnDiv">
-                    <button className="startBtn" disabled={isUndefined(selectedBeer) } onClick={this.startBrewing}>Start</button>
+                    <button className="startBtn" disabled={this.isStartButtonDisabled()} onClick={this.startBrewing}>Start</button>
                 </div>
                 <div className="startPollingBtnDiv">
-                    <button className="startPollingBtn" onClick={this.startBrewing}>
+                    <button className="startPollingBtn" disabled={this.isStartButtonDisabled()} onClick={this.startBrewing}>
                         <FontAwesomeIcon icon={faRepeat as IconProp} />
                     </button>
                 </div>
@@ -800,7 +824,8 @@ const mapStateToProps = (state: any) => (
         isToggleAgitatorSuccess: state.productionReducer.isToggleAgitatorSuccess,
         brewingStatus: state.productionReducer.brewingStatus,
         isBackenAvailable: state.productionReducer.isBackenAvailable,
-        waterStatus: state.productionReducer.waterStatus
+        waterStatus: state.productionReducer.waterStatus,
+        isPollingRunning: state.productionReducer.isPollingRunning
 
     });
 export default connect(mapStateToProps, mapDispatchToProps)(Production);

--- a/src/containers/Production/Production.tsx
+++ b/src/containers/Production/Production.tsx
@@ -33,7 +33,7 @@ import {ProcessList, createProcessSteps} from "./ProcessList/ProcessList";
 import { dataCollector } from '../../utils/DataCollector/dataCollector';
 import {getBrewingStatusLabel} from "../../utils/brewingStatus/selectors";
 
-interface ProductionProps {
+export interface ProductionProps {
     selectedBeer: Beer;
     temperature: number;
     currentAgitatorState: ToggleState;
@@ -55,6 +55,8 @@ interface ProductionProps {
     addFinishedBrew: (finishedBrew: FinishedBrew) => void;
     nextProcedureStep: () => void;
 }
+
+type RecipeWaterFill = 'mash' | 'sparge';
 
 interface ProductionState {
     agitatorState: ToggleState;
@@ -80,9 +82,13 @@ interface ProductionState {
     indexOfCurrentStep: number;
     brewingIsRunning: boolean;
     announcedHopTimes: number[];
+    completedMashWaterFill: boolean;
+    completedSpargeWaterFill: boolean;
+    pendingRecipeWaterFill: RecipeWaterFill | undefined;
+    waterFillHasStarted: boolean;
 }
 
-class Production extends React.Component<ProductionProps, ProductionState> {
+export class Production extends React.Component<ProductionProps, ProductionState> {
     private blinkIntervalMainSwitch: NodeJS.Timeout | null = null;
     private blinkIntervalWaterSwitch: NodeJS.Timeout | null = null;
     private timelineData: TimelineData[] = [];
@@ -118,7 +124,11 @@ class Production extends React.Component<ProductionProps, ProductionState> {
             brewingFinished: false,
             indexOfCurrentStep: 0,
             brewingIsRunning: false,
-            announcedHopTimes: []
+            announcedHopTimes: [],
+            completedMashWaterFill: false,
+            completedSpargeWaterFill: false,
+            pendingRecipeWaterFill: undefined,
+            waterFillHasStarted: false
         }
     }
 
@@ -132,12 +142,24 @@ class Production extends React.Component<ProductionProps, ProductionState> {
 
 
     componentDidUpdate(prevProps: Readonly<ProductionProps>, prevState: Readonly<ProductionState>) {
-        const {toggleAgitator, brewingStatus,isBackenAvailable,temperature,isToggleAgitatorSuccess,isWaterFillingSuccessful} = this.props;
+        const {toggleAgitator, brewingStatus,isBackenAvailable,temperature,isToggleAgitatorSuccess,isWaterFillingSuccessful, waterStatus} = this.props;
         const {intervalSwitchState, mainSwitchState, waterSwitchState,heatingAndStirringSwitchState,showHopsDialog,showFinishDialog, indexOfCurrentStep} = this.state;
 
 
         if (prevProps.selectedBeer !== this.props.selectedBeer) {
-            this.setState({indexOfCurrentStep: 0});
+            this.resetRecipeWaterFillState({indexOfCurrentStep: 0});
+        }
+
+        if (prevProps.brewingStatus?.process?.state !== brewingStatus?.process?.state && brewingStatus?.process?.state !== ProcessState.ACTIVE) {
+            this.resetRecipeWaterFillState();
+        }
+
+        if (waterStatus?.openClose === true && !prevProps.waterStatus?.openClose) {
+            this.setState({waterFillHasStarted: true});
+        }
+
+        if (prevProps.waterStatus?.openClose === true && waterStatus?.openClose === false) {
+            this.completePendingRecipeWaterFill();
         }
 
 
@@ -289,6 +311,66 @@ class Production extends React.Component<ProductionProps, ProductionState> {
         this.setState({liters: value});
     }
 
+    resetRecipeWaterFillState = (aAdditionalState?: Partial<ProductionState>): void => {
+        this.setState({
+            completedMashWaterFill: false,
+            completedSpargeWaterFill: false,
+            pendingRecipeWaterFill: undefined,
+            waterFillHasStarted: false,
+            ...aAdditionalState
+        });
+    }
+
+    completePendingRecipeWaterFill = (): void => {
+        const {pendingRecipeWaterFill, waterFillHasStarted} = this.state;
+        if (!waterFillHasStarted || pendingRecipeWaterFill === undefined) {
+            this.setState({waterSwitchState: false, waterFillHasStarted: false});
+            return;
+        }
+        this.setState({
+            waterSwitchState: false,
+            waterFillHasStarted: false,
+            pendingRecipeWaterFill: undefined,
+            completedMashWaterFill: pendingRecipeWaterFill === 'mash' ? true : this.state.completedMashWaterFill,
+            completedSpargeWaterFill: pendingRecipeWaterFill === 'sparge' ? true : this.state.completedSpargeWaterFill
+        });
+    }
+
+    getRecipeWaterVolume = (aRecipeWaterFill: RecipeWaterFill): number | undefined => {
+        const {selectedBeer} = this.props;
+        if (isUndefined(selectedBeer)) {
+            return undefined;
+        }
+        const volume = aRecipeWaterFill === 'mash' ? Number(selectedBeer.mashVolume) : Number(selectedBeer.spargeVolume);
+        return Number.isFinite(volume) && volume > 0 ? volume : undefined;
+    }
+
+    isWaterFillingActive = (): boolean => {
+        return this.state.waterSwitchState || this.props.waterStatus?.openClose === true;
+    }
+
+    startRecipeWaterFilling = (aRecipeWaterFill: RecipeWaterFill): void => {
+        const volume = this.getRecipeWaterVolume(aRecipeWaterFill);
+        if (volume === undefined || this.isWaterFillingActive()) {
+            return;
+        }
+        this.setState({
+            waterSwitchState: true,
+            liters: volume,
+            pendingRecipeWaterFill: aRecipeWaterFill,
+            waterFillHasStarted: false
+        });
+        this.props.startWaterFilling(volume);
+    }
+
+    startMashWaterFilling = (): void => {
+        this.startRecipeWaterFilling('mash');
+    }
+
+    startSpargeWaterFilling = (): void => {
+        this.startRecipeWaterFilling('sparge');
+    }
+
     toggleWaterSwitchState = () => {
         const {waterSwitchState, liters,} = this.state;
         const {startWaterFilling} = this.props;
@@ -301,6 +383,7 @@ class Production extends React.Component<ProductionProps, ProductionState> {
     }
     startBrewing = () => {
         const {selectedBeer, sendBrewingData} = this.props;
+        this.resetRecipeWaterFillState();
         console.log('Starting brewing with data:', sendBrewingData);
         const result = mapBeerToBrewingData(selectedBeer);
         console.log('Starting brewing with data:', result);
@@ -418,6 +501,11 @@ class Production extends React.Component<ProductionProps, ProductionState> {
             mainAgitatorError
         } = this.state;
         const {currentAgitatorSpeed, agitatorIsRunning, agitatorSpeed, waterStatus,selectedBeer} = this.props;
+        const waterFillingActive = this.isWaterFillingActive();
+        const mashWaterVolume = this.getRecipeWaterVolume('mash');
+        const spargeWaterVolume = this.getRecipeWaterVolume('sparge');
+        const mashWaterDisabled = waterFillingActive || this.state.completedMashWaterFill || mashWaterVolume === undefined;
+        const spargeWaterDisabled = waterFillingActive || this.state.completedSpargeWaterFill || spargeWaterVolume === undefined;
         return (
             <div className="Settings">
                 <h3>Settings</h3>
@@ -465,6 +553,10 @@ class Production extends React.Component<ProductionProps, ProductionState> {
                     </div>
 
 
+                </div>
+                <div className="recipeWaterButtons">
+                    <button className="recipeWaterBtn" disabled={mashWaterDisabled} onClick={this.startMashWaterFilling}>Hauptguss</button>
+                    <button className="recipeWaterBtn" disabled={spargeWaterDisabled} onClick={this.startSpargeWaterFilling}>Nachguss</button>
                 </div>
                 <div className="startBtnDiv">
                     <button className="startBtn" disabled={isUndefined(selectedBeer) } onClick={this.startBrewing}>Start</button>

--- a/src/epics/productionEpics.ts
+++ b/src/epics/productionEpics.ts
@@ -80,7 +80,7 @@ export const sendBrewingDataEpic$ = (action$: any) =>
       from(ProductionRepository.sendBrewingData(action.payload.brewingData)).pipe(
         switchMap((sendResult) => {
           if (sendResult) {
-            // Starte den Brauprozess
+            // Start the brewing process
             return from(ProductionRepository.startBrewing()).pipe(
               switchMap((startResult) => {
                 if (startResult) {
@@ -94,7 +94,7 @@ export const sendBrewingDataEpic$ = (action$: any) =>
                     takeWhile(({ brewingStatus }) => !(brewingStatus && (isProcessFinished(brewingStatus) || isProcessAborted(brewingStatus) || isProcessInError(brewingStatus))), true),
                     switchMap(({ available, brewingStatus }) => {
                       if (available?.isBackenAvailable && brewingStatus !== undefined) {
-                        // BrewingStatus im DataCollector speichern
+                        // Store BrewingStatus in the data collector
                         dataCollector.setBrewingStatus(brewingStatus);
                         return [
                           ProductionActions.setBrewingStatus(brewingStatus),
@@ -106,15 +106,15 @@ export const sendBrewingDataEpic$ = (action$: any) =>
                     catchError((error) => of({ type: 'NO_OP' }))
                   );
                 } else {
-                  return of({ type: 'NO_OP' });
+                  return of(ProductionActions.stopPolling());
                 }
               })
             );
           } else {
-            return of({ type: 'NO_OP' });
+            return of(ProductionActions.stopPolling());
           }
         }),
-        catchError((error) => of({ type: 'NO_OP' }))
+        catchError((error) => of(ProductionActions.stopPolling()))
       )
     )
   );

--- a/src/reducers/productionReducer.ts
+++ b/src/reducers/productionReducer.ts
@@ -3,6 +3,7 @@ import { ProductionRepository } from '../repositorys/ProductionRepository';
 import AllProductionActions = ProductionActions.AllProductionActions;
 import { ToggleState } from '../enums/eToggleState';
 import { BrewingStatus } from '../model/BrewingStatus';
+import { isProcessAborted, isProcessFinished, isProcessIdle, isProcessInError } from '../utils/brewingStatus/selectors';
 import { ConfirmStates } from '../enums/eConfirmStates';
 import { WaterStatus } from '../components/Controlls/WaterControll/WaterControl';
 
@@ -77,7 +78,9 @@ const productionReducer = (
             return { ...aState, isPollingRunning: true };
         }
         case ProductionActions.ActionTypes.SET_BREWING_STATUS: {
-            return { ...aState, brewingStatus: aAction.payload.brewingStatus };
+            const aBrewingStatus = aAction.payload.brewingStatus;
+            const aIsTerminalOrIdle = isProcessIdle(aBrewingStatus) || isProcessFinished(aBrewingStatus) || isProcessAborted(aBrewingStatus) || isProcessInError(aBrewingStatus);
+            return { ...aState, brewingStatus: aBrewingStatus, isPollingRunning: aIsTerminalOrIdle ? false : aState.isPollingRunning };
         }
         case ProductionActions.ActionTypes.START_POLLING: {
             return { ...aState, isPollingRunning: true };


### PR DESCRIPTION
### Motivation
- Provide two recipe-driven water-fill actions (`Hauptguss`, `Nachguss`) next to the existing manual water control while keeping the manual control unchanged. 
- Reuse the existing water-fill request/epic/repository and determine completion from the PI `WaterStatus` rather than UI timers.
- Ensure buttons are disabled when volumes are missing/invalid, while a fill is active, or after the corresponding recipe-fill completed, and reset state on recipe/brew lifecycle changes.

### Description
- Added two buttons `Hauptguss` and `Nachguss` to the Production settings area below the existing manual water control and introduced `.recipeWaterButtons` / `.recipeWaterBtn` CSS rules to match existing styling conventions. 
- Reused the existing `startWaterFilling` action/epic/`ProductionRepository.fillWaterAutomatic` call; recipe volumes are read from `selectedBeer.mashVolume` and `selectedBeer.spargeVolume` (liters). 
- Extended the `Production` class component state with `completedMashWaterFill`, `completedSpargeWaterFill`, `pendingRecipeWaterFill`, and `waterFillHasStarted`, and added methods `startRecipeWaterFilling`, `startMashWaterFilling`, `startSpargeWaterFilling`, `getRecipeWaterVolume`, `isWaterFillingActive`, `completePendingRecipeWaterFill`, and `resetRecipeWaterFillState`. 
- Completion detection uses `WaterStatus.openClose` transitions: when `openClose` becomes `true` we consider filling started, and when it transitions from `true` to `false` we mark the pending recipe fill as completed; this avoids artificial UI timers and relies on the existing PI `WaterStatus`. 
- Buttons are disabled when the recipe volume is missing/<=0, while any water fill is active (`waterSwitchState` or `waterStatus.openClose === true`), or after the specific recipe fill finished; other button remains available after one completes. 
- Reset behavior: completed flags are cleared when a different recipe is selected, when the brewing process state stops being `ACTIVE`, or when a new brew is started. 
- Added unit tests `src/containers/Production/Production.test.tsx` that cover recipe mash/sparge dispatch, active-disable behavior, completion marking, invalid/missing volumes, failed-request behavior, reset on recipe change and new brew start, and preserved manual control behavior.

### Testing
- Created and committed unit tests that assert the 10 required scenarios are covered in `src/containers/Production/Production.test.tsx` (tests added but not fully executed in this environment). 
- `git diff --check` reported no whitespace/merge problems. 
- Attempted to run the test suite but automated execution was blocked in this environment because `react-scripts` / test dependencies are not available and `npm install` / `npm ci` did not complete here, so the tests could not be executed end-to-end (test file present and syntactically integrated with the component).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a535c81b40c832fa790adf0dd8af54f)