### PR TITLE
Fix production TypeScript errors

### DIFF
--- a/src/containers/Production/Production.test.tsx
+++ b/src/containers/Production/Production.test.tsx
@@ -24,8 +24,8 @@ const createBeer = (aMashVolume: number | undefined = 18, aSpargeVolume: number 
         {type: 'Abmaischen', temperature: 78}
     ],
     malts: [],
-    wortBoiling: {hops: []},
-    fermentationMaturation: {yeast: []}
+    wortBoiling: {totalTime: 60, hops: []},
+    fermentationMaturation: {fermentationTemperature: 20, carbonation: 5, yeast: []}
 });
 
 const createBrewingStatus = (aProcessState: ProcessState = ProcessState.IDLE): BrewingStatus => ({

--- a/src/containers/Production/Production.tsx
+++ b/src/containers/Production/Production.tsx
@@ -58,6 +58,7 @@ export interface ProductionProps {
 }
 
 type RecipeWaterFill = 'mash' | 'sparge';
+type RecipeWaterFillResetState = Pick<ProductionState, 'completedMashWaterFill' | 'completedSpargeWaterFill' | 'pendingRecipeWaterFill' | 'waterFillHasStarted'>;
 
 interface ProductionState {
     agitatorState: ToggleState;
@@ -320,14 +321,14 @@ export class Production extends React.Component<ProductionProps, ProductionState
         this.setState({liters: value});
     }
 
-    resetRecipeWaterFillState = (aAdditionalState?: Partial<ProductionState>): void => {
-        this.setState({
+    resetRecipeWaterFillState = (aAdditionalState?: Pick<ProductionState, 'indexOfCurrentStep'>): void => {
+        const resetState: RecipeWaterFillResetState = {
             completedMashWaterFill: false,
             completedSpargeWaterFill: false,
             pendingRecipeWaterFill: undefined,
-            waterFillHasStarted: false,
-            ...aAdditionalState
-        });
+            waterFillHasStarted: false
+        };
+        this.setState(aAdditionalState === undefined ? resetState : {...resetState, ...aAdditionalState});
     }
 
     completePendingRecipeWaterFill = (): void => {


### PR DESCRIPTION
### Motivation
- Resolve TypeScript compilation errors in the Production area caused by test fixtures missing required `WortBoiling`/`FermentationMaturation` fields and by an unsafe `setState` spread of a broad `Partial<ProductionState>` that allowed `undefined` to flow into required state properties.

### Description
- Update the test beer fixture in `src/containers/Production/Production.test.tsx` to include `wortBoiling.totalTime` and `fermentationMaturation.fermentationTemperature` / `fermentationMaturation.carbonation` to match the `Beer` model.
- Narrow `resetRecipeWaterFillState` in `src/containers/Production/Production.tsx` to accept only a dedicated reset partial (`RecipeWaterFillResetState` / `Pick<ProductionState,'indexOfCurrentStep'>`) and build an explicit `resetState` object before calling `this.setState` to avoid spreading arbitrary `Partial<ProductionState>`.

### Testing
- Attempted to run the unit tests with `npm test -- --watchAll=false --runTestsByPath src/containers/Production/Production.test.tsx`, but the test runner could not execute because `node_modules/.bin/react-scripts` was not available in this environment (test run did not complete).
- Attempted `npm run build` and `npm ci`, but `npm ci` failed due to registry access restrictions (`403 Forbidden` fetching `@types/react`) and `build` could not run because required tooling was not installed, so automated TypeScript/test validation could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a53678b5a54832f934b04f1f71f7993)