### PR TITLE
Fix water-filling epic polling termination and add tests

### DIFF
--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -804,8 +804,9 @@ export namespace ProductionActions {
         };
     }
 
-    export function waterFillingFailure(error: any) {
-        return undefined;
+    export function waterFillingFailure(_error: any): StartWaterFillingSuccess {
+        void _error;
+        return startWaterFillingSuccess(false);
     }
 
     export function webSocketConnect(): WebSocketConnect {

--- a/src/epics/productionEpics.test.ts
+++ b/src/epics/productionEpics.test.ts
@@ -1,0 +1,122 @@
+import { Subject } from 'rxjs';
+import { ProductionActions } from '../actions/actions';
+import { startWaterFillingEpic$ } from './productionEpics';
+import { ProductionRepository } from '../repositorys/ProductionRepository';
+
+jest.mock('../repositorys/ProductionRepository', () => ({
+  ProductionRepository: {
+    fillWaterAutomatic: jest.fn(),
+    getWaterStatus: jest.fn(),
+  },
+}));
+
+const mockedProductionRepository = ProductionRepository as jest.Mocked<typeof ProductionRepository>;
+
+const flushPromises = async () => {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+};
+
+describe('startWaterFillingEpic$', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('polls and dispatches every water status while water filling is still open', async () => {
+    mockedProductionRepository.fillWaterAutomatic.mockResolvedValue(true);
+    mockedProductionRepository.getWaterStatus.mockResolvedValue({ liters: 1, openClose: true });
+
+    const action$ = new Subject<any>();
+    const emittedActions: any[] = [];
+    const subscription = startWaterFillingEpic$(action$).subscribe((action: any) => emittedActions.push(action));
+
+    action$.next(ProductionActions.startWaterFilling(24.8));
+    await flushPromises();
+    jest.advanceTimersByTime(1000);
+    await flushPromises();
+    jest.advanceTimersByTime(1000);
+    await flushPromises();
+
+    expect(mockedProductionRepository.getWaterStatus).toHaveBeenCalledTimes(3);
+    expect(emittedActions).toEqual([
+      ProductionActions.setWaterStatus({ liters: 1, openClose: true }),
+      ProductionActions.setWaterStatus({ liters: 1, openClose: true }),
+      ProductionActions.setWaterStatus({ liters: 1, openClose: true }),
+    ]);
+
+    subscription.unsubscribe();
+  });
+
+  it('dispatches the final closed water status before stopping polling', async () => {
+    mockedProductionRepository.fillWaterAutomatic.mockResolvedValue(true);
+    mockedProductionRepository.getWaterStatus
+      .mockResolvedValueOnce({ liters: 1, openClose: true })
+      .mockResolvedValueOnce({ liters: 10, openClose: true })
+      .mockResolvedValueOnce({ liters: 24.8, openClose: false });
+
+    const action$ = new Subject<any>();
+    const emittedActions: any[] = [];
+    const subscription = startWaterFillingEpic$(action$).subscribe((action: any) => emittedActions.push(action));
+
+    action$.next(ProductionActions.startWaterFilling(24.8));
+    await flushPromises();
+    jest.advanceTimersByTime(1000);
+    await flushPromises();
+    jest.advanceTimersByTime(1000);
+    await flushPromises();
+    jest.advanceTimersByTime(3000);
+    await flushPromises();
+
+    expect(mockedProductionRepository.getWaterStatus).toHaveBeenCalledTimes(3);
+    expect(emittedActions).toEqual([
+      ProductionActions.setWaterStatus({ liters: 1, openClose: true }),
+      ProductionActions.setWaterStatus({ liters: 10, openClose: true }),
+      ProductionActions.setWaterStatus({ liters: 24.8, openClose: false }),
+    ]);
+
+    subscription.unsubscribe();
+  });
+
+  it('dispatches a water filling failure and does not start polling when the fill command fails', async () => {
+    mockedProductionRepository.fillWaterAutomatic.mockResolvedValue(false);
+
+    const action$ = new Subject<any>();
+    const emittedActions: any[] = [];
+    const subscription = startWaterFillingEpic$(action$).subscribe((action: any) => emittedActions.push(action));
+
+    action$.next(ProductionActions.startWaterFilling(24.8));
+    await flushPromises();
+    jest.advanceTimersByTime(3000);
+    await flushPromises();
+
+    expect(mockedProductionRepository.getWaterStatus).not.toHaveBeenCalled();
+    expect(emittedActions).toEqual([ProductionActions.startWaterFillingSuccess(false)]);
+
+    subscription.unsubscribe();
+  });
+
+  it('dispatches a water filling failure and stops when polling fails', async () => {
+    mockedProductionRepository.fillWaterAutomatic.mockResolvedValue(true);
+    mockedProductionRepository.getWaterStatus.mockRejectedValue(new Error('WaterStatus failed'));
+
+    const action$ = new Subject<any>();
+    const emittedActions: any[] = [];
+    const subscription = startWaterFillingEpic$(action$).subscribe((action: any) => emittedActions.push(action));
+
+    action$.next(ProductionActions.startWaterFilling(24.8));
+    await flushPromises();
+    jest.advanceTimersByTime(3000);
+    await flushPromises();
+
+    expect(mockedProductionRepository.getWaterStatus).toHaveBeenCalledTimes(1);
+    expect(emittedActions).toEqual([ProductionActions.startWaterFillingSuccess(false)]);
+
+    subscription.unsubscribe();
+  });
+});

--- a/src/epics/productionEpics.ts
+++ b/src/epics/productionEpics.ts
@@ -1,6 +1,6 @@
 import { ofType } from 'redux-observable';
 import {from, of, interval, EMPTY, filter, takeWhile, startWith, Observable} from 'rxjs';
-import { catchError, map, mergeMap, switchMap, takeUntil } from 'rxjs/operators';
+import { catchError, map, mergeMap, switchMap } from 'rxjs/operators';
 import { ProductionActions } from '../actions/actions';
 import { ProductionRepository } from '../repositorys/ProductionRepository';
 import { dataCollector } from '../utils/DataCollector/dataCollector';
@@ -55,13 +55,10 @@ export const startWaterFillingEpic$ = (action$: any) =>
         switchMap((result) => {
           if (result) {
             return interval(1000).pipe(
+              startWith(0),
               switchMap(() => from(ProductionRepository.getWaterStatus())),
+              takeWhile((status: any) => status?.openClose === true, true),
               map((status: any) => ProductionActions.setWaterStatus(status)),
-              takeUntil(
-                from(ProductionRepository.getWaterStatus()).pipe(
-                  map((status: any) => status && status.openClose !== true)
-                )
-              ),
               catchError((error) => of(ProductionActions.waterFillingFailure(error)))
             );
           } else {


### PR DESCRIPTION
### Motivation
- Ensure the water-filling epic emits status immediately and includes the final closed status before stopping polling.
- Ensure failures in the water-filling flow produce a concrete action so downstream logic can handle them.
- Add unit tests to validate polling behavior and failure handling for the water-filling epic.

### Description
- Update `waterFillingFailure` in `src/actions/actions.ts` to accept an `_error` parameter, silence the unused variable, and return `startWaterFillingSuccess(false)` so a concrete failure action is dispatched.
- Modify `startWaterFillingEpic$` in `src/epics/productionEpics.ts` to use `startWith(0)` and `takeWhile(..., true)` so polling starts immediately and includes the terminal closed status, remove the previous `takeUntil`-based stop, and route errors to `ProductionActions.waterFillingFailure(error)`.
- Remove the unused `takeUntil` operator import from the rxjs operators list.
- Add `src/epics/productionEpics.test.ts` with unit tests that mock `ProductionRepository` and cover successful polling, final closed-status emission, handling when `fillWaterAutomatic` fails, and handling when polling fails.

### Testing
- Ran `jest src/epics/productionEpics.test.ts` which contains four unit tests exercising `startWaterFillingEpic$`.
- All tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a53e09ae5a8832fbae7221ba9dc0a26)