### PR TITLE
Deaktiviere Next-Button ohne aktiven Brauprozess

### DIFF
--- a/src/containers/Production/ProcessList/ProcessList.tsx
+++ b/src/containers/Production/ProcessList/ProcessList.tsx
@@ -36,6 +36,7 @@ export interface ProcessListProps {
     currentStepIndex: number; // 1-based PI-control currentStep.index
     currentStep?: ProcessListCurrentStep;
     onNextStep?: () => void;
+    isNextStepDisabled?: boolean;
 }
 
 interface ProcessListState {
@@ -101,7 +102,7 @@ export class ProcessList extends React.Component<ProcessListProps, ProcessListSt
     };
 
     render() {
-        const { selectedBeer, onNextStep } = this.props;
+        const { selectedBeer, onNextStep, isNextStepDisabled = false } = this.props;
         const steps = createProcessSteps(selectedBeer);
         const stepIndex = this.effectiveStepIndex;
 
@@ -136,6 +137,7 @@ export class ProcessList extends React.Component<ProcessListProps, ProcessListSt
                             <button
                                 className="nextStepBtn"
                                 onClick={onNextStep}
+                                disabled={isNextStepDisabled}
                                 title="Nächster Prozessschritt"
                             >
                                 Nächster Schritt

--- a/src/containers/Production/Production.test.tsx
+++ b/src/containers/Production/Production.test.tsx
@@ -139,6 +139,62 @@ describe('Production start button', () => {
 
 });
 
+
+describe('Production next button', () => {
+    const getNextButton = () => screen.getByRole('button', {name: 'Nächster Schritt'});
+
+    it('disables the next button while the status has not been loaded yet', () => {
+        renderProduction({brewingStatus: undefined});
+        expect(getNextButton()).toBeDisabled();
+    });
+
+    it('disables the next button without an active brewing process and does not dispatch next', () => {
+        const {props} = renderProduction({brewingStatus: createBrewingStatus(ProcessState.IDLE)});
+        const nextButton = getNextButton();
+
+        expect(nextButton).toBeDisabled();
+        fireEvent.click(nextButton);
+        expect(props.nextProcedureStep).not.toHaveBeenCalled();
+    });
+
+    it('guards the next click handler without an active brewing process', () => {
+        const {props} = renderProduction({brewingStatus: createBrewingStatus(ProcessState.IDLE)});
+        const production = new Production(props);
+
+        production.handleNextProcedureStep();
+
+        expect(props.nextProcedureStep).not.toHaveBeenCalled();
+    });
+
+    it('enables the next button during an active brewing process and dispatches next exactly once', () => {
+        const {props} = renderProduction({brewingStatus: createBrewingStatus(ProcessState.ACTIVE)});
+        const nextButton = getNextButton();
+
+        expect(nextButton).not.toBeDisabled();
+        fireEvent.click(nextButton);
+        expect(props.nextProcedureStep).toHaveBeenCalledTimes(1);
+    });
+
+    it('disables the next button again when the process is finished, aborted, or reset to idle', () => {
+        const {rerender, props} = renderProduction({brewingStatus: createBrewingStatus(ProcessState.ACTIVE)});
+        expect(getNextButton()).not.toBeDisabled();
+
+        rerender(<Production {...props} brewingStatus={createBrewingStatus(ProcessState.FINISHED)} />);
+        expect(getNextButton()).toBeDisabled();
+
+        rerender(<Production {...props} brewingStatus={createBrewingStatus(ProcessState.ABORTED)} />);
+        expect(getNextButton()).toBeDisabled();
+
+        rerender(<Production {...props} brewingStatus={createBrewingStatus(ProcessState.IDLE)} />);
+        expect(getNextButton()).toBeDisabled();
+    });
+
+    it('keeps the next button disabled after a failed status request leaves no status available', () => {
+        renderProduction({brewingStatus: undefined});
+        expect(getNextButton()).toBeDisabled();
+    });
+});
+
 describe('Production recipe water filling', () => {
     it('sends the recipe mash water volume when Hauptguss is clicked', () => {
         const {props} = renderProduction({selectedBeer: createBeer(21, 9)});

--- a/src/containers/Production/Production.tsx
+++ b/src/containers/Production/Production.tsx
@@ -31,7 +31,7 @@ import {eBrewState} from "../../enums/eBrewState";
 import {BackendAvailable} from "../../reducers/productionReducer";
 import {ProcessList, createProcessSteps} from "./ProcessList/ProcessList";
 import { dataCollector } from '../../utils/DataCollector/dataCollector';
-import {getBrewingStatusLabel, isProcessActive} from "../../utils/brewingStatus/selectors";
+import {getBrewingStatusLabel, isBrewingProcessActive, isProcessActive} from "../../utils/brewingStatus/selectors";
 
 export interface ProductionProps {
     selectedBeer: Beer;
@@ -47,7 +47,7 @@ export interface ProductionProps {
     isWaterFillingSuccessful: boolean;
     isToggleAgitatorSuccess: boolean;
     sendBrewingData: (brewingData: BrewingData) => void;
-    brewingStatus: BrewingStatus;
+    brewingStatus?: BrewingStatus;
     startPolling: () => void;
     stopPolling: () => void;
     isBackenAvailable: BackendAvailable;
@@ -429,6 +429,17 @@ export class Production extends React.Component<ProductionProps, ProductionState
         startPolling();
     }
 
+    isNextProcedureStepAvailable = (): boolean => {
+        return isBrewingProcessActive(this.props.brewingStatus);
+    }
+
+    handleNextProcedureStep = (): void => {
+        if (!this.isNextProcedureStepAvailable()) {
+            return;
+        }
+        this.props.nextProcedureStep();
+    }
+
     formatTime = (time: number) => {
         return TimeFormatter.formatSecondsToHMS(time);
     }
@@ -738,7 +749,7 @@ export class Production extends React.Component<ProductionProps, ProductionState
     renderProcessList() {
         const { selectedBeer, brewingStatus } = this.props;
         return (
-            <ProcessList selectedBeer={selectedBeer} currentStepIndex={brewingStatus?.currentStep?.index ?? 0} currentStep={brewingStatus?.currentStep} onNextStep={this.props.nextProcedureStep} />
+            <ProcessList selectedBeer={selectedBeer} currentStepIndex={brewingStatus?.currentStep?.index ?? 0} currentStep={brewingStatus?.currentStep} onNextStep={this.handleNextProcedureStep} isNextStepDisabled={!this.isNextProcedureStepAvailable()} />
         );
     }
 

--- a/src/utils/brewingStatus/selectors.test.ts
+++ b/src/utils/brewingStatus/selectors.test.ts
@@ -1,4 +1,4 @@
-import {getBrewingStatusLabel, getConfirmButtonLabel, getCountdownValue, shouldShowConfirmButton, shouldShowCountdown, shouldShowWaitingDialog} from './selectors';
+import {getBrewingStatusLabel, getConfirmButtonLabel, getCountdownValue, isBrewingProcessActive, shouldShowConfirmButton, shouldShowCountdown, shouldShowWaitingDialog} from './selectors';
 import {BrewingStatus, ProcessMode, ProcessPhase, ProcessState, WaitingFor} from '../../model/brewingStatus.types';
 
 const makeStatus = (aPart: Partial<BrewingStatus>): BrewingStatus => ({
@@ -10,6 +10,13 @@ const makeStatus = (aPart: Partial<BrewingStatus>): BrewingStatus => ({
 });
 
 describe('brewing selectors', () => {
+  it('derives an active brewing process from process.state ACTIVE only', () => {
+    expect(isBrewingProcessActive(undefined)).toBe(false);
+    expect(isBrewingProcessActive(makeStatus({process:{state:ProcessState.IDLE}}))).toBe(false);
+    expect(isBrewingProcessActive(makeStatus({process:{state:ProcessState.ACTIVE}}))).toBe(true);
+    expect(isBrewingProcessActive(makeStatus({process:{state:ProcessState.FINISHED}}))).toBe(false);
+  });
+
   it('process priority labels', () => {
     expect(getBrewingStatusLabel(makeStatus({process:{state:ProcessState.ERROR}}))).toContain('Fehler');
     expect(getBrewingStatusLabel(makeStatus({process:{state:ProcessState.ABORTED}}))).toContain('abgebrochen');

--- a/src/utils/brewingStatus/selectors.ts
+++ b/src/utils/brewingStatus/selectors.ts
@@ -7,6 +7,7 @@ import {BrewingStatus, ProcessMode, ProcessPhase, ProcessState, WaitingFor} from
  */
 export const isProcessIdle = (aStatus?: BrewingStatus) => aStatus?.process.state === ProcessState.IDLE;
 export const isProcessActive = (aStatus?: BrewingStatus) => aStatus?.process.state === ProcessState.ACTIVE;
+export const isBrewingProcessActive = (aStatus?: BrewingStatus) => isProcessActive(aStatus);
 export const isProcessFinished = (aStatus?: BrewingStatus) => aStatus?.process.state === ProcessState.FINISHED;
 export const isProcessAborted = (aStatus?: BrewingStatus) => aStatus?.process.state === ProcessState.ABORTED;
 export const isProcessInError = (aStatus?: BrewingStatus) => aStatus?.process.state === ProcessState.ERROR;


### PR DESCRIPTION
### Motivation
- Verhindern, dass die UI `POST /next` sendet, wenn die Steuerung keinen aktiven Brauvorgang meldet.
- Nutzung des bereits vorhandenen normalisierten Steuerungsstatus als einzige Entscheidungsquelle ohne zusätzliche Requests oder lokale Annahmen.
- Zusätzlicher Schutz im Click-Handler, damit ein ungültiger Zustand auch bei fehlerhafter UI-Darstellung keinen Request auslöst.

### Description
- Neue zentrale Ableitung: `isBrewingProcessActive` in `src/utils/brewingStatus/selectors.ts`, die `brewingStatus.process.state === ProcessState.ACTIVE` kapselt und als Grundlage für UI-Entscheidungen dient.
- `Production` (`src/containers/Production/Production.tsx`) nimmt `brewingStatus` optional an, importiert `isBrewingProcessActive`, fügt `isNextProcedureStepAvailable()` und `handleNextProcedureStep()` hinzu und leitet Next-Clicks über diesen gesicherten Handler weiter.
- `ProcessList` (`src/containers/Production/ProcessList/ProcessList.tsx`) erhält die neue Prop `isNextStepDisabled?: boolean` und verwendet sie, um den Next-Button (`disabled`) zu deaktivieren, statt rein lokal zu vertrauen.
- Tests ergänzt: neue Regressionstests in `src/containers/Production/Production.test.tsx` für Fälle (Status nicht geladen, kein aktiver Prozess, aktiver Prozess, Prozessende/Reset, Fehler beim Laden) und ein Selector-Test in `src/utils/brewingStatus/selectors.test.ts` für `isBrewingProcessActive`.

### Testing
- Hinzugefügte Unit-Tests: `Production`-Next-Button-Szenarien und `isBrewingProcessActive`-Spec wurden in den Testdateien ergänzt and committed. (siehe `src/containers/Production/Production.test.tsx` und `src/utils/brewingStatus/selectors.test.ts`).
- Versuch, die Tests lokal auszuführen: `npm test -- --watchAll=false src/containers/Production/Production.test.tsx src/containers/Production/ProcessList/ProcessList.test.tsx src/utils/brewingStatus/selectors.test.ts` schlug fehl, weil Abhängigkeiten nicht installiert werden konnten; `npm ci`/`npm install` scheiterten mit Registry-Fehler `403 Forbidden` für `@types/react`, daher konnten die Tests in dieser Umgebung nicht ausgeführt werden.
- Änderungen committed unter: "Disable next step without active brew" (enthält Code- und Teständerungen).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a53e5c7d3a4832fad9e8f94168b813f)