### PR TITLE
Fix nullable brewing status TypeScript errors

### DIFF
--- a/src/containers/Production/Production.tsx
+++ b/src/containers/Production/Production.tsx
@@ -194,15 +194,15 @@ export class Production extends React.Component<ProductionProps, ProductionState
                 this.setState({waterSwitchState: false, waterFillingError: true});
             }, delay);
         }
-        if (brewingStatus?.currentStep?.mode !== prevProps?.brewingStatus?.currentStep?.mode) {
+        if (brewingStatus && brewingStatus.currentStep?.mode !== prevProps?.brewingStatus?.currentStep?.mode) {
             let timelineData: TimelineData | undefined;
             if (brewingStatus.currentStep.mode === ProcessMode.HEATING) {
                 timelineData = {
-                    type: 'heating', elapsed: brewingStatus?.elapsedTime
+                    type: 'heating', elapsed: brewingStatus.elapsedTime
                 }
             } else {
                 timelineData = {
-                    type: 'rast', elapsed: brewingStatus?.elapsedTime
+                    type: 'rast', elapsed: brewingStatus.elapsedTime
                 }
             }
             if (timelineData !== undefined) {
@@ -231,7 +231,7 @@ export class Production extends React.Component<ProductionProps, ProductionState
 
         // Hopfengaben müssen relativ zur Kochphase berechnet werden,
         // nicht relativ zur gesamten Sudlaufzeit.
-        const aCookingElapsed = Math.floor(brewingStatus.currentStep?.elapsedTime ?? 0);
+        const aCookingElapsed = Math.floor(brewingStatus?.currentStep?.elapsedTime ?? 0);
         if (!hopsTimes.hasOwnProperty(aCookingElapsed)) {
             return;
         }
@@ -450,7 +450,7 @@ export class Production extends React.Component<ProductionProps, ProductionState
         if (this.timelineData.length > 0) {
             const lastObject = _.last(this.timelineData);
             if (lastObject) {
-                lastObject.elapsed = brewingStatus?.elapsedTime;
+                lastObject.elapsed = brewingStatus?.elapsedTime ?? 0;
             }
         }
     }
@@ -476,9 +476,10 @@ export class Production extends React.Component<ProductionProps, ProductionState
         const {brewingStatus} = this.props;
         let elapsedTime = '----';
         let targetTime = '----';
-       if(!isNaN(brewingStatus?.elapsedTime))
+       const currentElapsedTime = brewingStatus?.elapsedTime;
+       if(typeof currentElapsedTime === 'number' && !isNaN(currentElapsedTime))
        {
-           elapsedTime = this.formatTime(brewingStatus?.elapsedTime);
+           elapsedTime = this.formatTime(currentElapsedTime);
        }
        const stepDuration = Number(brewingStatus?.currentStep?.duration);
        if(Number.isFinite(stepDuration) && stepDuration > 0)


### PR DESCRIPTION
### Motivation
- Address several TypeScript errors where `brewingStatus` or its numeric fields were treated as non-nullable (TS18048 / TS2322 / TS2345). 
- Prevent runtime undefined reads from `brewingStatus` when the production status is temporarily absent during polling.

### Description
- Guard timeline updates so `brewingStatus` is checked before reading `currentStep.mode` and using `elapsedTime`. (updated `src/containers/Production/Production.tsx`)
- Use `brewingStatus.elapsedTime` after narrowing and provide safe numeric defaults where optional values were previously passed through to strictly-typed fields (timeline entries and timeline refresh).
- Make hop-reminder elapsed lookup robust with optional chaining and `?? 0` when `brewingStatus` is missing.
- Narrow `elapsedTime` into a local `currentElapsedTime` and verify it is a number before passing to `formatTime`, avoiding passing `number | undefined` into formatting code.

### Testing
- Ran `git diff --check` to validate whitespace/diff issues which passed.
- Attempted to run a full build (`npm run build`) and TypeScript checks, but `node_modules`/build tooling is not available in this environment so the build could not complete (`react-scripts`/local `tsc` not present).
- Attempted dependency install (`npm ci`) but it failed due to registry permission errors for `@types/react`, so a full local compile/test run could not be completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a53ea9fc714832faa34e63a4a6153b4)