### PR TITLE
Fix mash-out confirmation dialog mapping

### DIFF
--- a/docs/codex/data-flow.md
+++ b/docs/codex/data-flow.md
@@ -49,6 +49,7 @@ Needs verification: backend ordering of `GET beers`, because the UI treats the l
 - UI maps only concrete waiting reasons to confirm endpoints:
   - `IODINE_TEST` -> `Confirm/Iodine`
   - `MASHING_IN_CONFIRMATION` -> `Confirm/Mashup`
+  - `MASHING_OUT_CONFIRMATION` -> `Confirm/Mashup`
   - `BOILING_CONFIRMATION` -> `Confirm/Boiling`
   - `COOKING_CONFIRMATION` -> `Confirm/Cooking`
   - `DECOCTION_CONFIRMATION` -> `Confirm/Decoction`

--- a/docs/codex/domain-model.md
+++ b/docs/codex/domain-model.md
@@ -36,7 +36,7 @@ Runtime status is normalized into process state, current step, temperature, hard
 - `currentStep.duration`, `currentStep.elapsedTime`, and `currentStep.remainingTime`: duration/progress/countdown values in seconds. `currentTime` is preserved in collected status data but must not be used as a duration/countdown unless the PI control contract changes.
 - `temperature.current`/`target`: gauges and mobile display.
 - `hardware.heater`/`agitator`: flames, water-control agitator visual, mobile agitator display.
-- `waiting.waitingFor`/`canConfirm`: modal content and confirm endpoint mapping.
+- `waiting.waitingFor`/`canConfirm`: modal content and confirm endpoint mapping. `MASHING_OUT_CONFIRMATION` uses the existing `Confirm/Mashup` control confirmation value.
 
 ## Finished brew (`FinishedBrew`)
 

--- a/src/containers/index.test.tsx
+++ b/src/containers/index.test.tsx
@@ -1,21 +1,112 @@
 import React from 'react';
-import {render, screen} from '@testing-library/react';
+import {fireEvent, render, screen} from '@testing-library/react';
 import {Index} from './index';
 import {Views} from '../enums/eViews';
-import {BrewingStatus} from '../model/brewingStatus.types';
+import {BrewingStatus, ProcessMode, ProcessPhase, ProcessState, WaitingFor} from '../model/brewingStatus.types';
+import {ConfirmStates} from '../enums/eConfirmStates';
+
+const makeStatus = (overrides: Partial<BrewingStatus> = {}): BrewingStatus => ({
+    elapsedTime: 23,
+    currentTime: 1783885211,
+    process: {state: ProcessState.ACTIVE},
+    currentStep: {
+        index: 6,
+        count: 7,
+        phase: ProcessPhase.MASHING_OUT,
+        mode: ProcessMode.WAITING,
+        name: 'Abmaischen',
+        duration: 0,
+        elapsedTime: 23,
+        remainingTime: 0
+    },
+    temperature: {current: 24, target: 78},
+    hardware: {heater: 'ON', agitator: 'OFF'},
+    waiting: {waitingFor: WaitingFor.MASHING_OUT_CONFIRMATION, canConfirm: true},
+    error: {code: null, details: null},
+    ...overrides,
+});
+
+const renderIndex = (brewingStatus: BrewingStatus, confirm = jest.fn()) => {
+    const result = render(
+        <Index
+            viewState={Views.VERSION}
+            brewingStatus={brewingStatus}
+            confirm={confirm}
+            checkIsBackenAvailable={jest.fn()}
+            webSocketConnect={jest.fn()}
+        />
+    );
+    return {confirm, ...result};
+};
 
 describe('Index view routing', () => {
     it('points the version view to the version page', (): void => {
-        render(
-            <Index
-                viewState={Views.VERSION}
-                brewingStatus={{} as BrewingStatus}
-                confirm={jest.fn()}
-                checkIsBackenAvailable={jest.fn()}
-                webSocketConnect={jest.fn()}
-            />
-        );
+        renderIndex(makeStatus({process: {state: ProcessState.IDLE}, currentStep: {phase: ProcessPhase.NONE, mode: ProcessMode.NONE}, waiting: {waitingFor: WaitingFor.NONE, canConfirm: false}}));
 
         expect(screen.getByRole('heading', {name: 'Version'})).toBeInTheDocument();
+    });
+});
+
+describe('Index waiting confirmation dialog', () => {
+    it('shows the Abmaischen dialog for MASHING_OUT_CONFIRMATION when the active step is waiting and confirmable', () => {
+        renderIndex(makeStatus());
+
+        expect(screen.getByRole('dialog')).toBeInTheDocument();
+        expect(screen.getByText('Abmaischen: Bestätigung nötig')).toBeInTheDocument();
+    });
+
+    it('sends exactly one Mashup confirmation when the Abmaischen dialog is confirmed', () => {
+        const {confirm} = renderIndex(makeStatus());
+
+        fireEvent.click(screen.getByRole('button', {name: 'Ok'}));
+
+        expect(confirm).toHaveBeenCalledTimes(1);
+        expect(confirm).toHaveBeenCalledWith(ConfirmStates.MASHUP);
+    });
+
+    it('does not show a dialog when canConfirm is false', () => {
+        renderIndex(makeStatus({waiting: {waitingFor: WaitingFor.MASHING_OUT_CONFIRMATION, canConfirm: false}}));
+
+        expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
+
+    it('does not show a dialog when the current step is not WAITING', () => {
+        renderIndex(makeStatus({currentStep: {...makeStatus().currentStep, mode: ProcessMode.HEATING}}));
+
+        expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
+
+    it('does not show or send a false confirmation for unknown waitingFor values', () => {
+        const consoleWarn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+        const {confirm} = renderIndex(makeStatus({waiting: {waitingFor: 'UNKNOWN_CONFIRMATION', canConfirm: true}}));
+
+        expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+        expect(confirm).not.toHaveBeenCalled();
+        expect(consoleWarn).toHaveBeenCalledWith(expect.stringContaining('UNKNOWN_CONFIRMATION'));
+        consoleWarn.mockRestore();
+    });
+
+    it('shows the dialog when the initially loaded status is already waiting', () => {
+        renderIndex(makeStatus());
+
+        expect(screen.getByRole('dialog')).toBeInTheDocument();
+    });
+
+    it('keeps a single dialog instance when the same waiting status is received repeatedly through polling', () => {
+        const status = makeStatus();
+        const {rerender} = renderIndex(status);
+
+        rerender(<Index viewState={Views.VERSION} brewingStatus={{...status}} confirm={jest.fn()} checkIsBackenAvailable={jest.fn()} webSocketConnect={jest.fn()} />);
+
+        expect(screen.getAllByRole('dialog')).toHaveLength(1);
+    });
+
+    it('closes the dialog after the waiting state disappears after successful confirmation', () => {
+        const {rerender} = renderIndex(makeStatus());
+
+        expect(screen.getByRole('dialog')).toBeInTheDocument();
+        rerender(<Index viewState={Views.VERSION} brewingStatus={makeStatus({currentStep: {...makeStatus().currentStep, mode: ProcessMode.HEATING}, waiting: {waitingFor: WaitingFor.NONE, canConfirm: false}})} confirm={jest.fn()} checkIsBackenAvailable={jest.fn()} webSocketConnect={jest.fn()} />);
+
+        expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
     });
 });

--- a/src/containers/index.tsx
+++ b/src/containers/index.tsx
@@ -6,16 +6,15 @@ import Production from "./Production/Production";
 import DatabaseOverview from "./DatabaseOverview/BeerForm";
 import SimpleBar from "simplebar-react";
 import ModalDialog, {DialogType} from "../components/ModalDialog/ModalDialog";
-import {BrewingStatus, WaitingFor} from "../model/brewingStatus.types";
-import {BeerActions, ProductionActions} from "../actions/actions";
+import {BrewingStatus} from "../model/brewingStatus.types";
+import {ProductionActions} from "../actions/actions";
 import {ConfirmStates} from "../enums/eConfirmStates";
-import {FinishedBrew} from "../model/FinishedBrew";
 import FinishedBrewsTable from "./MainView/FinishBrewsBeers/FinishedBrewsTable";
 import BrewingCalculations from "./BrewingCalculations/BrewingCalculations";
 import IngredientsFormPage from "./DatabaseOverview/IngredientsFormPage";
 import SettingsPage from "./Settings/SettingsPage";
 import VersionPage from "./Version/VersionPage";
-import {getBrewingStatusLabel, shouldShowConfirmButton, shouldShowWaitingDialog} from "../utils/brewingStatus/selectors";
+import {getBrewingStatusLabel, getConfirmationType, shouldShowConfirmButton, shouldShowWaitingDialog} from "../utils/brewingStatus/selectors";
 
 interface indexMainProps {
     viewState: Views;
@@ -43,24 +42,7 @@ export class Index extends React.Component<indexMainProps> {
         }
     }
 
-    getConfirmStateForWaiting = (): ConfirmStates | undefined => {
-        const waitingFor = this.props.brewingStatus?.waiting?.waitingFor;
-        // Wait is a status, not a confirm command. Only concrete wait reasons may send Confirm endpoints.
-        switch (waitingFor) {
-            case WaitingFor.IODINE_TEST:
-                return ConfirmStates.IODINE;
-            case WaitingFor.MASHING_IN_CONFIRMATION:
-                return ConfirmStates.MASHUP;
-            case WaitingFor.BOILING_CONFIRMATION:
-                return ConfirmStates.BOILING;
-            case WaitingFor.COOKING_CONFIRMATION:
-                return ConfirmStates.COOKING;
-            case WaitingFor.DECOCTION_CONFIRMATION:
-                return ConfirmStates.DECOCTION;
-            default:
-                return undefined;
-        }
-    }
+    getConfirmStateForWaiting = (): ConfirmStates | undefined => getConfirmationType(this.props.brewingStatus);
 
     confirmDialog = () => {
         const {confirm} = this.props;

--- a/src/model/brewingStatus.types.ts
+++ b/src/model/brewingStatus.types.ts
@@ -37,6 +37,8 @@ export enum WaitingFor {
     DECOCTION_CONFIRMATION = "DECOCTION_CONFIRMATION"
 }
 
+export type WaitingState = WaitingFor | string;
+
 export interface BrewingStatus {
     elapsedTime: number;
     currentTime: number;
@@ -63,7 +65,7 @@ export interface BrewingStatus {
         agitator?: string;
     };
     waiting: {
-        waitingFor: WaitingFor;
+        waitingFor: WaitingState;
         canConfirm: boolean;
     };
     error: {

--- a/src/utils/brewingStatus/normalizeBrewingStatus.test.ts
+++ b/src/utils/brewingStatus/normalizeBrewingStatus.test.ts
@@ -23,4 +23,9 @@ describe('normalizeBrewingStatus', () => {
     expect(s.currentStep.mode).toBe(ProcessMode.HOLDING);
     expect(s.waiting.waitingFor).toBe(WaitingFor.IODINE_TEST);
   });
+
+  it('preserves unknown waitingFor values for central confirmation mapping warnings', () => {
+    const s = normalizeBrewingStatus({waiting:{waitingFor:'future_confirmation', canConfirm:true}});
+    expect(s.waiting.waitingFor).toBe('FUTURE_CONFIRMATION');
+  });
 });

--- a/src/utils/brewingStatus/normalizeBrewingStatus.ts
+++ b/src/utils/brewingStatus/normalizeBrewingStatus.ts
@@ -1,9 +1,9 @@
-import {BrewingStatus, LegacyBrewingStatus, ProcessMode, ProcessPhase, ProcessState, WaitingFor} from '../../model/brewingStatus.types';
+import {BrewingStatus, LegacyBrewingStatus, ProcessMode, ProcessPhase, ProcessState, WaitingFor, WaitingState} from '../../model/brewingStatus.types';
 const isObject = (aValue: unknown): aValue is Record<string, any> => typeof aValue === 'object' && aValue !== null;
 const normalizePhase = (aValue: unknown): ProcessPhase => { if (typeof aValue !== 'string') return ProcessPhase.NONE; const mapped = aValue.toUpperCase(); return (Object.values(ProcessPhase) as string[]).includes(mapped) ? mapped as ProcessPhase : ProcessPhase.NONE; };
 const normalizeMode = (aValue: unknown): ProcessMode => { if (typeof aValue !== 'string') return ProcessMode.NONE; const mapped = aValue.toUpperCase(); return (Object.values(ProcessMode) as string[]).includes(mapped) ? mapped as ProcessMode : ProcessMode.NONE; };
 const normalizeState = (aValue: unknown): ProcessState => { if (typeof aValue !== 'string') return ProcessState.IDLE; const mapped = aValue.toUpperCase(); return (Object.values(ProcessState) as string[]).includes(mapped) ? mapped as ProcessState : ProcessState.IDLE; };
-const normalizeWaitingFor = (aValue: unknown): WaitingFor => { if (typeof aValue !== 'string') return WaitingFor.NONE; const mapped = aValue.toUpperCase(); return (Object.values(WaitingFor) as string[]).includes(mapped) ? mapped as WaitingFor : WaitingFor.NONE; };
+const normalizeWaitingFor = (aValue: unknown): WaitingState => { if (typeof aValue !== 'string') return WaitingFor.NONE; const mapped = aValue.toUpperCase(); return (Object.values(WaitingFor) as string[]).includes(mapped) ? mapped as WaitingFor : mapped; };
 const mapLegacyTypeToPhase = (aType: unknown): ProcessPhase => { const value = typeof aType === 'string' ? aType.toUpperCase() : ''; if (value.includes('COOK')) return ProcessPhase.COOKING; if (value.includes('FINISH')) return ProcessPhase.FINISHED; if (value.includes('RAST')) return ProcessPhase.RAST; if (value.includes('MASHING_IN') || value.includes('EINMA')) return ProcessPhase.MASHING_IN; if (value.includes('MASHING_OUT') || value.includes('ABMA')) return ProcessPhase.MASHING_OUT; return ProcessPhase.NONE; };
 /**
  * Zentrale Kompatibilitätsschicht:

--- a/src/utils/brewingStatus/selectors.test.ts
+++ b/src/utils/brewingStatus/selectors.test.ts
@@ -1,5 +1,6 @@
-import {getBrewingStatusLabel, getConfirmButtonLabel, getCountdownValue, isBrewingProcessActive, shouldShowConfirmButton, shouldShowCountdown, shouldShowWaitingDialog} from './selectors';
+import {getBrewingStatusLabel, getConfirmButtonLabel, getConfirmationType, getCountdownValue, isBrewingProcessActive, shouldShowConfirmButton, shouldShowCountdown, shouldShowWaitingDialog} from './selectors';
 import {BrewingStatus, ProcessMode, ProcessPhase, ProcessState, WaitingFor} from '../../model/brewingStatus.types';
+import {ConfirmStates} from '../../enums/eConfirmStates';
 
 const makeStatus = (aPart: Partial<BrewingStatus>): BrewingStatus => ({
   elapsedTime: 0, currentTime: 0,
@@ -39,6 +40,18 @@ describe('brewing selectors', () => {
   it('does not enable or show confirmation without a concrete confirm endpoint', () => {
     const s = makeStatus({currentStep:{phase:ProcessPhase.RAST, mode:ProcessMode.WAITING}, waiting:{waitingFor:WaitingFor.USER_CONFIRMATION, canConfirm:true}});
     expect(shouldShowConfirmButton(s)).toBe(false);
+    expect(shouldShowWaitingDialog(s)).toBe(false);
+  });
+
+  it('maps MASHING_OUT_CONFIRMATION to the existing Mashup confirmation endpoint', () => {
+    const s = makeStatus({currentStep:{phase:ProcessPhase.MASHING_OUT, mode:ProcessMode.WAITING}, waiting:{waitingFor:WaitingFor.MASHING_OUT_CONFIRMATION, canConfirm:true}});
+    expect(getConfirmationType(s)).toBe(ConfirmStates.MASHUP);
+    expect(shouldShowWaitingDialog(s)).toBe(true);
+    expect(shouldShowConfirmButton(s)).toBe(true);
+  });
+
+  it('requires canConfirm to show the confirmation dialog', () => {
+    const s = makeStatus({currentStep:{phase:ProcessPhase.MASHING_OUT, mode:ProcessMode.WAITING}, waiting:{waitingFor:WaitingFor.MASHING_OUT_CONFIRMATION, canConfirm:false}});
     expect(shouldShowWaitingDialog(s)).toBe(false);
   });
 

--- a/src/utils/brewingStatus/selectors.ts
+++ b/src/utils/brewingStatus/selectors.ts
@@ -1,4 +1,5 @@
-import {BrewingStatus, ProcessMode, ProcessPhase, ProcessState, WaitingFor} from '../../model/brewingStatus.types';
+import {ConfirmStates} from '../../enums/eConfirmStates';
+import {BrewingStatus, ProcessMode, ProcessPhase, ProcessState, WaitingFor, WaitingState} from '../../model/brewingStatus.types';
 
 /**
  * Diese Selektoren kapseln alle UI-Entscheidungen.
@@ -12,10 +13,36 @@ export const isProcessFinished = (aStatus?: BrewingStatus) => aStatus?.process.s
 export const isProcessAborted = (aStatus?: BrewingStatus) => aStatus?.process.state === ProcessState.ABORTED;
 export const isProcessInError = (aStatus?: BrewingStatus) => aStatus?.process.state === ProcessState.ERROR;
 export const isStepWaiting = (aStatus?: BrewingStatus) => aStatus?.currentStep.mode === ProcessMode.WAITING;
-const CONCRETE_CONFIRMATION_WAITING_REASONS = [WaitingFor.IODINE_TEST, WaitingFor.MASHING_IN_CONFIRMATION, WaitingFor.BOILING_CONFIRMATION, WaitingFor.COOKING_CONFIRMATION, WaitingFor.DECOCTION_CONFIRMATION];
-export const hasConcreteConfirmation = (aStatus?: BrewingStatus) => !!aStatus && CONCRETE_CONFIRMATION_WAITING_REASONS.includes(aStatus.waiting.waitingFor);
-export const shouldShowWaitingDialog = (aStatus?: BrewingStatus) => !!aStatus && isProcessActive(aStatus) && isStepWaiting(aStatus) && hasConcreteConfirmation(aStatus);
-export const shouldShowConfirmButton = (aStatus?: BrewingStatus) => !!aStatus && isStepWaiting(aStatus) && aStatus.waiting.canConfirm && hasConcreteConfirmation(aStatus);
+
+export const confirmationTypeByWaitingState: Partial<Record<WaitingState, ConfirmStates>> = {
+    [WaitingFor.IODINE_TEST]: ConfirmStates.IODINE,
+    [WaitingFor.MASHING_IN_CONFIRMATION]: ConfirmStates.MASHUP,
+    [WaitingFor.MASHING_OUT_CONFIRMATION]: ConfirmStates.MASHUP,
+    [WaitingFor.BOILING_CONFIRMATION]: ConfirmStates.BOILING,
+    [WaitingFor.COOKING_CONFIRMATION]: ConfirmStates.COOKING,
+    [WaitingFor.DECOCTION_CONFIRMATION]: ConfirmStates.DECOCTION,
+};
+
+const warnedUnknownWaitingStates = new Set<string>();
+const waitingStatesWithoutConfirmEndpoint = [WaitingFor.NONE, WaitingFor.USER_CONFIRMATION];
+
+export const getConfirmationTypeForWaitingState = (aWaitingFor?: WaitingState): ConfirmStates | undefined => {
+    if (!aWaitingFor || waitingStatesWithoutConfirmEndpoint.includes(aWaitingFor as WaitingFor)) {
+        return undefined;
+    }
+
+    const confirmationType = confirmationTypeByWaitingState[aWaitingFor];
+    if (confirmationType === undefined && !warnedUnknownWaitingStates.has(aWaitingFor)) {
+        warnedUnknownWaitingStates.add(aWaitingFor);
+        console.warn(`Unknown waitingFor value "${aWaitingFor}" has no concrete confirmation command; no Confirm endpoint will be called.`);
+    }
+    return confirmationType;
+};
+
+export const getConfirmationType = (aStatus?: BrewingStatus) => getConfirmationTypeForWaitingState(aStatus?.waiting.waitingFor);
+export const hasConcreteConfirmation = (aStatus?: BrewingStatus) => getConfirmationType(aStatus) !== undefined;
+export const shouldShowWaitingDialog = (aStatus?: BrewingStatus) => !!aStatus && isProcessActive(aStatus) && isStepWaiting(aStatus) && aStatus.waiting.canConfirm === true && hasConcreteConfirmation(aStatus);
+export const shouldShowConfirmButton = (aStatus?: BrewingStatus) => shouldShowWaitingDialog(aStatus);
 export const getConfirmButtonLabel = (aStatus?: BrewingStatus) => {
     switch (aStatus?.waiting.waitingFor) {
         case WaitingFor.IODINE_TEST: return 'Iodine bestätigen';


### PR DESCRIPTION
### Motivation
- The UI did not open the confirmation dialog for a waiting `MASHING_OUT_CONFIRMATION` because that waiting state was not mapped to a concrete confirmation type and therefore no Confirm endpoint was chosen.
- The dialog logic was scattered and could silently drop unknown `waitingFor` values by normalizing them to `NONE`, preventing proper warnings and causing missed dialogs.
- The change centralizes the backend-to-UI confirmation mapping to avoid duplicated string comparisons and to ensure dialogs appear for an initially-loaded waiting status and are not stacked on repeated polls.

### Description
- Add a central mapping `confirmationTypeByWaitingState` and `getConfirmationType` in `src/utils/brewingStatus/selectors.ts` that maps `MASHING_OUT_CONFIRMATION` to `ConfirmStates.MASHUP` (API `Confirm/Mashup`) and preserves existing mappings for Iodine, MASHING_IN, Boiling, Cooking and Decoction.
- Change the dialog visibility gating to require `process.state === ProcessState.ACTIVE`, `currentStep.mode === ProcessMode.WAITING`, `waiting.canConfirm === true`, and a known confirmation type (via `getConfirmationType`).
- Preserve unknown `waitingFor` strings (uppercased) in `normalizeBrewingStatus` instead of converting them to `NONE`, so the central mapper can warn once and avoid sending an incorrect Confirm request.
- Replace the local `switch` in `src/containers/index.tsx` with the central mapping (`getConfirmationType`) and keep sending only concrete confirm values; add unit tests and update Codex docs to document `MASHING_OUT_CONFIRMATION -> Confirm/Mashup`.
- Files changed: `src/utils/brewingStatus/selectors.ts`, `src/utils/brewingStatus/selectors.test.ts`, `src/utils/brewingStatus/normalizeBrewingStatus.ts`, `src/utils/brewingStatus/normalizeBrewingStatus.test.ts`, `src/model/brewingStatus.types.ts`, `src/containers/index.tsx`, `src/containers/index.test.tsx`, and documentation updates in `docs/codex/data-flow.md` and `docs/codex/domain-model.md`.

### Testing
- `git diff --check` passed successfully after applying changes.
- Unit tests were added/updated (`src/utils/brewingStatus/selectors.test.ts`, `src/utils/brewingStatus/normalizeBrewingStatus.test.ts`, `src/containers/index.test.tsx`) covering: `MASHING_OUT_CONFIRMATION` dialog display, sending exactly one `ConfirmStates.MASHUP`, `canConfirm` gating, non-`WAITING` gating, unknown `waitingFor` behavior (warning + no dialog), initial waiting status display, poll idempotence (no dialog stacking), and dialog close after waiting ends.
- Attempted to run the Jest subset in this environment but automated test execution failed because the workspace lacks installed `node_modules` and `react-scripts` (npm registry access/installation failed), so test execution could not complete here; the new/updated tests should run and pass in CI or a dev environment with dependencies installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a53ee0a2eb8832fb7562aef3ecc854c)