### PR TITLE
Fix TypeScript compile errors

### DIFF
--- a/src/epics/productionEpics.test.ts
+++ b/src/epics/productionEpics.test.ts
@@ -85,7 +85,9 @@ describe('startWaterFillingEpic$', () => {
 
     const action$ = new Subject<ProductionActions.StartWaterFilling>();
     const emittedActions: ProductionActions.AllProductionActions[] = [];
-    const subscription = startWaterFillingEpic$(action$).subscribe((aAction: ProductionActions.AllProductionActions): void => emittedActions.push(aAction));
+    const subscription = startWaterFillingEpic$(action$).subscribe((aAction: ProductionActions.AllProductionActions): void => {
+      emittedActions.push(aAction);
+    });
 
     action$.next(ProductionActions.startWaterFilling(24.8));
     await flushPromises();
@@ -138,7 +140,9 @@ describe('startWaterFillingEpic$', () => {
 
     const action$ = new Subject<ProductionActions.StartWaterFilling>();
     const emittedActions: ProductionActions.AllProductionActions[] = [];
-    const subscription = startWaterFillingEpic$(action$).subscribe((aAction: ProductionActions.AllProductionActions): void => emittedActions.push(aAction));
+    const subscription = startWaterFillingEpic$(action$).subscribe((aAction: ProductionActions.AllProductionActions): void => {
+      emittedActions.push(aAction);
+    });
 
     action$.next(ProductionActions.startWaterFilling(24.8));
     await flushPromises();
@@ -165,7 +169,9 @@ describe('startWaterFillingEpic$', () => {
 
     const action$ = new Subject<ProductionActions.StartWaterFilling>();
     const emittedActions: ProductionActions.AllProductionActions[] = [];
-    const subscription = startWaterFillingEpic$(action$).subscribe((aAction: ProductionActions.AllProductionActions): void => emittedActions.push(aAction));
+    const subscription = startWaterFillingEpic$(action$).subscribe((aAction: ProductionActions.AllProductionActions): void => {
+      emittedActions.push(aAction);
+    });
 
     action$.next(ProductionActions.startWaterFilling(24.8));
     await flushPromises();
@@ -218,7 +224,9 @@ describe('sendBrewingDataEpic$', (): void => {
 
     const action$ = new Subject<ProductionActions.SendBrewingData>();
     const emittedActions: ProductionActions.AllProductionActions[] = [];
-    const subscription = sendBrewingDataEpic$(action$).subscribe((aAction: ProductionActions.AllProductionActions): void => emittedActions.push(aAction));
+    const subscription = sendBrewingDataEpic$(action$).subscribe((aAction: ProductionActions.AllProductionActions): void => {
+      emittedActions.push(aAction);
+    });
 
     action$.next(ProductionActions.sendBrewingData(createBrewingData()));
     await flushPromises();
@@ -237,7 +245,9 @@ describe('sendBrewingDataEpic$', (): void => {
 
     const action$ = new Subject<ProductionActions.SendBrewingData>();
     const emittedActions: ProductionActions.AllProductionActions[] = [];
-    const subscription = sendBrewingDataEpic$(action$).subscribe((aAction: ProductionActions.AllProductionActions): void => emittedActions.push(aAction));
+    const subscription = sendBrewingDataEpic$(action$).subscribe((aAction: ProductionActions.AllProductionActions): void => {
+      emittedActions.push(aAction);
+    });
 
     action$.next(ProductionActions.sendBrewingData(createBrewingData()));
     await flushPromises();

--- a/src/utils/debugMetrics.ts
+++ b/src/utils/debugMetrics.ts
@@ -2,7 +2,7 @@ import {ProcessState} from '../model/brewingStatus.types';
 
 export interface DebugMetricsStateSnapshot {
     applicationReducer?: {
-        view?: string;
+        view?: string | number;
         message?: string[];
     };
     productionReducer?: {


### PR DESCRIPTION
### Motivation
- Fix TypeScript errors where RxJS test subscription callbacks annotated as `void` were implicitly returning the numeric result of `Array.push`, causing `TS2322` in tests.
- Align `debugMetrics` snapshot typing with the actual Redux state that stores the view as a numeric `Views` enum value instead of a `string`.

### Description
- Updated subscription callbacks in `src/epics/productionEpics.test.ts` to use block bodies so `void`-typed callbacks do not return the `number` from `emittedActions.push(...)`.
- Broadened the `DebugMetricsStateSnapshot.applicationReducer.view` type from `string` to `string | number` in `src/utils/debugMetrics.ts` to accept the numeric `Views` enum.
- Changes touch `src/epics/productionEpics.test.ts` and `src/utils/debugMetrics.ts` only.

### Testing
- Ran `git diff --check` to validate whitespace and basic diffs successfully.
- Attempted `npm run build` and running the test suite but the build/test wrapper could not complete because project dependencies are not installed (`node_modules/.bin/react-scripts` missing) in this environment.
- Attempted `npm ci` to install dependencies but it failed due to a `403 Forbidden` from the npm registry for `@types/react`, so automated build/tests could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5491e61e98832f832d7600c1d09b9c)