### PR TITLE
Distinguish POST vs PUT for beer recipes; validate ingredient quantities and merge backend IDs

### DIFF
--- a/docs/codex/compatibility/cross-repo-contracts.md
+++ b/docs/codex/compatibility/cross-repo-contracts.md
@@ -131,12 +131,12 @@ Use `elapsedTime`, `currentStep.duration`, and `currentStep.remainingTime` for p
 
 UI should still keep defensive handling for null, undefined, or failed HTTP responses.
 
-### `POST /beer` response
+### Beer recipe create/update
 
-- UI documentation expects a created/imported `Beer`.
-- Database documentation says `POST /beer` returns only a message.
-
-Do not rely on this response without checking actual UI code and backend behavior.
+- New beer recipes are created with `POST /beer`; the request body must not include `id`.
+- Existing beer recipes are updated with `PUT /beer/{id}`; the path id is authoritative and body id, when present, must match it.
+- Create/update responses may include only `{ id, message, beer: { id } }`; the UI must preserve its current form data and merge the returned id instead of requiring a full `Beer`.
+- Unknown update ids return `404 BEER_NOT_FOUND` and must not trigger an automatic POST fallback.
 
 ## Compatibility rule
 

--- a/docs/codex/interfaces.md
+++ b/docs/codex/interfaces.md
@@ -7,7 +7,8 @@ Base URL: `DatabaseURL` (`http://192.168.178.72:5000/`).
 | Method | Path | UI use | Payload/response expected |
 |---|---|---|---|
 | GET | `beers` | Load recipes | `Beer[]` |
-| POST | `beer` | Create/submit recipe | `BeerDTO`, returns `Beer` |
+| POST | `beer` | Create recipe | `BeerDTO` without `id`, returns `{ id, message, beer: { id } }` |
+| PUT | `beer/{id}` | Update recipe | `BeerDTO` with matching `id` or no body id, returns `{ id, message, beer: { id } }`; unknown id returns `404 BEER_NOT_FOUND` |
 | DELETE | `beer/{id}` | Delete recipe | no body |
 | POST | `importbeer` | Import recipe file | multipart `file`, response `any`/imported beer |
 | GET | `finishedbeers` | Load finished brews | `FinishedBrew[]` |

--- a/scripts/build-with-version.js
+++ b/scripts/build-with-version.js
@@ -2,8 +2,9 @@ const { spawnSync } = require('child_process');
 const { resolveAppVersion } = require('./resolve-app-version');
 
 const script = process.argv[2] || 'build';
+const forwardedArgs = process.argv.slice(3);
 const appVersion = resolveAppVersion(process.env);
-const result = spawnSync(process.platform === 'win32' ? 'node_modules/.bin/react-scripts.cmd' : 'node_modules/.bin/react-scripts', [script], {
+const result = spawnSync(process.platform === 'win32' ? 'node_modules/.bin/react-scripts.cmd' : 'node_modules/.bin/react-scripts', [script, ...forwardedArgs], {
   stdio: 'inherit',
   env: {
     ...process.env,

--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -80,6 +80,7 @@ export namespace BeerActions {
 
     export interface SubmitBeerSuccess {
         readonly type: ActionTypes.SUBMIT_BEER_SUCCESS
+        payload: { beer: BeerDTO }
     }
 
     export interface SetSelectedBeer {
@@ -268,9 +269,10 @@ export namespace BeerActions {
         }
     }
 
-    export function submitBeerSuccess(): SubmitBeerSuccess {
+    export function submitBeerSuccess(aBeer: BeerDTO): SubmitBeerSuccess {
         return {
-            type: ActionTypes.SUBMIT_BEER_SUCCESS
+            type: ActionTypes.SUBMIT_BEER_SUCCESS,
+            payload: {beer: aBeer}
         }
     }
 

--- a/src/containers/DatabaseOverview/BeerForm.tsx
+++ b/src/containers/DatabaseOverview/BeerForm.tsx
@@ -22,6 +22,7 @@ import {AdditionalIngredientsActions} from "../../actions/additionalIngredients.
 import {AdditionalIngredient} from "../../model/AdditionalIngredient";
 import { COLOR_WHITE, COLOR_BREW_BG, COLOR_ACCENT, BORDER_TRANSPARENT, COLOR_DARK_BG, COLOR_BORDER_INPUT_ALT } from '../../colors';
 import ModalDialog, {DialogType} from "../../components/ModalDialog/ModalDialog";
+import { isRequiredPositiveQuantity } from "../../utils/beerSubmission";
 
 interface BeerFormProps {
     onSubmitBeer: (beer: BeerDTO) => void;
@@ -41,6 +42,7 @@ interface BeerFormProps {
     beers: Beer[];
     importBeer: (file: File) => void;
     importedBeer?: Beer;
+    isSavingBeer?: boolean;
 }
 
 interface BeerFormState {
@@ -68,6 +70,7 @@ interface BeerFormState {
     missingYeasts?: string[];
     showValidationDialog: boolean;
     validationDialogMessage: string;
+    validationErrors: Record<string, string>;
 }
 
 class BeerForm extends React.Component<BeerFormProps, BeerFormState> {
@@ -79,7 +82,7 @@ class BeerForm extends React.Component<BeerFormProps, BeerFormState> {
 
 
         const defaultState = {
-            id: '0',
+            id: '',
             name: '',
             type: '',
             color: '',
@@ -97,13 +100,14 @@ class BeerForm extends React.Component<BeerFormProps, BeerFormState> {
                 { type: 'Abmaischen', temperature: 0, time: 0 },
                 { type: 'Kochen', temperature: 0, time: 0 }
             ],
-            maltsDTO: [{ id: '', name: '', quantity: 0 }],
-            hopsDTO: [{ id: '', name: '', quantity: 0, time: 0, usage: HopUsage.BOIL, timeUnit: HopTimeUnit.MINUTES }],
-            yeastsDTO: [{ id: '', name: '', quantity: 0 }],
+            maltsDTO: [{ id: '', name: '', quantity: undefined as any }],
+            hopsDTO: [{ id: '', name: '', quantity: undefined as any, time: 0, usage: HopUsage.BOIL, timeUnit: HopTimeUnit.MINUTES }],
+            yeastsDTO: [{ id: '', name: '', quantity: undefined as any }],
             additionalIngredientsDTO: [],
             isSubmitSuccessful: false,
             showValidationDialog: false,
             validationDialogMessage: '',
+            validationErrors: {},
         };
 
         // Wenn ein gespeicherter Formularstatus existiert, verwenden wir diesen, ansonsten den Standardstatus
@@ -135,7 +139,7 @@ class BeerForm extends React.Component<BeerFormProps, BeerFormState> {
         // Wenn importedBeer gesetzt ist und sich geändert hat, Formular mit importierten Daten füllen
         if (importedBeer && importedBeer !== prevProps.importedBeer) {
             this.setState({
-                id: importedBeer.id || '0',
+                id: importedBeer.id || '',
                 name: importedBeer.name || '',
                 type: importedBeer.type || '',
                 color: importedBeer.color || '',
@@ -164,6 +168,10 @@ class BeerForm extends React.Component<BeerFormProps, BeerFormState> {
 
         if (!isEqual(this.state, prevState)) {
             this.props.saveBeerFormState(this.state);
+        }
+
+        if (this.props.beerFormState?.id && this.props.beerFormState.id !== prevProps.beerFormState?.id && this.props.beerFormState.id !== this.state.id) {
+            this.setState({id: this.props.beerFormState.id});
         }
     }
 
@@ -233,7 +241,7 @@ class BeerForm extends React.Component<BeerFormProps, BeerFormState> {
                 // usage/timeUnit wird getrennt geführt; Zeit darf nicht als DRY_HOP-Marker missbraucht werden.
                 const parsed = Number(aValue);
                 // @ts-ignore
-                step[aName] = isNaN(parsed) ? 0 : parsed;
+                step[aName] = aValue === '' ? undefined : (isNaN(parsed) ? aValue : parsed);
             } else if (aName === "timeUnit") {
                 step.timeUnit = aValue as HopTimeUnit;
             } else {
@@ -286,7 +294,7 @@ class BeerForm extends React.Component<BeerFormProps, BeerFormState> {
                 const aParsed = Number(aValue);
                 // time ist optional; leeres Feld bleibt undefined statt 0 als Marker.
                 // @ts-ignore
-                aStep[aName] = aValue === '' ? undefined : (isNaN(aParsed) ? 0 : aParsed);
+                aStep[aName] = aValue === '' ? undefined : (isNaN(aParsed) ? aValue : aParsed);
             } else if (aName === "phase") {
                 aStep.phase = aValue as AdditionalIngredientPhase;
             } else if (aName === "timeUnit") {
@@ -312,7 +320,7 @@ class BeerForm extends React.Component<BeerFormProps, BeerFormState> {
         for (const aIngredient of aIngredients) {
             const aHasIdOrName = !!aIngredient.id || !!(aIngredient.name && aIngredient.name.trim().length > 0);
             if (!aHasIdOrName) return false;
-            if (!(Number(aIngredient.quantity) > 0)) return false;
+            if (!this.isValidQuantity(aIngredient.quantity)) return false;
             if (!aIngredient.unit || aIngredient.unit.trim().length === 0) return false;
             if (!Object.values(AdditionalIngredientPhase).includes(aIngredient.phase)) return false;
             if (aIngredient.time !== undefined && !(Number(aIngredient.time) > 0)) return false;
@@ -320,6 +328,36 @@ class BeerForm extends React.Component<BeerFormProps, BeerFormState> {
         }
         return true;
     }
+
+    isValidQuantity = (aValue: unknown): boolean => {
+        return isRequiredPositiveQuantity(aValue);
+    };
+
+    validateIngredientQuantities = () => {
+        const validationErrors: Record<string, string> = {};
+        const quantityError = 'Bitte eine gültige Menge größer als 0 eingeben.';
+
+        this.state.maltsDTO.forEach((malt, index) => {
+            if (!this.isValidQuantity(malt.quantity)) validationErrors[`maltsDTO.${index}.quantity`] = quantityError;
+        });
+        this.state.hopsDTO.forEach((hop, index) => {
+            if (!this.isValidQuantity(hop.quantity)) validationErrors[`hopsDTO.${index}.quantity`] = quantityError;
+        });
+        this.state.yeastsDTO.forEach((yeast, index) => {
+            if (!this.isValidQuantity(yeast.quantity)) validationErrors[`yeastsDTO.${index}.quantity`] = quantityError;
+        });
+        this.state.additionalIngredientsDTO.forEach((ingredient, index) => {
+            if (!this.isValidQuantity(ingredient.quantity)) validationErrors[`additionalIngredientsDTO.${index}.quantity`] = quantityError;
+        });
+
+        this.setState({validationErrors});
+        return validationErrors;
+    };
+
+    renderFieldError = (aKey: string) => {
+        const error = this.state.validationErrors[aKey];
+        return error ? <div role="alert" style={{color: 'red', fontSize: '0.8rem'}}>{error}</div> : null;
+    };
 
 
 
@@ -346,6 +384,11 @@ class BeerForm extends React.Component<BeerFormProps, BeerFormState> {
             yeastsDTO,
             additionalIngredientsDTO,
         } = this.state;
+        const quantityValidationErrors = this.validateIngredientQuantities();
+        if (Object.keys(quantityValidationErrors).length > 0) {
+            this.openValidationDialog('Bitte korrigiere die markierten Mengenfelder. Mengen sind erforderlich und müssen größer als 0 sein.');
+            return;
+        }
         if (!this.validateFermentationSteps(fermentationSteps)) {
             this.openValidationDialog('Bitte prüfe den Maischeplan: Zeitgesteuerte Rasten benötigen Zeit > 0, Halte-Rasten nur Temperatur.');
             return;
@@ -355,7 +398,7 @@ class BeerForm extends React.Component<BeerFormProps, BeerFormState> {
             .map((aMalt) => {
                 const malt = malts.find((malt) => malt.name === aMalt.name);
                 if (!malt) return undefined;
-                const quantity = aMalt.quantity;
+                const quantity = Number(aMalt.quantity);
                 return { name: malt.name, id: malt.id, quantity: quantity };
             })
             .filter((m): m is MaltDTO => m !== undefined);
@@ -370,7 +413,7 @@ class BeerForm extends React.Component<BeerFormProps, BeerFormState> {
             .map((aHop): HopDTO | undefined => {
                 const hop = hops.find((hop) => hop.name === aHop.name);
                 if (!hop) return undefined;
-                const quantity = aHop.quantity;
+                const quantity = Number(aHop.quantity);
                 const time = aHop.time;
                 return {
                     id: hop.id,
@@ -387,7 +430,7 @@ class BeerForm extends React.Component<BeerFormProps, BeerFormState> {
             .map((aYeast) => {
                 const yeast = yeasts.find((yeast) => yeast.name === aYeast.name);
                 if (!yeast) return undefined;
-                const quantity = aYeast.quantity;
+                const quantity = Number(aYeast.quantity);
                 return { name: yeast.name, id: yeast.id, quantity: quantity };
             })
             .filter((y): y is YeastDTO => y !== undefined);
@@ -398,7 +441,7 @@ class BeerForm extends React.Component<BeerFormProps, BeerFormState> {
         }
 
         const beer: BeerDTO = {
-            id: id || '0',
+            id,
             name,
             type,
             color,
@@ -417,6 +460,7 @@ class BeerForm extends React.Component<BeerFormProps, BeerFormState> {
             fermentationMaturation: { fermentationTemperature: 0, carbonation: 0, yeast: yeasts_DTO},
             // additionalIngredients wird 1:1 aus dem Rezepteditor übernommen, damit Import/Load/Save verlustfrei bleibt.
             additionalIngredients: additionalIngredientsDTO
+                .map((aIngredient) => ({...aIngredient, quantity: Number(aIngredient.quantity)}))
         };
 
         console.log(beer);
@@ -434,6 +478,7 @@ class BeerForm extends React.Component<BeerFormProps, BeerFormState> {
     resetForm = () => {
         this.setState({
             name: '',
+            id: '',
             type: '',
             color: '',
             alcohol: 0,
@@ -450,6 +495,7 @@ class BeerForm extends React.Component<BeerFormProps, BeerFormState> {
             hopsDTO: [],
             yeastsDTO: [],
             additionalIngredientsDTO: [],
+            validationErrors: {},
         }, () => {
             // Nach dem Zurücksetzen des Formulars aktualisieren wir den gespeicherten Status
             this.props.saveBeerFormState(this.state);
@@ -470,26 +516,26 @@ class BeerForm extends React.Component<BeerFormProps, BeerFormState> {
 
     addMalts = () => {
         this.setState((prevState) => ({
-            maltsDTO: [...prevState.maltsDTO, { id: '', name: '', quantity: 0 }],
+            maltsDTO: [...prevState.maltsDTO, { id: '', name: '', quantity: undefined as any }],
         }));
     }
 
     addHops = () => {
         this.setState((prevState) => ({
-            hopsDTO: [...prevState.hopsDTO, { id: '', name: '', quantity: 0, time: 0, usage: HopUsage.BOIL, timeUnit: HopTimeUnit.MINUTES }],
+            hopsDTO: [...prevState.hopsDTO, { id: '', name: '', quantity: undefined as any, time: 0, usage: HopUsage.BOIL, timeUnit: HopTimeUnit.MINUTES }],
         }));
     }
 
     addYeast = () => {
         this.setState((prevState) => ({
-            yeastsDTO: [...prevState.yeastsDTO, {id: '', name: '', quantity: 0}],
+            yeastsDTO: [...prevState.yeastsDTO, {id: '', name: '', quantity: undefined as any}],
         }));
     }
 
     addAdditionalIngredient = () => {
         this.setState((prevState) => ({
             additionalIngredientsDTO: [...prevState.additionalIngredientsDTO, {
-                quantity: 0,
+                quantity: undefined as any,
                 unit: 'g',
                 phase: AdditionalIngredientPhase.MATURATION,
                 time: undefined,
@@ -550,7 +596,7 @@ class BeerForm extends React.Component<BeerFormProps, BeerFormState> {
         const selectedBeer = beers.find(b => String(b.id) === selectedId);
         if (selectedBeer) {
             this.setState({
-                id: selectedBeer.id || '0',
+                id: selectedBeer.id || '',
                 name: selectedBeer.name || '',
                 type: selectedBeer.type || '',
                 color: selectedBeer.color || '',
@@ -828,6 +874,7 @@ class BeerForm extends React.Component<BeerFormProps, BeerFormState> {
                                                     onChange={(e) => this.handleMaltChange(e.target.value, e.target.name, index)}
                                                     required={true}
                                                 />
+                                                {this.renderFieldError(`maltsDTO.${index}.quantity`)}
                                             </td>
                                             <td className="action-column">
                                                 <button
@@ -888,6 +935,7 @@ class BeerForm extends React.Component<BeerFormProps, BeerFormState> {
                                                     onChange={(e) => this.handleHopChange(e.target.value, "quantity", index)}
                                                     required={true}
                                                 />
+                                                {this.renderFieldError(`hopsDTO.${index}.quantity`)}
                                             </td>
                                             <td>
                                                 <select
@@ -980,6 +1028,7 @@ class BeerForm extends React.Component<BeerFormProps, BeerFormState> {
                                                     onChange={(e) => this.handleYeastChange(e.target.value, e.target.name, index)}
                                                     required={true}
                                                 />
+                                                {this.renderFieldError(`yeastsDTO.${index}.quantity`)}
                                             </td>
                                             <td className="action-column">
                                                 <button
@@ -1035,6 +1084,7 @@ class BeerForm extends React.Component<BeerFormProps, BeerFormState> {
                                         <td>
                                             <input type="number" min={0} name="quantity" value={aStep.quantity}
                                                    onChange={(e) => this.handleAdditionalIngredientChange(e.target.value, "quantity", aIndex)} />
+                                            {this.renderFieldError(`additionalIngredientsDTO.${aIndex}.quantity`)}
                                         </td>
                                         <td>
                                             <input type="text" name="unit" value={aStep.unit}
@@ -1081,7 +1131,7 @@ class BeerForm extends React.Component<BeerFormProps, BeerFormState> {
                     </div>
                 </div>
 
-                <button className="finish-btn submit-button" type="submit">
+                <button className="finish-btn submit-button" type="submit" disabled={this.props.isSavingBeer}>
                     <span role="img" aria-label="Erstellen" style={{ fontSize: 22, verticalAlign: 'middle', display: 'inline-block', position: 'relative', top: '3px', marginRight: '8px' }}>💾</span>
                 </button>
             </form>
@@ -1135,6 +1185,7 @@ const mapStateToProps = (state: any) => ({
     beerFormState: state.beerDataReducer.beerFormState,
     beers: state.beerDataReducer.beers,
     importedBeer: state.beerDataReducer.importedBeer,
+    isSavingBeer: state.beerDataReducer.isSavingBeer,
 });
 
 const mapDispatchToProps = (dispatch: any) => ({

--- a/src/epics/beerEpics.ts
+++ b/src/epics/beerEpics.ts
@@ -1,9 +1,10 @@
 import { ofType } from 'redux-observable';
 import {fromEvent, of, from} from 'rxjs';
-import { catchError, map, mergeMap } from 'rxjs/operators';
+import { catchError, exhaustMap, map, mergeMap } from 'rxjs/operators';
 import {ApplicationActions, BeerActions} from '../actions/actions';
 import { BeerRepository } from '../repositorys/BeerRepository';
 import {Beer} from "../model/Beer";
+import { extractBeerErrorMessage, resolveSubmittedBeer } from "../utils/beerSubmission";
 import {FinishedBrew} from "../model/FinishedBrew";
 import { FinishedBrewListPdfStrategy } from '../utils/pdf/finishedBrewStrategy';
 import {PdfGenerator} from "../utils/pdf/PdfGenerator";
@@ -53,15 +54,16 @@ export const getFinishedBeersEpic = (action$: any) =>
 export const submitBeerEpic = (aAction$: any) =>
     aAction$.pipe(
         ofType(BeerActions.ActionTypes.SUBMIT_BEER),
-        mergeMap((aAction: any) =>
+        exhaustMap((aAction: any) =>
             from(BeerRepository.submitBeer(aAction.payload.beer)).pipe(
-                map(() => BeerActions.submitBeerSuccess()),
+                map((aResponse) => BeerActions.submitBeerSuccess(resolveSubmittedBeer(aAction.payload.beer, aResponse))),
                 catchError((aError: Error) =>
                     from([
+                        BeerActions.isSubmitSuccessful(false, extractBeerErrorMessage(aError, "Bier konnte nicht gespeichert werden"), "error"),
                         ApplicationActions.openErrorDialog(
                             true,
                             "Bier fehler",
-                            "Submit Bier: " + aError.message
+                            extractBeerErrorMessage(aError, "Bier konnte nicht gespeichert werden")
                         )
                     ])
                 )

--- a/src/reducers/beerReducer.ts
+++ b/src/reducers/beerReducer.ts
@@ -20,6 +20,7 @@ export interface BeerDataReducerState {
     finishedBrews?: FinishedBrew[] | undefined,
     beerFormState?: any
     importedBeer?: Beer | undefined
+    isSavingBeer?: boolean
 }
 
 export const initialBeerState: BeerDataReducerState =
@@ -32,6 +33,7 @@ export const initialBeerState: BeerDataReducerState =
         message: undefined,
         type: undefined,
         importedBeer: undefined,
+        isSavingBeer: false,
     }
 
 const beerDataReducer = (
@@ -40,7 +42,7 @@ const beerDataReducer = (
 ) => {
   switch (aAction.type) {
     case BeerActions.ActionTypes.SUBMIT_BEER: {
-      return { ...aState };
+      return { ...aState, isSavingBeer: true, isSubmitSuccessful: undefined, message: undefined, type: undefined };
     }
       case BeerActions.ActionTypes.GET_BEERS_SUCCESS: {
           const selectedBeer = aAction.payload.beers.at(-1);
@@ -65,13 +67,35 @@ const beerDataReducer = (
       return { ...aState, selectedBeer: aAction.payload.beer };
     }
     case BeerActions.ActionTypes.SUBMIT_BEER_SUCCESS: {
-      return { ...aState, isSuccessful: true };
+      const submittedBeer = aAction.payload.beer;
+      const beerForList = {
+        ...submittedBeer,
+        fermentation: submittedBeer.fermentationSteps,
+      } as unknown as Beer;
+      const beers = aState.beers ?? [];
+      const existingIndex = beers.findIndex((aBeer) => aBeer.id === submittedBeer.id);
+      const updatedBeers = existingIndex >= 0
+        ? beers.map((aBeer) => aBeer.id === submittedBeer.id ? { ...aBeer, ...beerForList } : aBeer)
+        : [...beers, beerForList];
+
+      return {
+        ...aState,
+        isSuccessful: true,
+        isSubmitSuccessful: true,
+        isSavingBeer: false,
+        message: 'Beer saved successfully',
+        type: 'success',
+        beer: submittedBeer,
+        beers: updatedBeers,
+        selectedBeer: beerForList,
+        beerFormState: aState.beerFormState ? { ...aState.beerFormState, id: submittedBeer.id } : aState.beerFormState,
+      };
     }
 
 
 
     case BeerActions.ActionTypes.SET_IS_SUBMIT_SUCCESSFUL: {
-      return { ...aState, isSubmitSuccessful: aAction.payload.isSubmitSuccessful };
+      return { ...aState, isSubmitSuccessful: aAction.payload.isSubmitSuccessful, isSavingBeer: false, message: aAction.payload.message, type: aAction.payload.type };
     }
     case BeerActions.ActionTypes.SET_BEER_TO_BREW: {
       return { ...aState, beerToBrew: aAction.payload.beer };

--- a/src/repositorys/BaseRepository.ts
+++ b/src/repositorys/BaseRepository.ts
@@ -27,6 +27,16 @@ export class BaseRepository {
         }
     }
 
+    protected static async put<T>(aUrl: string, aBody: any): Promise<T> {
+        try {
+            const aResponse = await api.put<T>(aUrl, aBody);
+            return aResponse.data;
+        } catch (aError) {
+            console.error(`PUT ${aUrl} fehlgeschlagen`, aError);
+            throw aError;
+        }
+    }
+
     protected static async delete(aUrl: string): Promise<void> {
         try {
             await api.delete(aUrl);

--- a/src/repositorys/BeerRepository.test.ts
+++ b/src/repositorys/BeerRepository.test.ts
@@ -1,0 +1,70 @@
+import {api} from './BaseRepository';
+import {BeerRepository} from './BeerRepository';
+import {BeerDTO} from '../model/BeerDTO';
+
+jest.mock('./BaseRepository', () => {
+    const post = jest.fn();
+    const put = jest.fn();
+    return {
+        api: {post, put},
+        BaseRepository: class {
+            protected static async post<T>(aUrl: string, aBody: any): Promise<T> {
+                const response = await post(aUrl, aBody);
+                return response.data;
+            }
+            protected static async put<T>(aUrl: string, aBody: any): Promise<T> {
+                const response = await put(aUrl, aBody);
+                return response.data;
+            }
+        },
+    };
+});
+
+const mockedApi = api as unknown as { post: jest.Mock; put: jest.Mock };
+
+const makeBeer = (id: string): BeerDTO => ({
+    id,
+    name: 'Testbier',
+    type: 'Pils',
+    color: 'hell',
+    alcohol: 5,
+    originalwort: 12,
+    bitterness: 30,
+    description: '',
+    rating: 0,
+    mashVolume: 20,
+    spargeVolume: 10,
+    cookingTime: 60,
+    cookingTemperatur: 99,
+    fermentationSteps: [],
+    malts: [{id: '26', name: 'Pilsener Malz', quantity: 7}],
+    wortBoiling: {totalTime: 60, hops: [{id: '10', name: 'Hallertau', quantity: 50, time: 60}]},
+    fermentationMaturation: {fermentationTemperature: 18, carbonation: 5, yeast: [{id: '1', name: 'Ale', quantity: 1}]},
+});
+
+describe('BeerRepository.submitBeer', () => {
+    beforeEach(() => {
+        mockedApi.post.mockReset();
+        mockedApi.put.mockReset();
+    });
+
+    it('creates a new recipe with POST beer and without id in the body', async () => {
+        mockedApi.post.mockResolvedValueOnce({data: {id: 'generated-id', beer: {id: 'generated-id'}}});
+
+        const result = await BeerRepository.submitBeer(makeBeer(''));
+
+        expect(result.id).toBe('generated-id');
+        expect(mockedApi.post).toHaveBeenCalledWith('beer', expect.not.objectContaining({id: expect.anything()}));
+        expect(mockedApi.put).not.toHaveBeenCalled();
+    });
+
+    it('updates an existing recipe with PUT beer/<id>', async () => {
+        const beer = makeBeer('existing-id');
+        mockedApi.put.mockResolvedValueOnce({data: {id: 'existing-id', beer: {id: 'existing-id'}}});
+
+        await BeerRepository.submitBeer(beer);
+
+        expect(mockedApi.put).toHaveBeenCalledWith('beer/existing-id', expect.objectContaining({id: 'existing-id'}));
+        expect(mockedApi.post).not.toHaveBeenCalled();
+    });
+});

--- a/src/repositorys/BeerRepository.ts
+++ b/src/repositorys/BeerRepository.ts
@@ -4,6 +4,7 @@ import {DatabaseURL} from "../global";
 import {FinishedBrew} from "../model/FinishedBrew";
 import {Beer} from "../model/Beer";
 import {BaseRepository} from "./BaseRepository";
+import { BeerSubmissionResponse, hasPersistedBeerId, toBeerCreatePayload } from "../utils/beerSubmission";
 
 export class BeerRepository extends BaseRepository {
 
@@ -11,9 +12,12 @@ export class BeerRepository extends BaseRepository {
         return this.get<Beer[]>('beers')
     }
 
-    static async submitBeer(aBeer: BeerDTO): Promise<Beer> {
-        console.log(aBeer);
-        return this.post<Beer>("beer", aBeer);
+    static async submitBeer(aBeer: BeerDTO): Promise<BeerSubmissionResponse> {
+        if (hasPersistedBeerId(aBeer)) {
+            return this.put<BeerSubmissionResponse>(`beer/${aBeer.id}`, aBeer);
+        }
+
+        return this.post<BeerSubmissionResponse>("beer", toBeerCreatePayload(aBeer));
     }
 
     static async importBeer(aFile: File): Promise<any> {

--- a/src/utils/beerSubmission.test.ts
+++ b/src/utils/beerSubmission.test.ts
@@ -1,0 +1,72 @@
+import { extractBeerErrorMessage, hasPersistedBeerId, isRequiredPositiveQuantity, resolveSubmittedBeer, toBeerCreatePayload } from './beerSubmission';
+import { BeerDTO } from '../model/BeerDTO';
+
+const makeBeer = (id: any): BeerDTO => ({
+  id,
+  name: 'Testbier',
+  type: 'Pils',
+  color: 'hell',
+  alcohol: 5,
+  originalwort: 12,
+  bitterness: 30,
+  description: '',
+  rating: 0,
+  mashVolume: 20,
+  spargeVolume: 10,
+  cookingTime: 60,
+  cookingTemperatur: 99,
+  fermentationSteps: [],
+  malts: [{ id: '26', name: 'Pilsener Malz', quantity: 7 }],
+  wortBoiling: { totalTime: 60, hops: [{ id: '10', name: 'Hallertau', quantity: 50, time: 60 }] },
+  fermentationMaturation: { fermentationTemperature: 18, carbonation: 5, yeast: [{ id: '1', name: 'Ale', quantity: 1 }] },
+  additionalIngredients: [{ id: 'a1', name: 'Orange', quantity: 2, unit: 'g', phase: 'BOIL' as any }],
+});
+
+describe('beer submission helpers', () => {
+  it('treats empty, missing, and 0 ids as new recipes', () => {
+    expect(hasPersistedBeerId(makeBeer(''))).toBe(false);
+    expect(hasPersistedBeerId(makeBeer('0'))).toBe(false);
+    expect(hasPersistedBeerId(makeBeer(null))).toBe(false);
+    expect(hasPersistedBeerId(makeBeer(undefined))).toBe(false);
+  });
+
+  it('treats a non-empty backend id as an existing recipe', () => {
+    expect(hasPersistedBeerId(makeBeer('a9fc1e36-db1b-41d4-a6ff-9a580209889e'))).toBe(true);
+  });
+
+  it('removes id from create payload', () => {
+    expect(toBeerCreatePayload(makeBeer(''))).not.toHaveProperty('id');
+    expect(toBeerCreatePayload(makeBeer('old-id'))).not.toHaveProperty('id');
+  });
+
+  it('uses the created backend id from a create response', () => {
+    expect(resolveSubmittedBeer(makeBeer(''), { id: 'generated-id', beer: { id: 'generated-id' } }).id).toBe('generated-id');
+  });
+
+  it('keeps the update backend id from an update response', () => {
+    expect(resolveSubmittedBeer(makeBeer('existing-id'), { id: 'existing-id', beer: { id: 'existing-id' } }).id).toBe('existing-id');
+  });
+
+
+
+  it('rejects missing and invalid ingredient quantities', () => {
+    ['', 0, -1, 'abc', null, undefined].forEach((value) => {
+      expect(isRequiredPositiveQuantity(value)).toBe(false);
+    });
+  });
+
+  it('accepts positive numeric ingredient quantities and string form values', () => {
+    expect(isRequiredPositiveQuantity(7)).toBe(true);
+    expect(isRequiredPositiveQuantity('7')).toBe(true);
+  });
+
+  it('maps backend validation errors to a user-facing message', () => {
+    const message = extractBeerErrorMessage({ response: { status: 400, data: { error: 'VALIDATION_ERROR', message: 'The beer recipe contains invalid data.', fields: [{ path: 'malts[0].quantity', message: 'quantity is required' }] } } }, 'fallback');
+    expect(message).toContain('The beer recipe contains invalid data.');
+    expect(message).toContain('malts[0].quantity: quantity is required');
+  });
+
+  it('maps missing update ids to a specific message', () => {
+    expect(extractBeerErrorMessage({ response: { status: 404, data: { error: 'BEER_NOT_FOUND' } } }, 'fallback')).toBe('Das Rezept konnte nicht aktualisiert werden, da es nicht mehr existiert.');
+  });
+});

--- a/src/utils/beerSubmission.ts
+++ b/src/utils/beerSubmission.ts
@@ -1,0 +1,53 @@
+import { BeerDTO } from "../model/BeerDTO";
+
+export interface BeerSubmissionResponse {
+  id?: string;
+  message?: string;
+  beer?: Partial<BeerDTO> & { id?: string };
+}
+
+export const hasPersistedBeerId = (beer: Pick<BeerDTO, 'id'>): boolean => {
+  const id = beer.id;
+  return id !== undefined && id !== null && String(id).trim() !== '' && String(id).trim() !== '0';
+};
+
+export const toBeerCreatePayload = (beer: BeerDTO): Omit<BeerDTO, 'id'> => {
+  const { id, ...payload } = beer;
+  return payload;
+};
+
+export const resolveSubmittedBeer = (submittedBeer: BeerDTO, response: BeerSubmissionResponse): BeerDTO => {
+  const responseId = response?.beer?.id ?? response?.id;
+  return {
+    ...submittedBeer,
+    ...(response?.beer ?? {}),
+    id: responseId ?? submittedBeer.id,
+  } as BeerDTO;
+};
+
+export const isRequiredPositiveQuantity = (value: unknown): boolean => {
+  if (value === undefined || value === null || value === '') return false;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed > 0;
+};
+
+export const extractBeerErrorMessage = (error: any, fallback: string): string => {
+  const status = error?.response?.status;
+  const data = error?.response?.data;
+
+  if (status === 404 && data?.error === 'BEER_NOT_FOUND') {
+    return 'Das Rezept konnte nicht aktualisiert werden, da es nicht mehr existiert.';
+  }
+
+  if (status === 400 && data?.error === 'VALIDATION_ERROR') {
+    const fieldMessages = Array.isArray(data.fields)
+      ? data.fields
+        .map((field: any) => [field?.path, field?.message].filter(Boolean).join(': '))
+        .filter(Boolean)
+        .join('; ')
+      : '';
+    return [data.message || 'Die Rezeptdaten sind ungültig.', fieldMessages].filter(Boolean).join(' ');
+  }
+
+  return error?.message ? `${fallback}: ${error.message}` : fallback;
+};


### PR DESCRIPTION
### Motivation
- Align UI save workflow with new backend contract that requires `POST /beer` for create (no `id` in body) and `PUT /beer/<id>` for updates (path id authoritative). 
- Prevent accidental duplicate-creates when editing existing recipes and ensure the UI preserves and uses backend-assigned IDs after create. 
- Enforce required `quantity` validation for ingredient lines so invalid payloads are never sent.

### Description
- Implemented server-method selection in `BeerRepository.submitBeer` to call `POST beer` for new recipes (body `id` removed) and `PUT beer/<id>` for persisted recipes, using helper `hasPersistedBeerId` and `toBeerCreatePayload`. (`src/repositorys/BeerRepository.ts`, `src/utils/beerSubmission.ts`)
- Added `PUT` helper to `BaseRepository` so repository layer can issue `PUT` requests. (`src/repositorys/BaseRepository.ts`)
- Epic and action flow: `BeerForm` → `BeerActions.submitBeer` → `submitBeerEpic` now uses `exhaustMap` to prevent parallel saves and maps backend response into a success action that carries the merged/returned beer DTO; backend IDs are merged into the UI recipe via `resolveSubmittedBeer`. (`src/epics/beerEpics.ts`, `src/actions/actions.ts`)
- UI form: `BeerForm` validates ingredient `quantity` for malts, hops, yeasts and additional ingredients before dispatch; invalid fields show inline errors and block submission; new fields keep empty quantity instead of defaulting to `0`. The save button is disabled while a save is in-flight. (`src/containers/DatabaseOverview/BeerForm.tsx`, `src/reducers/beerReducer.ts`)
- Reducer: on submit-success the returned/merged `BeerDTO` is stored into `beer`, `beers` list and `selectedBeer`, and `beerFormState.id` is updated so subsequent saves become updates (PUT). (`src/reducers/beerReducer.ts`)
- Error handling: translated backend `400 VALIDATION_ERROR` and `404 BEER_NOT_FOUND` into user-friendly messages and prevented automatic POST fallback on 404. (`src/utils/beerSubmission.ts`, `src/epics/beerEpics.ts`)
- Documentation: updated Codex docs to reflect the new create/update contract for `POST /beer` and `PUT /beer/{id}`. (`docs/codex/interfaces.md`, `docs/codex/compatibility/cross-repo-contracts.md`)
- Tests: added unit tests for submission helpers and repository behavior (new files `src/utils/beerSubmission.test.ts`, `src/repositorys/BeerRepository.test.ts`). Also added a small CLI fix so forwarded args reach `react-scripts` when running tests via the wrapper. (`scripts/build-with-version.js`)

### Testing
- Unit tests added: `src/utils/beerSubmission.test.ts` and `src/repositorys/BeerRepository.test.ts` were created and exercise ID-detection, create-payload stripping, response-ID merging, and POST-vs-PUT repository calls; they are present in the branch. (added)
- Attempted to run the focused tests with the project test wrapper, but automated execution was blocked in this environment because `node_modules/.bin/react-scripts` is not installed; `npm install` also failed due to registry access errors (403 on `@types/react`). (failed to execute)
- Type-check (`tsc --noEmit`) was attempted; it reports many errors that are caused by missing installed dependencies/types in the environment rather than the changes themselves. (blocked)
- `git diff --check` was run and returned clean results for the change set. (ok)

Changed files (high-level): `src/repositorys/BeerRepository.ts`, `src/repositorys/BaseRepository.ts`, `src/containers/DatabaseOverview/BeerForm.tsx`, `src/epics/beerEpics.ts`, `src/reducers/beerReducer.ts`, `src/actions/actions.ts`, `src/utils/beerSubmission.ts` (+ tests), and updated docs under `docs/codex/`.

Notes: tests and full type-check must be executed in a developer environment with dependencies installed (`npm install`) and network access to the registry; the code changes are guarded and use existing project patterns (actions/epics/reducer) to preserve compatibility with other flows.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a54a802a904832fb02995c4ee6ab10a)