### PR TITLE
PWA: Localize app, update manifest/icons, simplify service worker, and only register SW in production

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -4,40 +4,17 @@
     <meta charset="utf-8" />
     <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
     <meta name="viewport" content="initial-scale=1, minimum-scale=0.67, maximum-scale=0.67, user-scalable=no" />
-    <meta name="theme-color" content="#000000" />
+    <meta name="theme-color" content="#333333" />
     <meta
       name="description"
-      content="Web site created using create-react-app"
+      content="Brauhaus-Oberfläche zur Überwachung und Steuerung des Brauprozesses."
     />
-    <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
-    <!--
-      manifest.json provides metadata used when your web app is installed on a
-      user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
-    -->
+    <link rel="apple-touch-icon" href="%PUBLIC_URL%/brewery.png" />
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
-    <!--
-      Notice the use of %PUBLIC_URL% in the tags above.
-      It will be replaced with the URL of the `public` folder during the build.
-      Only files inside the `public` folder can be referenced from the HTML.
-
-      Unlike "/favicon.ico" or "favicon.ico", "%PUBLIC_URL%/favicon.ico" will
-      work correctly both with client-side routing and a non-root public URL.
-      Learn how to configure a non-root public URL by running `npm run build`.
-    -->
     <title>Brauhaus</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
-    <!--
-      This HTML file is a template.
-      If you open it directly in the browser, you will see an empty page.
-
-      You can add webfonts, meta tags, or analytics to this file.
-      The build step will place the bundled scripts into the <body> tag.
-
-      To begin the development, run `npm start` or `yarn start`.
-      To create a production bundle, use `npm run build` or `yarn build`.
-    -->
   </body>
 </html>

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,6 +1,14 @@
 {
-  "short_name": "React App",
-  "name": "Create React App Sample",
+  "id": "/",
+  "name": "Brauhaus",
+  "short_name": "Brauhaus",
+  "description": "Mobile und Desktop-Oberfläche zur Überwachung und Steuerung des Brauhaus-Brauprozesses.",
+  "start_url": "/",
+  "scope": "/",
+  "display": "standalone",
+  "orientation": "portrait",
+  "theme_color": "#333333",
+  "background_color": "#333333",
   "icons": [
     {
       "src": "favicon.ico",
@@ -8,18 +16,10 @@
       "type": "image/x-icon"
     },
     {
-      "src": "logo192.png",
+      "src": "brewery.png",
       "type": "image/png",
-      "sizes": "192x192"
-    },
-    {
-      "src": "logo512.png",
-      "type": "image/png",
-      "sizes": "512x512"
+      "sizes": "512x512",
+      "purpose": "any"
     }
-  ],
-  "start_url": ".",
-  "display": "standalone",
-  "theme_color": "#000000",
-  "background_color": "#ffffff"
+  ]
 }

--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -1,13 +1,21 @@
-// Einfache Service Worker-Implementierung für PWA-Funktionalität
-self.addEventListener('install', function(event) {
-  self.skipWaiting();
+// Minimaler Service Worker für die Installierbarkeit der Brauhaus-PWA.
+// Aktuell wird bewusst keine eigene Cache-Strategie verwendet:
+// - keine API-Antworten
+// - keine Steuerungsstatus
+// - keine Datenbankantworten
+// - keine Build-Metadaten wie index.html, manifest.json, asset-manifest.json oder version.json
+// So bleiben Browser-/Server-Caches und bestehende Versionsmechanismen maßgeblich.
+self.addEventListener('install', function() {
+  // skipWaiting() wird absichtlich nicht aufgerufen: Ein Update soll eine laufende
+  // Brauansicht nicht ungefragt durch einen neuen Service Worker übernehmen.
 });
 
 self.addEventListener('activate', function(event) {
-  // Aktivierungscode
+  event.waitUntil(self.clients.claim());
 });
 
-self.addEventListener('fetch', function(event) {
-  // Standard: Netzwerkanfragen nicht cachen, aber hier könnte man erweitern
+self.addEventListener('fetch', function() {
+  // Keine Fetch-Antwort wird durch den Service Worker ersetzt: jede Anfrage läuft unverändert über Netzwerk,
+  // Browser-Cache oder Server-Cache. Das gilt insbesondere für /api/database/*
+  // und /api/controller/*.
 });
-

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -26,15 +26,15 @@ ReactDOM.render(
     document.getElementById('root')
 );
 
-// Register the service worker for PWA support.
-if ('serviceWorker' in navigator) {
+// Register the service worker for PWA support in production builds only.
+if (process.env.NODE_ENV === 'production' && 'serviceWorker' in navigator) {
   window.addEventListener('load', () => {
     navigator.serviceWorker.register(process.env.PUBLIC_URL + '/service-worker.js')
       .then(registration => {
-        console.log('ServiceWorker registration successful:', registration);
+        console.info('ServiceWorker registration successful:', registration.scope);
       })
       .catch(error => {
-        console.log('ServiceWorker registration failed:', error);
+        console.warn('ServiceWorker registration failed:', error);
       });
   });
 }


### PR DESCRIPTION
### Motivation
- Localize and rebrand the application to "Brauhaus" and provide appropriate PWA metadata and icons for mobile/desktop installability. 
- Avoid surprising client-side behavior and cache issues by simplifying the service worker and preventing an automatic takeover of running pages. 
- Only enable service worker registration for production builds to keep development feedback loops fast and predictable.

### Description
- Updated `public/index.html` to change the theme color to `#333333`, replace the description with a German text, swap the apple touch icon to `brewery.png`, and remove boilerplate comments. 
- Rewrote `public/manifest.json` to set `name`, `short_name`, `id`, `description`, `start_url`, `scope`, `display`, `orientation`, `theme_color`, `background_color` and updated the icons to reference `brewery.png` with proper sizes and `purpose`. 
- Replaced `public/service-worker.js` with a minimal service worker that intentionally does not cache responses or call `skipWaiting()`, calls `clients.claim()` on `activate`, and does not intercept `fetch` events. 
- Modified `src/index.tsx` to only register the service worker when `process.env.NODE_ENV === 'production'`, and to use `console.info`/`console.warn` with the registration `scope` in logs.

### Testing
- Ran a production build with `npm run build` which completed successfully. 
- Executed the test suite with `npm test` and all runnable unit tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a55454df23c832fb8efc0067163fe85)