### PR TITLE
CRA-Dev-Proxy für /api/* hinzufügen und zentrale API-URLs auf relative Pfade umstellen

### DIFF
--- a/docs/codex/app-context.md
+++ b/docs/codex/app-context.md
@@ -2,7 +2,7 @@
 
 ## Repository role
 
-This repository is a Create React App TypeScript UI named `test1`. It presents beer recipes, ingredient/database maintenance, finished brews, brewing calculations, settings, and production/control screens for a Brauhaus brewing setup. The UI talks to two hard-coded HTTP origins: a database/backend service at `http://192.168.178.72:5000/` and a brewing-control service at `http://192.168.178.37:5000/`.
+This repository is a Create React App TypeScript UI named `test1`. It presents beer recipes, ingredient/database maintenance, finished brews, brewing calculations, settings, and production/control screens for a Brauhaus brewing setup. The UI talks to Caddy-routed relative API paths on the current origin: `/api/database` for the database/backend service and `/api/controller` for the brewing-control service. In local CRA development, `src/setupProxy.js` forwards `/api/*` to the Caddy HTTPS origin for development only.
 
 ## Entry points and shell
 
@@ -82,7 +82,7 @@ See `interfaces.md` and `docs/frontend-api-usage.md` for endpoint details.
 
 Scripts from `package.json`:
 
-- `npm start`: CRA dev server.
+- `npm start`: version wrapper around the CRA dev server; CRA loads `src/setupProxy.js` for local `/api` proxying.
 - `npm run build`: production build.
 - `npm test`: CRA/Jest test runner.
 - `npm run build-deploy`: build then `scp -r build/* boris@192.168.178.72:/srv/sites/braumeister`.

--- a/docs/codex/dependencies.md
+++ b/docs/codex/dependencies.md
@@ -4,9 +4,9 @@
 
 Core dependencies observed in `package.json`:
 
-- React 18, React DOM, TypeScript 4.9, Create React App `react-scripts` 5.
+- React 18, React DOM, TypeScript 4.9, Create React App `react-scripts` 5. The CRA development server uses `src/setupProxy.js` for the local `/api` proxy.
 - Redux stack: `redux`, `@reduxjs/toolkit`, `react-redux`, `redux-observable`, `rxjs`, `redux-thunk`.
-- HTTP/realtime: `axios`, `socket.io-client`.
+- HTTP/realtime: `axios`, `socket.io-client`; local development proxy: `http-proxy-middleware` as a direct development dependency for CRA `src/setupProxy.js`.
 - UI: MUI v5 packages, Material UI v4 core, React Bootstrap/Bootstrap, Font Awesome, SimpleBar, react-switch, react-dial-knob, react-thermometer-component, Recharts, React Google Charts, Konva/react-konva, gantt-task-react.
 - PDF/export: `pdfmake`, `pdf-lib`, `file-saver`.
 - Utilities: lodash, fuse.js.
@@ -15,18 +15,18 @@ Needs verification: the app mixes Material UI v4 and MUI v5 packages, which can 
 
 ## URL configuration
 
-`src/global.ts` exports fixed URLs:
+`src/global.ts` exports relative API URLs for the Caddy-routed production origin:
 
-- `DatabaseURL = 'http://192.168.178.72:5000/'`
-- `CommandsURL = 'http://192.168.178.37:5000/Command/'`
-- `ConfirmURL = 'http://192.168.178.37:5000/Confirm/'`
-- `BaseURL = 'http://192.168.178.37:5000/'`
+- `DatabaseURL = '/api/database'`
+- `BaseURL = '/api/controller'`
+- `CommandsURL = '/api/controller/Command/'`
+- `ConfirmURL = '/api/controller/Confirm/'`
 
-No environment override was found. `PUBLIC_URL` is used only for CRA public assets/service worker.
+No environment override is used for API origins. In local CRA development only, `src/setupProxy.js` proxies `/api/*` to `https://192.168.178.72/api/*` without path rewriting. `PUBLIC_URL` is used only for CRA public assets/service worker.
 
 ## Scripts
 
-- `start`: CRA development server.
+- `start`: version wrapper around the CRA development server; CRA loads `src/setupProxy.js` for the local `/api` development proxy.
 - `build`: CRA production build to `build/`.
 - `test`: CRA/Jest runner.
 - `build-deploy`: build then copy build output to `boris@192.168.178.72:/srv/sites/braumeister`.

--- a/docs/codex/interfaces.md
+++ b/docs/codex/interfaces.md
@@ -2,7 +2,7 @@
 
 ## Database/backend REST endpoints
 
-Base URL: `DatabaseURL` (`http://192.168.178.72:5000/`).
+Base URL: `DatabaseURL` (`/api/database`).
 
 | Method | Path | UI use | Payload/response expected |
 |---|---|---|---|
@@ -30,7 +30,7 @@ Base URL: `DatabaseURL` (`http://192.168.178.72:5000/`).
 
 ## PI/control REST endpoints
 
-Base URL: `BaseURL` (`http://192.168.178.37:5000/`), `CommandsURL`, and `ConfirmURL`.
+Base URL: `BaseURL` (`/api/controller`), `CommandsURL` (`/api/controller/Command/`), and `ConfirmURL` (`/api/controller/Confirm/`).
 
 | Method | Path | UI use | Success expectation |
 |---|---|---|---|

--- a/package-lock.json
+++ b/package-lock.json
@@ -65,7 +65,8 @@
       },
       "devDependencies": {
         "@types/file-saver": "^2.0.7",
-        "@types/uuid": "^10.0.0"
+        "@types/uuid": "^10.0.0",
+        "http-proxy-middleware": "^2.0.6"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
   },
   "devDependencies": {
     "@types/file-saver": "^2.0.7",
-    "@types/uuid": "^10.0.0"
+    "@types/uuid": "^10.0.0",
+    "http-proxy-middleware": "^2.0.6"
   }
 }

--- a/src/global.ts
+++ b/src/global.ts
@@ -1,4 +1,4 @@
-export const DatabaseURL = 'http://192.168.178.72:5000/';
-export const CommandsURL = 'http://192.168.178.37:5000/Command/';
-export const ConfirmURL = 'http://192.168.178.37:5000/Confirm/';
-export const BaseURL =  'http://192.168.178.37:5000/';
+export const DatabaseURL = "/api/database";
+export const BaseURL = "/api/controller";
+export const CommandsURL = `${BaseURL}/Command/`;
+export const ConfirmURL = `${BaseURL}/Confirm/`;

--- a/src/repositorys/ProductionRepository.ts
+++ b/src/repositorys/ProductionRepository.ts
@@ -121,7 +121,7 @@ export class ProductionRepository {
 
     private static async _doGetTemperature(): Promise<number> {
         try {
-            const response = await axios.get(BaseURL + 'temperatur/0');
+            const response = await axios.get(`${BaseURL}/temperatur/0`);
             if (response.status == 200) {
                 return response.data;
             } else {
@@ -137,7 +137,7 @@ export class ProductionRepository {
     private static async _doGetWaterFillStatus(aTimeoutMs?: number, aFailOnError: boolean = false): Promise<WaterStatus> {
         const aConfig = createRequestConfig(aTimeoutMs);
         try {
-            const response = await axios.get(BaseURL + 'WaterStatus', aConfig.config);
+            const response = await axios.get(`${BaseURL}/WaterStatus`, aConfig.config);
             if (response.status == 200) {
                 return normalizeWaterStatus(response.data);
 
@@ -167,7 +167,7 @@ export class ProductionRepository {
     private static async _doGetBrewingStatus(aTimeoutMs?: number): Promise<{ available: BackendAvailable, brewingStatus: BrewingStatus | undefined }> {
         const aConfig = createRequestConfig(aTimeoutMs);
         try {
-            const response = await axios.get(BaseURL + 'Status/', aConfig.config);
+            const response = await axios.get(`${BaseURL}/Status/`, aConfig.config);
             if (response.status == 200) {
                 const available: BackendAvailable = {
                     isBackenAvailable: true, statusText: response.statusText
@@ -198,13 +198,13 @@ export class ProductionRepository {
     }
 
     private static async _doGetDiagnosticVersion(): Promise<string> {
-        const response = await axios.get<IDiagnosticResponse>(BaseURL + 'diag');
+        const response = await axios.get<IDiagnosticResponse>(`${BaseURL}/diag`);
         return normalizeDiagnosticVersion(response.data);
     }
 
     private static async _doSendBrewingData(aBrewingData: BrewingData) {
         try {
-            const response = await axios.post(BaseURL + 'Recipe/', aBrewingData);
+            const response = await axios.post(`${BaseURL}/Recipe/`, aBrewingData);
 
             return response.status == 201;
         } catch (error) {
@@ -272,7 +272,7 @@ export class ProductionRepository {
 
     private static async _doCheckIsBackendAvailable(): Promise<boolean> {
         try {
-            const response = await axios.get(BaseURL+"Available/");
+            const response = await axios.get(`${BaseURL}/Available/`);
             return response.status === 200;
         } catch (error) {
             return false;
@@ -281,7 +281,7 @@ export class ProductionRepository {
 
     private static async _doNextProcedureStep() {
         try {
-            const response = await axios.post(BaseURL + 'next');
+            const response = await axios.post(`${BaseURL}/next`);
             return response.status === 200;
         } catch (error) {
             console.error('Fehler beim API-Aufruf', error);

--- a/src/setupProxy.js
+++ b/src/setupProxy.js
@@ -1,0 +1,18 @@
+const { createProxyMiddleware } = require("http-proxy-middleware");
+
+module.exports = function setupProxy(app) {
+    app.use(
+        "/api",
+        createProxyMiddleware({
+            target: "https://192.168.178.72",
+            changeOrigin: true,
+            secure: false,
+            onError(aError, aRequest) {
+                console.error(
+                    `Development proxy failed for ${aRequest.method} ${aRequest.url}:`,
+                    aError.message
+                );
+            },
+        })
+    );
+};


### PR DESCRIPTION
### Motivation
- Lokale CRA-Entwicklung leitet derzeit relative Requests an `http://localhost:3000`, was die produktiven Caddy-Routen unter `/api/*` nicht erreicht; deshalb soll der CRA-Dev-Server `/api/*` an den Caddy-HTTPS-Origin weiterleiten, ohne die produktiven relativen URLs zu ändern.

### Description
- Neue CRA-Proxy-Datei `src/setupProxy.js` hinzugefügt, die `createProxyMiddleware` nutzt und `/api` an `https://192.168.178.72` weiterreicht mit `changeOrigin: true`, `secure: false` und ohne `pathRewrite`, plus minimales `onError`-Logging.
- Zentrale API-Konstanten in `src/global.ts` auf produktionssichere relative Pfade umgestellt: `DatabaseURL = "/api/database"`, `BaseURL = "/api/controller"`, und daraus abgeleitete `CommandsURL`/`ConfirmURL`.
- Controller-Aufrufe in `src/repositorys/ProductionRepository.ts` an die neuen relativen `BaseURL`-Strings angepasst (z.B. `${BaseURL}/Status/`, `${BaseURL}/diag`, `${BaseURL}/Recipe/`, `${BaseURL}/Available/`, `${BaseURL}/next`).
- `http-proxy-middleware` als `devDependency` in `package.json` ergänzt und `package-lock.json` entsprechend aktualisiert, da CRA `src/setupProxy.js` per `require()` lädt.
- Projektdokumentation aktualisiert: `docs/codex/app-context.md`, `docs/codex/dependencies.md` und `docs/codex/interfaces.md` um Hinweise zu den relativen API-URLs und dem lokalen Proxy ergänzt.

### Testing
- Statische/automatisierte Validierungen wurden ausgeführt und sind erfolgreich: `src/setupProxy.js` befindet sich an der CRA-unterstützten Position, es existiert kein `proxy`-Feld in `package.json`, die Proxy-Konfiguration enthält kein `pathRewrite`, `secure: false` ist gesetzt und `http-proxy-middleware` wurde als Dev-Dependency in `package.json`/`package-lock.json` vermerkt.
- Versuche, `npm install`, `npm start` und `npm run build` in dieser Umgebung auszuführen, schlugen fehl wegen fehlender/fehlkonfigurierter `node_modules` bzw. fehlendem Zugriff auf das Registry/Cache, weshalb keine Laufzeit- oder e2e-Tests gegen einen echten Caddy-Origin automatisch durchgeführt werden konnten.
- Empfehlung für automatisierte Verifikation in der Entwicklungsumgebung: nach `npm install` den Dev-Server mit dem vorhandenen Start-Wrapper `npm start` starten und folgende GET-Requests prüfen, die über den Proxy an Caddy weitergeleitet werden müssen: `GET http://localhost:3000/api/database/diag`, `GET http://localhost:3000/api/database/beers`, `GET http://localhost:3000/api/controller/diag`, `GET http://localhost:3000/api/controller/Status`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a55de576174832f96bb143f25b7dea6)