### PR TITLE
Add PWA web push UI support

### DIFF
--- a/docs/codex/compatibility/cross-repo-contracts.md
+++ b/docs/codex/compatibility/cross-repo-contracts.md
@@ -151,3 +151,14 @@ If a changed field, endpoint, enum, unit, or response shape is listed in this fi
 ### Final UI ↔ PI control contract
 
 The final confirmed contract is documented in `docs/codex/compatibility/final-ui-control-compatibility-report.md`. Future changes must preserve: `GET /Available/` as the UI-facing availability route, `GET /` as an existing PI route, both `GET /WaterStatus` and `GET /WaterStatus/`, object-shaped WaterStatus defaults, no-value `TurnOn`/`TurnOff`, preserved value-bearing command aliases, concrete-only confirmations, rejection of `/Confirm/Wait`, and `currentTime` as a Unix timestamp rather than a UI duration/progress field.
+
+### Control Web Push endpoints
+
+The React PWA now expects the PI/control service to expose Web-Push management below the existing controller base URL `/api/controller`:
+
+- `GET /push/public-key` returns `{ "publicKey": "<VAPID_PUBLIC_KEY>" }`.
+- `POST /push/subscriptions` stores a browser `PushSubscription` idempotently.
+- `DELETE /push/subscriptions` removes a subscription by `{ "endpoint": "..." }`.
+- `POST /push/test` sends a test notification to registered subscriptions.
+
+Push notifications are triggered by the control service when `waiting.canConfirm` becomes true for confirmation states such as `MASHING_IN_CONFIRMATION`, `IODINE_TEST`, `MASHING_OUT_CONFIRMATION`, `COOKING_CONFIRMATION`, `BOILING_CONFIRMATION`, or `DECOCTION_CONFIRMATION`. This repository only implements the UI/service-worker side; backend persistence and status-transition detection remain **Needs verification** in the PI/control repository.

--- a/docs/codex/interfaces.md
+++ b/docs/codex/interfaces.md
@@ -85,3 +85,16 @@ interface BrewingStatus {
 
 Legacy fallback fields still accepted by `normalizeBrewingStatus`: `Temperature`, `TargetTemperature`, `StatusText`, `HeatingStates`, `Name`, `Type`, `WaitingStatus`, `HeatUpStatus`, `AgitatorStatus`, `index`, `elapsedTime`, and `currentTime`.
 
+
+## PI/control Web Push endpoints
+
+Additional controller API endpoints expected by the PWA:
+
+| Method | Path | Payload/response expected |
+|---|---|---|
+| GET | `/push/public-key` | `200 { "publicKey": "<VAPID_PUBLIC_KEY>" }`; never returns the private key |
+| POST | `/push/subscriptions` | Browser `PushSubscription` JSON; idempotently stores by endpoint |
+| DELETE | `/push/subscriptions` | `{ "endpoint": "..." }`; removes the stored subscription for that endpoint |
+| POST | `/push/test` | Sends a test notification to registered subscriptions |
+
+These paths are consumed through the existing relative UI base URL `/api/controller`. Backend implementation, durable storage, and process-state event detection are **Needs verification** in the PI/control repository.

--- a/docs/web-push.md
+++ b/docs/web-push.md
@@ -1,0 +1,102 @@
+# Web-Push für Brauhaus-PWA und Steuerung
+
+## Architekturfund
+
+- Der Service Worker der PWA wird in `src/index.tsx` bei `window.load` registriert und lädt `public/service-worker.js` nur in Production-Builds.
+- Die UI-Einstellungen liegen in `src/containers/Settings/SettingsPage.tsx` und verwenden bestehende Klassenkomponenten und CSS in `SettingsPage.css`.
+- Steuerungs-Requests sind in `src/repositorys/ProductionRepository.ts` über relative URLs unter `/api/controller` gekapselt; die Push-UI nutzt denselben relativen Controller-Basis-Pfad in `src/utils/pushService.ts`.
+- Der aktuelle Prozessstatus wird von der PI-Steuerung als `GET /Status/` geliefert. Laut externem Control-Kontext liegt die Statushoheit in der Steuerung; in diesem UI-Repository ist der Python-Code nicht vorhanden.
+- Ein Zustandswechsel zu `waiting.waitingFor` muss zuverlässig in der Steuerung beim internen Statuswechsel erkannt werden, nicht beim UI-Polling. Geeigneter Ereignisschlüssel: Prozessidentität, `currentStep.index`, `currentStep.phase`, `waiting.waitingFor`.
+- Bestehende Persistenz der Steuerung ist in diesem Repository nicht implementierbar, weil die Flask-/Raspberry-Pi-Steuerung nicht Teil dieses Checkouts ist. Needs verification im Steuerungs-Repository.
+- Teststruktur der UI: CRA/Jest-Tests liegen neben den Dateien als `*.test.ts`/`*.test.tsx`. Backendtests der Steuerung sind in diesem Repository nicht vorhanden. Needs verification im Steuerungs-Repository.
+
+## Neue UI-Endpunkte unter `/api/controller`
+
+Die PWA erwartet folgende Steuerungs-Endpunkte:
+
+| Methode | Pfad | Zweck |
+| --- | --- | --- |
+| `GET` | `/push/public-key` | VAPID Public Key für `PushManager.subscribe()` abrufen. |
+| `POST` | `/push/subscriptions` | Browser-`PushSubscription` idempotent speichern. |
+| `DELETE` | `/push/subscriptions` | Subscription anhand von `{ "endpoint": "..." }` entfernen. |
+| `POST` | `/push/test` | Testnachricht an registrierte Subscriptions senden. |
+
+Über Caddy werden diese im Browser relativ als `/api/controller/push/...` aufgerufen. Es wird keine direkte Browser-Verbindung zu Port 5000 aufgebaut.
+
+## Konfiguration im Steuerungs-Backend
+
+Empfohlene Environment-Variablen:
+
+```text
+WEB_PUSH_VAPID_PUBLIC_KEY=<public key>
+WEB_PUSH_VAPID_PRIVATE_KEY=<private key>
+WEB_PUSH_VAPID_SUBJECT=mailto:admin@example.local
+WEB_PUSH_SUBSCRIPTIONS_FILE=/var/lib/brauhaus/push-subscriptions.json
+```
+
+Der Private Key darf niemals an die UI ausgeliefert oder im Repository gespeichert werden. Nur `WEB_PUSH_VAPID_PUBLIC_KEY` wird über `GET /push/public-key` an die PWA gesendet.
+
+## VAPID-Schlüssel erzeugen
+
+Wenn im Steuerungs-Backend `pywebpush`/`py-vapid` eingesetzt wird:
+
+```bash
+python -m venv .venv
+. .venv/bin/activate
+pip install py-vapid
+python -m py_vapid --gen
+```
+
+Alternativ kann mit Node/Web-Push ein Paar erzeugt werden:
+
+```bash
+npx web-push generate-vapid-keys
+```
+
+Die erzeugten Werte anschließend als Environment-Variablen im systemd-Service der Steuerung eintragen und die Steuerung neu starten.
+
+## Backend-Implementierungsvorgaben
+
+- Subscription-Payload vollständig validieren: `endpoint`, `keys.p256dh`, `keys.auth` müssen nicht-leere Strings sein.
+- Endpoint ist die eindeutige ID; mehrfaches Registrieren desselben Endpoints ist idempotent.
+- Persistenz atomisch schreiben, z. B. temporäre Datei plus `os.replace`.
+- Eine beschädigte Persistenzdatei darf den Start nicht verhindern; stattdessen leer starten und Fehler ohne Secrets loggen.
+- Versand in einem gekapselten Push-Service implementieren: `subscribe`, `unsubscribe`, `send_notification`, `send_to_all`.
+- HTTP 404/410 des Push-Dienstes entfernt die Subscription; temporäre Fehler bleiben gespeichert.
+- Push-Versand darf den Brauprozess nie abbrechen und sollte über vorhandene Nebenläufigkeitsmuster oder einen begrenzten Executor erfolgen.
+- Trigger nur beim Eintritt in einen bestätigungspflichtigen Zustand mit `canConfirm === true` senden, nicht bei Status-Polling.
+
+## Notification-Payload
+
+Beispiel:
+
+```json
+{
+  "title": "Abmaischen",
+  "body": "Bitte Abmaischen bestätigen.",
+  "url": "/",
+  "tag": "brew-confirmation-6-MASHING_OUT_CONFIRMATION",
+  "data": {
+    "waitingFor": "MASHING_OUT_CONFIRMATION",
+    "stepIndex": 6,
+    "phase": "MASHING_OUT"
+  }
+}
+```
+
+Der Service Worker öffnet ausschließlich URLs innerhalb des eigenen Origins; externe Push-Payload-URLs werden auf `/` zurückgesetzt.
+
+## Einrichtung und Android-Test
+
+1. PWA über `https://192.168.178.72` laden.
+2. In Android/Chrome die PWA installieren.
+3. In der PWA `Einstellungen` öffnen.
+4. `Push-Benachrichtigungen aktivieren` antippen und Berechtigung erlauben.
+5. `Testnachricht senden` antippen.
+6. PWA schließen oder in den Hintergrund legen.
+7. Einen Brauzustand erreichen, in dem `waiting.canConfirm === true` und `waiting.waitingFor` einer der bestätigungspflichtigen Werte ist.
+8. Prüfen, dass Android eine Benachrichtigung anzeigt und ein Klick die vorhandene PWA fokussiert oder `/` öffnet.
+
+## Abgelaufene Subscriptions
+
+Antwortet der Push-Dienst beim Versand mit HTTP 404 oder 410, entfernt die Steuerung die Subscription aus ihrer Persistenz. Temporäre Netzwerk- oder Serverfehler werden geloggt, behalten die Subscription aber bei und dürfen andere Geräte nicht blockieren.

--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -19,3 +19,70 @@ self.addEventListener('fetch', function() {
   // Browser-Cache oder Server-Cache. Das gilt insbesondere für /api/database/*
   // und /api/controller/*.
 });
+
+const DEFAULT_NOTIFICATION = {
+  title: 'Brauhaus',
+  body: 'Der Brauvorgang benötigt Aufmerksamkeit.',
+  url: '/',
+  tag: 'brauhaus-push',
+  icon: '/logo192.png',
+  badge: '/logo192.png'
+};
+
+function parsePushPayload(event) {
+  if (!event.data) {
+    return DEFAULT_NOTIFICATION;
+  }
+
+  try {
+    const payload = event.data.json();
+    return Object.assign({}, DEFAULT_NOTIFICATION, payload || {});
+  } catch (error) {
+    return DEFAULT_NOTIFICATION;
+  }
+}
+
+function sameOriginUrl(url) {
+  try {
+    const target = new URL(url || '/', self.location.origin);
+    if (target.origin !== self.location.origin) {
+      return '/';
+    }
+    return target.pathname + target.search + target.hash;
+  } catch (error) {
+    return '/';
+  }
+}
+
+self.addEventListener('push', function(event) {
+  const payload = parsePushPayload(event);
+  const title = typeof payload.title === 'string' && payload.title ? payload.title : DEFAULT_NOTIFICATION.title;
+  const options = {
+    body: typeof payload.body === 'string' ? payload.body : DEFAULT_NOTIFICATION.body,
+    icon: typeof payload.icon === 'string' ? payload.icon : DEFAULT_NOTIFICATION.icon,
+    badge: typeof payload.badge === 'string' ? payload.badge : DEFAULT_NOTIFICATION.badge,
+    tag: typeof payload.tag === 'string' ? payload.tag : DEFAULT_NOTIFICATION.tag,
+    data: Object.assign({}, payload.data || {}, { url: sameOriginUrl(payload.url) })
+  };
+
+  event.waitUntil(self.registration.showNotification(title, options));
+});
+
+self.addEventListener('notificationclick', function(event) {
+  event.notification.close();
+  const targetUrl = sameOriginUrl(event.notification && event.notification.data && event.notification.data.url);
+
+  event.waitUntil(self.clients.matchAll({ type: 'window', includeUncontrolled: true }).then(function(clientList) {
+    for (const client of clientList) {
+      const clientUrl = new URL(client.url);
+      if (clientUrl.origin === self.location.origin && 'focus' in client) {
+        return client.focus();
+      }
+    }
+
+    if (self.clients.openWindow) {
+      return self.clients.openWindow(targetUrl);
+    }
+    return undefined;
+  }));
+});

--- a/src/containers/Settings/SettingsPage.css
+++ b/src/containers/Settings/SettingsPage.css
@@ -213,3 +213,47 @@
     align-items: flex-start;
   }
 }
+
+.push-status-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  color: var(--color-border-strong);
+}
+
+.settings-error,
+.settings-warning {
+  border-radius: 0.5rem;
+  padding: 0.65rem 0.75rem;
+  margin: 0;
+}
+
+.settings-error {
+  background: var(--color-danger-surface, #fff0f0);
+  border: 1px solid var(--color-danger, #c62828);
+  color: var(--color-danger-dark, #8b0000);
+}
+
+.settings-warning {
+  background: var(--color-warning-surface, #fff7e6);
+  border: 1px solid var(--color-orange-dark);
+  color: var(--color-brown-deep);
+}
+
+.settings-secondary {
+  padding: 0.75rem 1.25rem;
+  border-radius: 0.75rem;
+  background: var(--color-input-bg2);
+  border: 1px solid var(--color-input-border);
+  color: var(--color-black);
+  font-weight: 800;
+  cursor: pointer;
+}
+
+.settings-primary:disabled,
+.settings-secondary:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+  transform: none;
+  box-shadow: none;
+}

--- a/src/containers/Settings/SettingsPage.tsx
+++ b/src/containers/Settings/SettingsPage.tsx
@@ -3,6 +3,7 @@ import { connect } from 'react-redux';
 import './SettingsPage.css';
 import { ThemeName } from '../../utils/theme';
 import { ApplicationActions } from '../../actions/actions';
+import { PushService, getPermissionState, isPushSupported } from '../../utils/pushService';
 
 interface SettingsPageProps {
     theme: ThemeName;
@@ -14,6 +15,11 @@ interface SettingsPageState {
     notificationsEnabled: boolean;
     temperatureUnit: 'celsius' | 'fahrenheit';
     statusMessage: string | null;
+    pushSupported: boolean;
+    pushPermission: NotificationPermission;
+    pushSubscribed: boolean;
+    pushLoading: boolean;
+    pushError: string | null;
 }
 
 class SettingsPage extends React.Component<SettingsPageProps, SettingsPageState> {
@@ -25,12 +31,101 @@ class SettingsPage extends React.Component<SettingsPageProps, SettingsPageState>
             notificationsEnabled: false,
             temperatureUnit: 'celsius',
             statusMessage: null,
+            pushSupported: isPushSupported(),
+            pushPermission: getPermissionState(),
+            pushSubscribed: false,
+            pushLoading: false,
+            pushError: null,
         };
     }
 
     get activeThemeLabel() {
         return this.props.theme === 'dark-alt' ? 'Dunkles Theme' : 'Helles Theme';
     }
+
+    componentDidMount() {
+        this.refreshPushState();
+    }
+
+    refreshPushState = async () => {
+        const pushSupported = isPushSupported();
+        if (!pushSupported) {
+            this.setState({
+                pushSupported: false,
+                pushPermission: getPermissionState(),
+                pushSubscribed: false,
+            });
+            return;
+        }
+
+        try {
+            const subscription = await PushService.getSubscription();
+            this.setState({
+                pushSupported,
+                pushPermission: getPermissionState(),
+                pushSubscribed: Boolean(subscription),
+                pushError: null,
+            });
+        } catch (error) {
+            this.setState({
+                pushSupported,
+                pushPermission: getPermissionState(),
+                pushSubscribed: false,
+                pushError: this.formatPushError(error),
+            });
+        }
+    };
+
+    formatPushError = (error: unknown): string => {
+        if (error instanceof Error) {
+            return error.message;
+        }
+        return 'Push-Benachrichtigungen konnten nicht aktualisiert werden.';
+    };
+
+    get permissionLabel(): string {
+        switch (this.state.pushPermission) {
+            case 'granted':
+                return 'Erlaubt';
+            case 'denied':
+                return 'Blockiert';
+            default:
+                return 'Nicht angefragt';
+        }
+    }
+
+    handlePushToggle = async () => {
+        this.setState({ pushLoading: true, pushError: null, statusMessage: null });
+        try {
+            if (this.state.pushSubscribed) {
+                await PushService.unsubscribe();
+                this.setState({ statusMessage: 'Push-Benachrichtigungen deaktiviert.' });
+            } else {
+                await PushService.subscribe();
+                this.setState({ statusMessage: 'Push-Benachrichtigungen aktiviert.' });
+            }
+            await this.refreshPushState();
+        } catch (error) {
+            this.setState({
+                pushError: this.formatPushError(error),
+                pushPermission: getPermissionState(),
+            });
+        } finally {
+            this.setState({ pushLoading: false });
+        }
+    };
+
+    handlePushTest = async () => {
+        this.setState({ pushLoading: true, pushError: null, statusMessage: null });
+        try {
+            await PushService.sendTestNotification();
+            this.setState({ statusMessage: 'Testnachricht wurde an den Controller übergeben.' });
+        } catch (error) {
+            this.setState({ pushError: this.formatPushError(error) });
+        } finally {
+            this.setState({ pushLoading: false });
+        }
+    };
 
     handleThemeChange = (nextTheme: ThemeName) => {
         this.props.setTheme(nextTheme);
@@ -57,7 +152,7 @@ class SettingsPage extends React.Component<SettingsPageProps, SettingsPageState>
 
     render() {
         const { theme } = this.props;
-        const { autoConnect, notificationsEnabled, temperatureUnit, statusMessage } = this.state;
+        const { autoConnect, notificationsEnabled, temperatureUnit, statusMessage, pushSupported, pushSubscribed, pushLoading, pushError, pushPermission } = this.state;
 
         return (
             <div className="settings-page">
@@ -130,6 +225,46 @@ class SettingsPage extends React.Component<SettingsPageProps, SettingsPageState>
                                 />
                                 <label htmlFor="notifications">{notificationsEnabled ? 'Aktiviert' : 'Deaktiviert'}</label>
                             </div>
+                        </div>
+                    </section>
+
+
+
+                    <section className="settings-card">
+                        <div className="settings-card-header">
+                            <h3>Push-Benachrichtigungen</h3>
+                            <p>Erhalte Hinweise, wenn der Brauvorgang eine Bestätigung benötigt.</p>
+                        </div>
+                        <div className="push-status-list">
+                            <div><strong>Browser unterstützt Push:</strong> {pushSupported ? 'Ja' : 'Nein'}</div>
+                            <div><strong>Berechtigung:</strong> {this.permissionLabel}</div>
+                            <div><strong>Subscription:</strong> {pushSubscribed ? 'Aktiv' : 'Nicht aktiv'}</div>
+                        </div>
+                        {pushPermission === 'denied' && (
+                            <p className="settings-warning">
+                                Die Berechtigung ist blockiert. Bitte Push-Benachrichtigungen in den Browser- oder App-Einstellungen wieder erlauben.
+                            </p>
+                        )}
+                        {pushError && (
+                            <p className="settings-error" role="alert">{pushError}</p>
+                        )}
+                        <div className="setting-options">
+                            <button
+                                className="settings-primary"
+                                type="button"
+                                onClick={this.handlePushToggle}
+                                disabled={!pushSupported || pushLoading || pushPermission === 'denied'}
+                            >
+                                {pushSubscribed ? 'Push-Benachrichtigungen deaktivieren' : 'Push-Benachrichtigungen aktivieren'}
+                            </button>
+                            <button
+                                className="settings-secondary"
+                                type="button"
+                                onClick={this.handlePushTest}
+                                disabled={!pushSubscribed || pushLoading}
+                            >
+                                Testnachricht senden
+                            </button>
                         </div>
                     </section>
 

--- a/src/utils/pushService.test.ts
+++ b/src/utils/pushService.test.ts
@@ -1,0 +1,127 @@
+import axios from 'axios';
+import { getPermissionState, isPushSupported, subscribe, unsubscribe, urlBase64ToUint8Array } from './pushService';
+
+jest.mock('axios');
+
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+const originalNotification = window.Notification;
+
+const defineNavigatorProperty = (name: string, value: unknown) => {
+    Object.defineProperty(navigator, name, {
+        configurable: true,
+        value,
+    });
+};
+
+const defineWindowProperty = (name: string, value: unknown) => {
+    Object.defineProperty(window, name, {
+        configurable: true,
+        value,
+    });
+};
+
+describe('pushService', () => {
+    beforeEach(() => {
+        jest.resetAllMocks();
+        defineNavigatorProperty('serviceWorker', undefined);
+        defineWindowProperty('PushManager', undefined);
+        defineWindowProperty('Notification', originalNotification);
+    });
+
+    it('detects unsupported browsers', () => {
+        expect(isPushSupported()).toBe(false);
+        expect(getPermissionState()).toBe('default');
+    });
+
+    it('converts base64url public keys to Uint8Array', () => {
+        expect(Array.from(urlBase64ToUint8Array('AQIDBA'))).toEqual([1, 2, 3, 4]);
+    });
+
+    it('requests permission only while subscribing and registers the subscription at the backend', async () => {
+        const requestPermission = jest.fn().mockResolvedValue('granted');
+        const subscription = {
+            endpoint: 'https://push.example/subscription-1',
+            toJSON: () => ({
+                endpoint: 'https://push.example/subscription-1',
+                keys: { p256dh: 'key', auth: 'auth' },
+            }),
+            unsubscribe: jest.fn(),
+        };
+        const pushManager = {
+            getSubscription: jest.fn().mockResolvedValue(null),
+            subscribe: jest.fn().mockResolvedValue(subscription),
+        };
+
+        defineWindowProperty('Notification', {
+            permission: 'default',
+            requestPermission,
+        });
+        defineWindowProperty('PushManager', function PushManager() {});
+        defineNavigatorProperty('serviceWorker', {
+            ready: Promise.resolve({ pushManager }),
+        });
+        mockedAxios.get.mockResolvedValue({ data: { publicKey: 'AQIDBA' } });
+        mockedAxios.post.mockResolvedValue({ status: 201 });
+
+        expect(requestPermission).not.toHaveBeenCalled();
+
+        await expect(subscribe()).resolves.toBe(subscription as unknown as PushSubscription);
+
+        expect(requestPermission).toHaveBeenCalledTimes(1);
+        expect(mockedAxios.get).toHaveBeenCalledWith('/api/controller/push/public-key');
+        expect(pushManager.subscribe).toHaveBeenCalledWith({
+            userVisibleOnly: true,
+            applicationServerKey: new Uint8Array([1, 2, 3, 4]),
+        });
+        expect(mockedAxios.post).toHaveBeenCalledWith('/api/controller/push/subscriptions', {
+            endpoint: 'https://push.example/subscription-1',
+            keys: { p256dh: 'key', auth: 'auth' },
+        });
+    });
+
+    it('does not request permission when permission is denied', async () => {
+        const requestPermission = jest.fn();
+        defineWindowProperty('Notification', {
+            permission: 'denied',
+            requestPermission,
+        });
+        defineWindowProperty('PushManager', function PushManager() {});
+        defineNavigatorProperty('serviceWorker', {
+            ready: Promise.resolve({
+                pushManager: {
+                    getSubscription: jest.fn().mockResolvedValue(null),
+                },
+            }),
+        });
+
+        await expect(subscribe()).rejects.toThrow('blockiert');
+        expect(requestPermission).not.toHaveBeenCalled();
+    });
+
+    it('removes backend and local subscriptions while unsubscribing', async () => {
+        const unsubscribeLocal = jest.fn().mockResolvedValue(true);
+        const subscription = {
+            endpoint: 'https://push.example/subscription-1',
+            toJSON: () => ({ endpoint: 'https://push.example/subscription-1' }),
+            unsubscribe: unsubscribeLocal,
+        };
+        defineWindowProperty('Notification', { permission: 'granted', requestPermission: jest.fn() });
+        defineWindowProperty('PushManager', function PushManager() {});
+        defineNavigatorProperty('serviceWorker', {
+            ready: Promise.resolve({
+                pushManager: {
+                    getSubscription: jest.fn().mockResolvedValue(subscription),
+                },
+            }),
+        });
+        mockedAxios.delete.mockResolvedValue({ status: 204 });
+
+        await unsubscribe();
+
+        expect(mockedAxios.delete).toHaveBeenCalledWith('/api/controller/push/subscriptions', {
+            data: { endpoint: 'https://push.example/subscription-1' },
+        });
+        expect(unsubscribeLocal).toHaveBeenCalledTimes(1);
+    });
+});

--- a/src/utils/pushService.ts
+++ b/src/utils/pushService.ts
@@ -1,0 +1,128 @@
+import axios from 'axios';
+import { BaseURL } from '../global';
+
+export interface PushPublicKeyResponse {
+    publicKey: string;
+}
+
+const PUBLIC_KEY_URL = `${BaseURL}/push/public-key`;
+const SUBSCRIPTIONS_URL = `${BaseURL}/push/subscriptions`;
+const TEST_URL = `${BaseURL}/push/test`;
+
+export const isPushSupported = (): boolean => (
+    typeof window !== 'undefined'
+    && 'serviceWorker' in navigator
+    && 'Notification' in window
+    && 'PushManager' in window
+);
+
+export const getPermissionState = (): NotificationPermission => {
+    if (typeof window === 'undefined' || !('Notification' in window)) {
+        return 'default';
+    }
+    return Notification.permission;
+};
+
+export const urlBase64ToUint8Array = (base64String: string): Uint8Array => {
+    const padding = '='.repeat((4 - base64String.length % 4) % 4);
+    const base64 = (base64String + padding).replace(/-/g, '+').replace(/_/g, '/');
+    const rawData = window.atob(base64);
+    const outputArray = new Uint8Array(rawData.length);
+
+    for (let i = 0; i < rawData.length; ++i) {
+        outputArray[i] = rawData.charCodeAt(i);
+    }
+
+    return outputArray;
+};
+
+const getReadyRegistration = async (): Promise<ServiceWorkerRegistration> => {
+    if (!isPushSupported()) {
+        throw new Error('Push-Benachrichtigungen werden von diesem Browser nicht unterstützt.');
+    }
+    return await navigator.serviceWorker.ready;
+};
+
+const loadPublicKey = async (): Promise<string> => {
+    const response = await axios.get<PushPublicKeyResponse>(PUBLIC_KEY_URL);
+    if (!response.data || typeof response.data.publicKey !== 'string' || response.data.publicKey.trim() === '') {
+        throw new Error('Der Controller hat keinen gültigen VAPID Public Key geliefert.');
+    }
+    return response.data.publicKey;
+};
+
+export const getSubscription = async (): Promise<PushSubscription | null> => {
+    const registration = await getReadyRegistration();
+    return await registration.pushManager.getSubscription();
+};
+
+export const subscribe = async (): Promise<PushSubscription> => {
+    const registration = await getReadyRegistration();
+    const existingSubscription = await registration.pushManager.getSubscription();
+    if (existingSubscription) {
+        await axios.post(SUBSCRIPTIONS_URL, existingSubscription.toJSON());
+        return existingSubscription;
+    }
+
+    if (Notification.permission === 'denied') {
+        throw new Error('Push-Berechtigungen sind blockiert. Bitte in den Browser- oder App-Einstellungen wieder erlauben.');
+    }
+
+    const permission = Notification.permission === 'granted'
+        ? 'granted'
+        : await Notification.requestPermission();
+
+    if (permission !== 'granted') {
+        throw new Error('Push-Benachrichtigungen wurden nicht erlaubt.');
+    }
+
+    const publicKey = await loadPublicKey();
+    const applicationServerKey = urlBase64ToUint8Array(publicKey);
+    const subscription = await registration.pushManager.subscribe({
+        userVisibleOnly: true,
+        applicationServerKey,
+    });
+
+    await axios.post(SUBSCRIPTIONS_URL, subscription.toJSON());
+    return subscription;
+};
+
+export const unsubscribe = async (): Promise<void> => {
+    const registration = await getReadyRegistration();
+    const subscription = await registration.pushManager.getSubscription();
+
+    if (!subscription) {
+        return;
+    }
+
+    const subscriptionJson = subscription.toJSON();
+    const endpoint = subscriptionJson.endpoint || subscription.endpoint;
+    let backendError: unknown = null;
+
+    if (endpoint) {
+        try {
+            await axios.delete(SUBSCRIPTIONS_URL, { data: { endpoint } });
+        } catch (error) {
+            backendError = error;
+        }
+    }
+
+    await subscription.unsubscribe();
+
+    if (backendError) {
+        throw new Error('Die lokale Subscription wurde entfernt, aber der Controller konnte nicht aktualisiert werden.');
+    }
+};
+
+export const sendTestNotification = async (): Promise<void> => {
+    await axios.post(TEST_URL);
+};
+
+export const PushService = {
+    isPushSupported,
+    getPermissionState,
+    getSubscription,
+    subscribe,
+    unsubscribe,
+    sendTestNotification,
+};


### PR DESCRIPTION
### Motivation

- Add full Web Push support on the PWA side so installed Brauhaus PWAs on Android receive notifications even when closed or in background.
- Provide a clean, project-conforming UI integration and service-worker handling while leaving backend (Flask PI/control) push persistence and trigger logic to the control repo (documented as Needs verification).

### Description

- Added a TypeScript push client `src/utils/pushService.ts` that handles VAPID public-key retrieval (`GET /api/controller/push/public-key`), `subscribe()`, `unsubscribe()`, `getSubscription()`, `sendTestNotification()` and correct Base64URL -> `Uint8Array` conversion.  
- Extended settings UI in `src/containers/Settings/SettingsPage.tsx` and `SettingsPage.css` to show push support, permission state, subscription state, enable/disable button, and a test-message button with loading and error handling.  
- Enhanced `public/service-worker.js` with `push` and `notificationclick` listeners to parse JSON payloads robustly, show notifications via `registration.showNotification(...)`, enforce same-origin target URLs and focus/open the PWA window on click.  
- Added Jest unit tests `src/utils/pushService.test.ts` covering support detection, permission flow, public-key conversion, backend registration and unsubscribe behavior.  
- Documented expected controller API endpoints, VAPID env vars, key generation, backend implementation guidance, Android test flow, and cross-repo compatibility notes in `docs/web-push.md` and updated `docs/codex/interfaces.md` and `docs/codex/compatibility/cross-repo-contracts.md` to list the new `/push/*` endpoints.

### Testing

- Added unit tests at `src/utils/pushService.test.ts` (Jest) but running them in this environment was blocked by dependency installation issues; tests are present and intended to run with the existing CRA/Jest commands.  
- `git diff --check` passed for the changes.  
- Attempts to run `npm ci` and `CI=true npm test -- --runTestsByPath src/utils/pushService.test.ts` failed in this environment because `npm ci` could not complete due to `403 Forbidden` responses from the npm registry, so tests and full build could not be executed here.  

Files changed (high level): `public/service-worker.js`, `src/utils/pushService.ts`, `src/utils/pushService.test.ts`, `src/containers/Settings/SettingsPage.tsx`, `src/containers/Settings/SettingsPage.css`, `docs/web-push.md`, `docs/codex/interfaces.md`, `docs/codex/compatibility/cross-repo-contracts.md`.

Notes: No new frontend dependencies were added; backend push library recommendation (e.g. `pywebpush`/`py-vapid`) is documented but backend implementation and persistence remain to be implemented/verified in the PI/control repository.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a55f1b3967c832fb2ae0b2c658a8e47)