### PR TITLE
Make Settings reachable on mobile and fix mobile-status scrolling

### DIFF
--- a/docs/web-push.md
+++ b/docs/web-push.md
@@ -4,6 +4,9 @@
 
 - Der Service Worker der PWA wird in `src/index.tsx` bei `window.load` registriert und lädt `public/service-worker.js` nur in Production-Builds.
 - Die UI-Einstellungen liegen in `src/containers/Settings/SettingsPage.tsx` und verwenden bestehende Klassenkomponenten und CSS in `SettingsPage.css`.
+- Mobil wird dieselbe `SettingsPage` über den Tab `Einstellungen` in `MobileProductionView` geöffnet; es gibt keine separate mobile Push-Logik.
+- Die mobile Shell nutzt eine interne Tab-Umschaltung (`Status`, `Aktiver Sud`, `Berechnungen`, `Einstellungen`). Header/Tabs bleiben im mobilen Layout oberhalb des Inhalts, während der Container `.mobile-content` vertikal scrollt.
+- Für Android-Chrome und den installierten PWA-Modus verwendet die mobile Hülle `100dvh` mit `100vh`-Fallback und Safe-Area-Padding. So werden Inhalte nicht durch Browser-Chrome oder den unteren Bildschirmrand abgeschnitten.
 - Steuerungs-Requests sind in `src/repositorys/ProductionRepository.ts` über relative URLs unter `/api/controller` gekapselt; die Push-UI nutzt denselben relativen Controller-Basis-Pfad in `src/utils/pushService.ts`.
 - Der aktuelle Prozessstatus wird von der PI-Steuerung als `GET /Status/` geliefert. Laut externem Control-Kontext liegt die Statushoheit in der Steuerung; in diesem UI-Repository ist der Python-Code nicht vorhanden.
 - Ein Zustandswechsel zu `waiting.waitingFor` muss zuverlässig in der Steuerung beim internen Statuswechsel erkannt werden, nicht beim UI-Polling. Geeigneter Ereignisschlüssel: Prozessidentität, `currentStep.index`, `currentStep.phase`, `waiting.waitingFor`.
@@ -90,12 +93,23 @@ Der Service Worker öffnet ausschließlich URLs innerhalb des eigenen Origins; e
 
 1. PWA über `https://192.168.178.72` laden.
 2. In Android/Chrome die PWA installieren.
-3. In der PWA `Einstellungen` öffnen.
-4. `Push-Benachrichtigungen aktivieren` antippen und Berechtigung erlauben.
-5. `Testnachricht senden` antippen.
-6. PWA schließen oder in den Hintergrund legen.
-7. Einen Brauzustand erreichen, in dem `waiting.canConfirm === true` und `waiting.waitingFor` einer der bestätigungspflichtigen Werte ist.
-8. Prüfen, dass Android eine Benachrichtigung anzeigt und ein Klick die vorhandene PWA fokussiert oder `/` öffnet.
+3. PWA vollständig schließen und nach dem neuen UI-Deployment wieder öffnen, damit der aktualisierte Service Worker und die neue mobile Shell aktiv sind.
+4. Auf der mobilen Statusseite bis zum unteren Inhalt scrollen. Der scrollbare Bereich ist `.mobile-content`; die Tab-Leiste selbst ist nicht der vertikale Scroll-Container.
+5. In der mobilen Tab-Leiste `Einstellungen` öffnen.
+6. Prüfen, dass der Abschnitt `Push-Benachrichtigungen` sichtbar ist und die Statuszeilen `Browser unterstützt Push`, `Berechtigung` und `Subscription` angezeigt werden.
+7. `Push-Benachrichtigungen aktivieren` antippen und Berechtigung erlauben. Die Berechtigungsabfrage erfolgt weiterhin erst durch diese direkte Benutzeraktion.
+8. `Testnachricht senden` antippen.
+9. PWA schließen oder in den Hintergrund legen.
+10. Einen Brauzustand erreichen, in dem `waiting.canConfirm === true` und `waiting.waitingFor` einer der bestätigungspflichtigen Werte ist.
+11. Prüfen, dass Android eine Benachrichtigung anzeigt und ein Klick die vorhandene PWA fokussiert oder `/` öffnet.
+
+## Browser-Mobile-Emulation
+
+1. Chrome DevTools öffnen.
+2. Device Toolbar aktivieren und ein Android-Gerät mit ungefähr `390 × 844` auswählen.
+3. Statusseite öffnen und bis ganz nach unten scrollen.
+4. In der mobilen Tab-Leiste `Einstellungen` öffnen.
+5. Prüfen, dass der vorhandene Push-Bereich der `SettingsPage` vollständig erreichbar ist.
 
 ## Abgelaufene Subscriptions
 

--- a/src/containers/App.css
+++ b/src/containers/App.css
@@ -43,4 +43,10 @@
     margin-top: 80px;
 }
 
-
+@media (max-width: 767px) {
+    .AppContainer {
+        height: 100vh;
+        height: 100dvh;
+        overflow: hidden;
+    }
+}

--- a/src/containers/Mobile/MobileStatusView/MobileProductionView.css
+++ b/src/containers/Mobile/MobileStatusView/MobileProductionView.css
@@ -1,16 +1,32 @@
 .mobile-production-container {
-  padding: 18px 8px 32px 8px;
+  box-sizing: border-box;
+  padding: calc(18px + env(safe-area-inset-top)) 8px calc(16px + env(safe-area-inset-bottom)) 8px;
   background: var(--color-amber-bright);
-  border-radius: 16px;
-  box-shadow: 0 4px 16px var(--shadow-secondary);
-  max-width: 600px;
-  margin: 24px auto;
+  max-width: 100vw;
+  margin: 0 auto;
   font-family: Arial, sans-serif;
   display: flex;
   flex-direction: column;
   align-items: center;
   width: 100vw;
   height: 100vh;
+  height: 100dvh;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.mobile-content {
+  flex: 1 1 auto;
+  width: 100%;
+  min-height: 0;
+  overflow-y: auto;
+  overflow-x: hidden;
+  -webkit-overflow-scrolling: touch;
+  padding: 0 8px calc(24px + env(safe-area-inset-bottom));
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
 }
 
 .mobile-info-wrapper {
@@ -20,8 +36,6 @@
   flex-direction: column;
   justify-content: flex-start;
   align-items: center;
-  overflow-y: auto;
-  padding-bottom: 16px;
 }
 
 .mobile-production-container h2 {
@@ -130,9 +144,14 @@
 
 .mobile-tabs {
   display: flex;
-  justify-content: center;
+  justify-content: flex-start;
   margin-bottom: 18px;
   gap: 8px;
+  width: 100%;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+  flex: 0 0 auto;
+  padding-bottom: 2px;
 }
 
 .mobile-tabs button {
@@ -144,6 +163,8 @@
   font-size: 1.1rem;
   font-weight: bold;
   padding: 8px 22px;
+  min-height: 44px;
+  white-space: nowrap;
   outline: none;
   cursor: pointer;
   transition: background 0.2s, color 0.2s, border 0.2s, transform 0.08s;
@@ -174,6 +195,7 @@
   border-top: 2px solid var(--color-gold-deep);
   margin: 0 0 18px 0;
   width: 100%;
+  flex: 0 0 auto;
   box-shadow: none;
   background: none;
 }
@@ -311,6 +333,14 @@ outline: none;
   .mobile-production-container {
     padding: 8px 2px 18px 2px;
     max-width: 100vw;
+  }
+  .mobile-content {
+    padding-left: 6px;
+    padding-right: 6px;
+  }
+  .mobile-tabs button {
+    padding: 8px 14px;
+    font-size: 0.95rem;
   }
   .mobile-info-list {
     grid-template-columns: 1fr;

--- a/src/containers/Mobile/MobileStatusView/MobileProductionView.test.tsx
+++ b/src/containers/Mobile/MobileStatusView/MobileProductionView.test.tsx
@@ -1,0 +1,80 @@
+import React from 'react';
+import {fireEvent, render, screen} from '@testing-library/react';
+import {Provider} from 'react-redux';
+import {configureStore} from '@reduxjs/toolkit';
+import {MobileProductionView} from './MobileProductionView';
+import {BrewingStatus, ProcessMode, ProcessPhase, ProcessState, WaitingFor} from '../../../model/brewingStatus.types';
+import {rootReducer} from '../../../reducers/rootReducer';
+import * as pushService from '../../../utils/pushService';
+
+jest.mock('../MobileBrewingCalculationsView/MobileBrewingCalculationsView', () => () => <div>Berechnungen Mock</div>);
+
+const makeStatus = (): BrewingStatus => ({
+    elapsedTime: 23,
+    currentTime: 1783885211,
+    process: {state: ProcessState.ACTIVE},
+    currentStep: {
+        index: 1,
+        count: 4,
+        phase: ProcessPhase.MASHING_IN,
+        mode: ProcessMode.HEATING,
+        name: 'Einmaischen',
+        duration: 120,
+        elapsedTime: 23,
+        remainingTime: 97,
+    },
+    temperature: {current: 24, target: 65},
+    hardware: {heater: 'ON', agitator: 'OFF'},
+    waiting: {waitingFor: WaitingFor.NONE, canConfirm: false},
+    error: {code: null, details: null},
+});
+
+const renderMobileView = () => {
+    const store = configureStore({reducer: rootReducer});
+    return render(
+        <Provider store={store}>
+            <MobileProductionView
+                temperature={24}
+                brewingStatus={makeStatus()}
+                startPolling={jest.fn()}
+                isPollingRunning={false}
+            />
+        </Provider>
+    );
+};
+
+describe('MobileProductionView navigation', () => {
+    beforeEach(() => {
+        jest.spyOn(pushService, 'isPushSupported').mockReturnValue(false);
+        jest.spyOn(pushService, 'getPermissionState').mockReturnValue('default');
+        jest.spyOn(pushService.PushService, 'getSubscription').mockResolvedValue(null);
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    it('shows settings as a mobile tab and opens the existing SettingsPage without requesting push permission', async () => {
+        renderMobileView();
+
+        expect(screen.getByRole('button', {name: 'Einstellungen'})).toBeInTheDocument();
+        expect(screen.getByTestId('mobile-scroll-content')).toHaveClass('mobile-content');
+
+        fireEvent.click(screen.getByRole('button', {name: 'Einstellungen'}));
+
+        expect(await screen.findByRole('heading', {name: 'Einstellungen'})).toBeInTheDocument();
+        expect(screen.getByRole('heading', {name: 'Push-Benachrichtigungen'})).toBeInTheDocument();
+        expect(screen.getByText(/Browser unterstützt Push:/)).toBeInTheDocument();
+        expect(screen.getByRole('button', {name: 'Push-Benachrichtigungen aktivieren'})).toBeInTheDocument();
+        expect(screen.getByRole('button', {name: 'Testnachricht senden'})).toBeDisabled();
+    });
+
+    it('returns from settings to the mobile status page', () => {
+        renderMobileView();
+
+        fireEvent.click(screen.getByRole('button', {name: 'Einstellungen'}));
+        fireEvent.click(screen.getByRole('button', {name: 'Status'}));
+
+        expect(screen.getByRole('heading', {name: 'Brauhaus Mobile'})).toBeInTheDocument();
+    });
+});

--- a/src/containers/Mobile/MobileStatusView/MobileProductionView.tsx
+++ b/src/containers/Mobile/MobileStatusView/MobileProductionView.tsx
@@ -6,6 +6,7 @@ import { ProductionActions } from '../../../actions/actions';
 import { TimeFormatter } from "../../../utils/TimeFormatter";
 import MobileBrewingCalculationsView from '../MobileBrewingCalculationsView/MobileBrewingCalculationsView';
 import {getBrewingStatusLabel, getStatusChangeKey, isStepWaiting} from '../../../utils/brewingStatus/selectors';
+import SettingsPage from '../../Settings/SettingsPage';
 
 interface MobileProductionViewProps {
     temperature: number;
@@ -15,16 +16,18 @@ interface MobileProductionViewProps {
 }
 
 interface MobileProductionViewState {
-    activeTab: 'status' | 'finishedBrew' | 'calculations';
+    activeTab: MobileTab;
 }
 
-class MobileProductionView extends React.Component<MobileProductionViewProps, MobileProductionViewState> {
+type MobileTab = 'status' | 'finishedBrew' | 'calculations' | 'settings';
+
+export class MobileProductionView extends React.Component<MobileProductionViewProps, MobileProductionViewState> {
     constructor(props: MobileProductionViewProps) {
         super(props);
         this.state = { activeTab: 'status' };
     }
 
-    handleTabChange = (tab: 'status' | 'finishedBrew' | 'calculations') => {
+    handleTabChange = (tab: MobileTab) => {
         this.setState({ activeTab: tab });
     };
 
@@ -55,7 +58,7 @@ class MobileProductionView extends React.Component<MobileProductionViewProps, Mo
         const deltaX = this.touchEndX - this.touchStartX;
         if (Math.abs(deltaX) > 50) {
             // Swipe nach links: nächste Seite, nach rechts: vorherige Seite
-            const tabOrder: ('status' | 'finishedBrew' | 'calculations')[] = ['status', 'finishedBrew', 'calculations'];
+            const tabOrder: MobileTab[] = ['status', 'finishedBrew', 'calculations', 'settings'];
             const currentIdx = tabOrder.indexOf(this.state.activeTab);
             if (deltaX < 0 && currentIdx < tabOrder.length - 1) {
                 this.setState({ activeTab: tabOrder[currentIdx + 1] });
@@ -82,8 +85,10 @@ class MobileProductionView extends React.Component<MobileProductionViewProps, Mo
                     <button className={activeTab === 'status' ? 'active' : ''} onClick={() => this.handleTabChange('status')}>Status</button>
                     <button className={activeTab === 'finishedBrew' ? 'active' : ''} onClick={() => this.handleTabChange('finishedBrew')}>Aktiver Sud</button>
                     <button className={activeTab === 'calculations' ? 'active' : ''} onClick={() => this.handleTabChange('calculations')}>Berechnungen</button>
+                    <button className={activeTab === 'settings' ? 'active' : ''} onClick={() => this.handleTabChange('settings')}>Einstellungen</button>
                 </div>
                 <hr className="mobile-tabs-separator" />
+                <main className="mobile-content" data-testid="mobile-scroll-content">
                 {activeTab === 'status' && (
                     <>
                         <h2>Brauhaus Mobile</h2>
@@ -138,6 +143,10 @@ class MobileProductionView extends React.Component<MobileProductionViewProps, Mo
                 {activeTab === 'calculations' && (
                     <MobileBrewingCalculationsView />
                 )}
+                {activeTab === 'settings' && (
+                    <SettingsPage />
+                )}
+                </main>
             </div>
         );
     }

--- a/src/containers/Settings/SettingsPage.css
+++ b/src/containers/Settings/SettingsPage.css
@@ -4,6 +4,10 @@
   display: flex;
   flex-direction: column;
   gap: 1rem;
+  box-sizing: border-box;
+  width: 100%;
+  max-width: 100%;
+  overflow-wrap: anywhere;
 }
 
 .settings-header {
@@ -75,6 +79,7 @@
   display: flex;
   flex-direction: column;
   gap: 0.75rem;
+  min-width: 0;
 }
 
 .settings-card-header {
@@ -118,6 +123,7 @@
   display: flex;
   gap: 0.5rem;
   flex-wrap: wrap;
+  max-width: 100%;
 }
 
 .settings-chip {
@@ -181,6 +187,7 @@
   cursor: pointer;
   box-shadow: 0 4px 10px var(--shadow-orange-bold);
   transition: transform 0.15s ease, box-shadow 0.15s ease;
+  overflow-wrap: anywhere;
 }
 
 .settings-primary:hover {
@@ -198,14 +205,36 @@
 }
 
 @media (max-width: 768px) {
+  .settings-page {
+    padding: 1rem 0;
+  }
+
   .settings-header {
     flex-direction: column;
     align-items: flex-start;
   }
 
+  .settings-grid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
   .setting-row {
     flex-direction: column;
     align-items: flex-start;
+  }
+
+  .setting-options,
+  .settings-primary,
+  .settings-secondary,
+  .settings-chip,
+  .settings-select {
+    width: 100%;
+  }
+
+  .settings-primary,
+  .settings-secondary,
+  .settings-chip {
+    min-height: 44px;
   }
 
   .settings-footer {
@@ -226,6 +255,7 @@
   border-radius: 0.5rem;
   padding: 0.65rem 0.75rem;
   margin: 0;
+  overflow-wrap: anywhere;
 }
 
 .settings-error {


### PR DESCRIPTION
### Motivation
- Mobile users could not reach the existing `SettingsPage`, preventing activation of web-push on phones, and the mobile status screen was not fully vertically scrollable. 
- The root cause was the mobile shell rendering `MobileProductionView` without a scrollable content area and no entrypoint to `SettingsPage` on mobile. 
- Desktop behavior and existing Settings/PUSH logic must remain unchanged while enabling a single, reusable mobile entry to settings.

### Description
- Add a mobile `Einstellungen` tab to `MobileProductionView` that reuses the existing `SettingsPage` instead of duplicating push logic or backend calls. (`src/containers/Mobile/MobileStatusView/MobileProductionView.tsx`)
- Introduce a dedicated scroll container `.mobile-content` and adjust the mobile layout to use `min-height: 0`, `overflow-y: auto`, `-webkit-overflow-scrolling: touch`, and `100dvh`/safe-area padding so the status content scrolls correctly on Android/PWA. (`src/containers/Mobile/MobileStatusView/MobileProductionView.css`, `src/containers/App.css`)
- Make `SettingsPage` CSS responsive and safe for narrow screens (one-column grid under 768px, full-width buttons, no horizontal overflow) so the existing push controls are usable on mobile. (`src/containers/Settings/SettingsPage.css`)
- Add a unit test for mobile navigation and Settings visibility and update `docs/web-push.md` with the mobile access and Android/PWA verification steps. (`src/containers/Mobile/MobileStatusView/MobileProductionView.test.tsx`, `docs/web-push.md`)

### Testing
- `git diff --check` passed with no whitespace or lint diffs reported. 
- A new Jest unit test was added: `src/containers/Mobile/MobileStatusView/MobileProductionView.test.tsx`, but automated test execution could not complete in this environment because `npm ci` failed (registry 403) and `react-scripts`/dependencies were therefore unavailable. 
- `npm run build` and `npm test` could not be run here for the same reason (missing local `node_modules`/`react-scripts`), so build/test status is `not executed` in CI within this environment. 
- Manual verification steps for Chrome DevTools mobile emulation and installed Android PWA are documented in `docs/web-push.md` for on-device confirmation of scrolling and mobile Settings access.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a56131a4b6c832f8c68be7351636bdc)