### PR TITLE
Fix Brauhaus PWA push notification handling

### DIFF
--- a/docs/web-push.md
+++ b/docs/web-push.md
@@ -114,3 +114,109 @@ Der Service Worker öffnet ausschließlich URLs innerhalb des eigenen Origins; e
 ## Abgelaufene Subscriptions
 
 Antwortet der Push-Dienst beim Versand mit HTTP 404 oder 410, entfernt die Steuerung die Subscription aus ihrer Persistenz. Temporäre Netzwerk- oder Serverfehler werden geloggt, behalten die Subscription aber bei und dürfen andere Geräte nicht blockieren.
+
+## Analyse 2026-07-14: Hintergrundzustellung
+
+### Bestätigte Implementierungspunkte im UI-Repository
+
+- `public/service-worker.js` verarbeitet Push ausschließlich im Service-Worker-Kontext und ruft im `push`-Event keine `clients.matchAll()`-Abfrage auf. Die Anzeige hängt dadurch nicht von einem geöffneten Browserfenster oder React-Client ab.
+- Die asynchrone Anzeige wird mit `event.waitUntil(notificationPromise)` an die Lebensdauer des Push-Events gebunden. Das ist für geschlossene PWAs wichtig, weil der Browser den Service Worker sonst vor Abschluss der Anzeige beenden darf.
+- Ungültige oder leere Payloads führen weiterhin zu einer sichtbaren Fallback-Benachrichtigung mit Titel `Brauhaus`, Body `Eine neue Brauhaus-Benachrichtigung ist eingegangen.`, URL `/` und Tag `brauhaus-push`.
+- Notification-Klicks nutzen `event.waitUntil(...)`, fokussieren einen vorhandenen Same-Origin-Client oder öffnen sonst `/` beziehungsweise eine Same-Origin-URL aus den Notification-Daten. Externe URLs werden nicht geöffnet.
+- Die Notification-Optionen verwenden `body`, `icon`, `badge`, `tag`, `renotify` und `data`. `renotify: true` ist gesetzt, damit ein erneuter Push mit gleichem Tag auf Android/Chrome nicht still durch eine ersetzte Notification wirkt. `silent` wird nicht gesetzt.
+- `requireInteraction` wird bewusst nicht gesetzt: Mobile Browser/Android können das Verhalten einschränken oder ignorieren; für zuverlässige Hintergrundzustellung ist es nicht die primäre Ursache.
+- Der Service Worker enthält bewusst keine Cache-Strategie und keinen API-/App-Shell-`fetch`-Handler. Caches aus dem Worker können daher keine alten API-Antworten oder Statusdaten liefern.
+- `src/index.tsx` registriert `/service-worker.js` nur in Production-Builds über `process.env.PUBLIC_URL + '/service-worker.js'`. Bei Deployment unter dem Origin-Root ergibt das den Scope `/` und kontrolliert die gesamte PWA.
+- Die Push-Subscription wird in `src/utils/pushService.ts` über `navigator.serviceWorker.ready` auf der aktiven Registrierung gelesen/erstellt. Bestehende lokale Subscriptions werden erneut an `/api/controller/push/subscriptions` gesendet; Backendfehler lassen `subscribe()` fehlschlagen und dürfen nicht als aktiv interpretiert werden.
+- `Notification.requestPermission()` wird weiterhin nur im direkten Benutzerpfad `subscribe()` ausgelöst, nicht automatisch beim App-Start.
+
+### Backend-Prüfpunkte im Steuerungs-Repository
+
+Das Flask-/`pywebpush`-Backend ist nicht Teil dieses UI-Checkouts; folgende Punkte sind deshalb **Needs verification** im Steuerungs-Repository:
+
+- `pywebpush.webpush(...)` sollte einen expliziten, fachlich kurzen TTL setzen, empfohlen für Brau-Bestätigungen: `ttl=300`. So wird eine Nachricht bei kurz schlafendem Gerät nicht sofort verworfen, bleibt aber nicht unnötig lange gültig.
+- Für bestätigungspflichtige Brauzustände und Testnachrichten sollte geprüft werden, ob die installierte `pywebpush`-Version Header unterstützt und `headers={"Urgency": "high"}` korrekt an den Web-Push-Anbieter übergibt. Das ist für zeitnahe Android-Zustellung fachlich plausibel, ersetzt aber keine Android-Benachrichtigungseinstellungen.
+- Der Versand sollte Timeout und Logging ohne Secrets enthalten: Versandversuch, gekürzte technische Subscription-ID, TTL/Urgency, Annahme durch den Push-Anbieter, Fehlerstatus und Entfernung bei HTTP 404/410.
+- Ein erfolgreicher HTTP-Status vom Push-Anbieter bedeutet nur Annahme, nicht zwingend sichtbare Zustellung auf dem Gerät.
+
+### Service-Worker-Update auf Android sicherstellen
+
+Nach Änderungen an `public/service-worker.js` muss auf dem Handy der neue Worker aktiv werden:
+
+1. Production-Build erzeugen: `npm run build`.
+2. Build ins tatsächliche Caddy-Verzeichnis deployen, z. B. über das vorhandene Deployment-Skript oder den produktiven Release-Prozess.
+3. Prüfen, dass `/service-worker.js` vom Caddy-Origin aktuell ausgeliefert wird; für diese Datei ist serverseitig `Cache-Control: no-cache` sinnvoll. Eine Caddy-Konfiguration liegt in diesem Repository nicht vor, daher ist dies ein externer Prüfpunkt.
+4. PWA vollständig schließen.
+5. `https://192.168.178.72` erneut öffnen und warten, bis der neue Worker installiert/aktiviert wurde.
+6. Falls das Update nicht zuverlässig greift: PWA deinstallieren, Websitedaten für `192.168.178.72` löschen, Seite neu laden, PWA neu installieren und Push erneut aktivieren. Nach dem Löschen der Websitedaten muss die Subscription erneut beim Controller registriert werden.
+
+### Android-Prüfablauf
+
+Die Codekorrektur ersetzt keine Geräteeinstellungen. Nach einem technisch korrekten Web-Push-Pfad sind weiterhin diese Punkte zu prüfen; exakte Bezeichnungen variieren je nach Hersteller:
+
+```text
+Einstellungen
+→ Apps
+→ Brauhaus beziehungsweise Chrome
+→ Benachrichtigungen
+→ Sperrbildschirm und alle Kategorien erlauben
+```
+
+```text
+Einstellungen
+→ Apps
+→ Brauhaus beziehungsweise Chrome
+→ Akku
+→ Uneingeschränkt / Keine Einschränkungen
+```
+
+Zusätzlich prüfen:
+
+- Brauhaus/Chrome wurde nicht über „Stopp erzwingen“ beendet.
+- Hintergrunddaten und Datensparmodus blockieren Chrome/PWA nicht.
+- Hersteller-spezifischer Tiefschlaf deaktiviert die PWA nicht.
+- Sperrbildschirm-Benachrichtigungen sind für die App sichtbar erlaubt.
+
+### End-to-End-Testplan
+
+#### Test A: PWA geöffnet
+
+1. PWA öffnen.
+2. `POST /api/controller/push/test` auslösen.
+3. Eine echte Systembenachrichtigung muss erscheinen.
+
+#### Test B: PWA im Hintergrund
+
+1. Home-Taste drücken.
+2. PWA nicht aus der App-Übersicht entfernen.
+3. Testnachricht senden.
+4. Benachrichtigung muss erscheinen.
+
+#### Test C: PWA geschlossen
+
+1. PWA aus der App-Übersicht entfernen.
+2. Kein „Stopp erzwingen“ verwenden.
+3. Testnachricht senden.
+4. Benachrichtigung muss erscheinen.
+
+#### Test D: Display gesperrt
+
+1. PWA schließen.
+2. Display sperren.
+3. Mindestens kurz warten.
+4. Testnachricht senden.
+5. Benachrichtigung muss auf dem Sperrbildschirm erscheinen oder unmittelbar nach dem Aufwecken sichtbar sein.
+
+#### Test E: Deduplizierung
+
+1. Mehrere Testnachrichten mit gleichem Tag senden.
+2. Prüfen, ob die vorhandene Notification erwartungsgemäß ersetzt und durch `renotify` erneut signalisiert wird.
+3. Falls der Prozess-Payload eindeutige Tags pro bestätigungspflichtigem Zustand verwendet, darf je Zustand nur eine sichtbare Prozessbenachrichtigung entstehen.
+
+#### Test F: Echter Brauzustand
+
+1. PWA schließen.
+2. Display sperren.
+3. Einen bestätigungspflichtigen Prozesszustand erreichen.
+4. Automatische Push-Nachricht prüfen.
+5. Sicherstellen, dass der Zustand nur einmal benachrichtigt wird und die Prozess-Deduplizierung in der Steuerung erhalten bleibt.

--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -5,12 +5,16 @@
 // - keine Datenbankantworten
 // - keine Build-Metadaten wie index.html, manifest.json, asset-manifest.json oder version.json
 // So bleiben Browser-/Server-Caches und bestehende Versionsmechanismen maßgeblich.
+const SERVICE_WORKER_VERSION = 'brauhaus-push-v2';
+
 self.addEventListener('install', function() {
+  console.debug('[ServiceWorker] Installed', SERVICE_WORKER_VERSION);
   // skipWaiting() wird absichtlich nicht aufgerufen: Ein Update soll eine laufende
   // Brauansicht nicht ungefragt durch einen neuen Service Worker übernehmen.
 });
 
 self.addEventListener('activate', function(event) {
+  console.debug('[ServiceWorker] Activated', SERVICE_WORKER_VERSION);
   event.waitUntil(self.clients.claim());
 });
 
@@ -22,7 +26,7 @@ self.addEventListener('fetch', function() {
 
 const DEFAULT_NOTIFICATION = {
   title: 'Brauhaus',
-  body: 'Der Brauvorgang benötigt Aufmerksamkeit.',
+  body: 'Eine neue Brauhaus-Benachrichtigung ist eingegangen.',
   url: '/',
   tag: 'brauhaus-push',
   icon: '/logo192.png',
@@ -38,8 +42,16 @@ function parsePushPayload(event) {
     const payload = event.data.json();
     return Object.assign({}, DEFAULT_NOTIFICATION, payload || {});
   } catch (error) {
+    console.error('[ServiceWorker] Push payload parsing failed', error);
     return DEFAULT_NOTIFICATION;
   }
+}
+
+function getPayloadData(payload) {
+  if (payload && payload.data && typeof payload.data === 'object') {
+    return payload.data;
+  }
+  return {};
 }
 
 function sameOriginUrl(url) {
@@ -55,6 +67,7 @@ function sameOriginUrl(url) {
 }
 
 self.addEventListener('push', function(event) {
+  console.debug('[ServiceWorker] Push event received');
   const payload = parsePushPayload(event);
   const title = typeof payload.title === 'string' && payload.title ? payload.title : DEFAULT_NOTIFICATION.title;
   const options = {
@@ -62,10 +75,20 @@ self.addEventListener('push', function(event) {
     icon: typeof payload.icon === 'string' ? payload.icon : DEFAULT_NOTIFICATION.icon,
     badge: typeof payload.badge === 'string' ? payload.badge : DEFAULT_NOTIFICATION.badge,
     tag: typeof payload.tag === 'string' ? payload.tag : DEFAULT_NOTIFICATION.tag,
-    data: Object.assign({}, payload.data || {}, { url: sameOriginUrl(payload.url) })
+    renotify: true,
+    data: Object.assign({}, getPayloadData(payload), {
+      url: sameOriginUrl(payload.url),
+      serviceWorkerVersion: SERVICE_WORKER_VERSION
+    })
   };
 
-  event.waitUntil(self.registration.showNotification(title, options));
+  const notificationPromise = self.registration.showNotification(title, options)
+    .catch(function(error) {
+      console.error('[ServiceWorker] Notification display failed', error);
+      throw error;
+    });
+
+  event.waitUntil(notificationPromise);
 });
 
 self.addEventListener('notificationclick', function(event) {

--- a/src/utils/pushService.test.ts
+++ b/src/utils/pushService.test.ts
@@ -80,6 +80,61 @@ describe('pushService', () => {
         });
     });
 
+
+    it('reuses an existing subscription from navigator.serviceWorker.ready and registers it at the backend', async () => {
+        const requestPermission = jest.fn();
+        const subscription = {
+            endpoint: 'https://push.example/existing',
+            toJSON: () => ({
+                endpoint: 'https://push.example/existing',
+                keys: { p256dh: 'existing-key', auth: 'existing-auth' },
+            }),
+            unsubscribe: jest.fn(),
+        };
+        const pushManager = {
+            getSubscription: jest.fn().mockResolvedValue(subscription),
+            subscribe: jest.fn(),
+        };
+
+        defineWindowProperty('Notification', { permission: 'granted', requestPermission });
+        defineWindowProperty('PushManager', function PushManager() {});
+        defineNavigatorProperty('serviceWorker', {
+            ready: Promise.resolve({ pushManager }),
+        });
+        mockedAxios.post.mockResolvedValue({ status: 201 });
+
+        await expect(subscribe()).resolves.toBe(subscription as unknown as PushSubscription);
+
+        expect(pushManager.getSubscription).toHaveBeenCalledTimes(1);
+        expect(pushManager.subscribe).not.toHaveBeenCalled();
+        expect(requestPermission).not.toHaveBeenCalled();
+        expect(mockedAxios.post).toHaveBeenCalledWith('/api/controller/push/subscriptions', {
+            endpoint: 'https://push.example/existing',
+            keys: { p256dh: 'existing-key', auth: 'existing-auth' },
+        });
+    });
+
+    it('does not resolve as active when backend registration of an existing subscription fails', async () => {
+        const subscription = {
+            endpoint: 'https://push.example/existing',
+            toJSON: () => ({ endpoint: 'https://push.example/existing' }),
+            unsubscribe: jest.fn(),
+        };
+        defineWindowProperty('Notification', { permission: 'granted', requestPermission: jest.fn() });
+        defineWindowProperty('PushManager', function PushManager() {});
+        defineNavigatorProperty('serviceWorker', {
+            ready: Promise.resolve({
+                pushManager: {
+                    getSubscription: jest.fn().mockResolvedValue(subscription),
+                    subscribe: jest.fn(),
+                },
+            }),
+        });
+        mockedAxios.post.mockRejectedValue(new Error('backend unavailable'));
+
+        await expect(subscribe()).rejects.toThrow('backend unavailable');
+    });
+
     it('does not request permission when permission is denied', async () => {
         const requestPermission = jest.fn();
         defineWindowProperty('Notification', {

--- a/src/utils/serviceWorker.test.ts
+++ b/src/utils/serviceWorker.test.ts
@@ -1,0 +1,135 @@
+import fs from 'fs';
+import path from 'path';
+import vm from 'vm';
+
+type Listener = (event: any) => void;
+
+const loadServiceWorker = () => {
+    const listeners: Record<string, Listener> = {};
+    const showNotification = jest.fn().mockResolvedValue(undefined);
+    const matchAll = jest.fn().mockResolvedValue([]);
+    const openWindow = jest.fn().mockResolvedValue(undefined);
+    const context: any = {
+        console: {
+            debug: jest.fn(),
+            error: jest.fn(),
+        },
+        URL,
+    };
+    context.self = {
+        location: { origin: 'https://192.168.178.72' },
+        registration: { showNotification },
+        clients: {
+            claim: jest.fn().mockResolvedValue(undefined),
+            matchAll,
+            openWindow,
+        },
+        addEventListener: (type: string, listener: Listener) => {
+            listeners[type] = listener;
+        },
+    };
+
+    const serviceWorkerPath = path.resolve(__dirname, '../../public/service-worker.js');
+    const code = fs.readFileSync(serviceWorkerPath, 'utf8');
+    vm.runInNewContext(code, context);
+
+    return { listeners, showNotification, matchAll, openWindow, context };
+};
+
+describe('service-worker push handling', () => {
+    it('shows a notification for a valid JSON payload and binds the promise to waitUntil', async () => {
+        const { listeners, showNotification } = loadServiceWorker();
+        const waitUntil = jest.fn();
+        const data = {
+            title: 'Abmaischen',
+            body: 'Bitte bestätigen.',
+            url: '/production?step=6',
+            tag: 'brew-confirmation-6',
+            data: { waitingFor: 'MASHING_OUT_CONFIRMATION' },
+        };
+
+        listeners.push({
+            data: { json: () => data },
+            waitUntil,
+        });
+
+        expect(showNotification).toHaveBeenCalledWith('Abmaischen', expect.objectContaining({
+            body: 'Bitte bestätigen.',
+            icon: '/logo192.png',
+            badge: '/logo192.png',
+            tag: 'brew-confirmation-6',
+            renotify: true,
+            data: expect.objectContaining({
+                url: '/production?step=6',
+                waitingFor: 'MASHING_OUT_CONFIRMATION',
+                serviceWorkerVersion: 'brauhaus-push-v2',
+            }),
+        }));
+        expect(waitUntil).toHaveBeenCalledTimes(1);
+        await expect(waitUntil.mock.calls[0][0]).resolves.toBeUndefined();
+    });
+
+    it('shows a fallback notification for invalid payloads', () => {
+        const { listeners, showNotification, context } = loadServiceWorker();
+        const waitUntil = jest.fn();
+
+        listeners.push({
+            data: { json: () => { throw new Error('invalid json'); } },
+            waitUntil,
+        });
+
+        expect(context.console.error).toHaveBeenCalledWith('[ServiceWorker] Push payload parsing failed', expect.any(Error));
+        expect(showNotification).toHaveBeenCalledWith('Brauhaus', expect.objectContaining({
+            body: 'Eine neue Brauhaus-Benachrichtigung ist eingegangen.',
+            tag: 'brauhaus-push',
+            data: expect.objectContaining({ url: '/' }),
+        }));
+        expect(waitUntil).toHaveBeenCalledTimes(1);
+    });
+
+    it('shows a fallback notification for empty payloads without requiring an open client', () => {
+        const { listeners, showNotification, matchAll } = loadServiceWorker();
+        const waitUntil = jest.fn();
+
+        listeners.push({ waitUntil });
+
+        expect(showNotification).toHaveBeenCalledWith('Brauhaus', expect.objectContaining({
+            body: 'Eine neue Brauhaus-Benachrichtigung ist eingegangen.',
+        }));
+        expect(matchAll).not.toHaveBeenCalled();
+        expect(waitUntil).toHaveBeenCalledTimes(1);
+    });
+
+    it('focuses an existing same-origin window on notification click', async () => {
+        const { listeners, matchAll, openWindow } = loadServiceWorker();
+        const focus = jest.fn().mockResolvedValue(undefined);
+        matchAll.mockResolvedValue([{ url: 'https://192.168.178.72/', focus }]);
+        const waitUntil = jest.fn();
+        const close = jest.fn();
+
+        listeners.notificationclick({
+            notification: { close, data: { url: '/production' } },
+            waitUntil,
+        });
+
+        expect(close).toHaveBeenCalledTimes(1);
+        expect(waitUntil).toHaveBeenCalledTimes(1);
+        await waitUntil.mock.calls[0][0];
+        expect(focus).toHaveBeenCalledTimes(1);
+        expect(openWindow).not.toHaveBeenCalled();
+    });
+
+    it('opens only same-origin fallback URLs when no client exists', async () => {
+        const { listeners, matchAll, openWindow } = loadServiceWorker();
+        matchAll.mockResolvedValue([]);
+        const waitUntil = jest.fn();
+
+        listeners.notificationclick({
+            notification: { close: jest.fn(), data: { url: 'https://example.invalid/phishing' } },
+            waitUntil,
+        });
+
+        await waitUntil.mock.calls[0][0];
+        expect(openWindow).toHaveBeenCalledWith('/');
+    });
+});


### PR DESCRIPTION
### Motivation

- Users reported that Web Push notifications only reliably appeared while the PWA was open or the display was on, so the Service Worker and push lifecycle were audited and hardened to guarantee background delivery where possible. 
- The goal was to ensure the `push` and `notificationclick` handlers bind async work via `event.waitUntil(...)`, provide robust payload fallbacks, avoid dependency on open clients, and surface minimal diagnostics.

### Description

- Harden `public/service-worker.js`: add `SERVICE_WORKER_VERSION`, diagnostic `console.debug`/`console.error` logs, robust payload parsing with fallback defaults, defensive payload `data` normalization, same-origin URL enforcement, `renotify: true`, and explicit `event.waitUntil(notificationPromise)` wrapping the `showNotification()` call; `notificationclick` remains same-origin-safe and uses `event.waitUntil(...)`. 
- Add unit tests: new `src/utils/serviceWorker.test.ts` simulates the worker in a VM to assert push handling, fallback behavior, `waitUntil` binding, click focus/open behavior, and same-origin URL normalization; extend `src/utils/pushService.test.ts` with cases for reusing existing subscriptions and backend registration failure handling. 
- Update docs: expand `docs/web-push.md` with the analysis, backend verification points (TTL/Urgency/timeout/logging), Android troubleshooting and update procedure, and a detailed end-to-end test plan; no backend code was changed. 

### Testing

- Performed a VM smoke test that loads `public/service-worker.js` in a Node `vm` context and verified a `push` event triggers `showNotification()` and that external payload URLs are normalized to same-origin; this check passed. 
- Added Jest tests (`src/utils/serviceWorker.test.ts` and extended `src/utils/pushService.test.ts`) but running the test suite in this environment failed because `npm ci` could not complete (`@types/react` returned HTTP 403) and `react-scripts` was not available, so the new tests were not executed here. 
- Local repository checks (`git diff --check`, file diffs) and an inline VM verification were done and succeeded; CI/test execution should be re-run in the normal developer environment (after `npm ci`) to run the added Jest tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a562890d6e4832fa7990dc8565907f5)