### PR TITLE
Optimize Production layout for Full HD kiosk

### DIFF
--- a/src/components/Controlls/WaterControll/WaterControll.css
+++ b/src/components/Controlls/WaterControll/WaterControll.css
@@ -1,6 +1,6 @@
 .watercontainer {
-    width: 80%;
-    height: 90%;
+    width: clamp(8.5rem, 74%, 11rem);
+    height: 92%;
     position: relative;
     background: white;
     box-shadow: 0 0 10px var(--shadow-water);

--- a/src/containers/Production/Production.css
+++ b/src/containers/Production/Production.css
@@ -7,20 +7,24 @@
 /* Gesamtes App-Grid */
 .containerProduction {
     display: grid;
-    grid-template-columns: minmax(14rem, 20rem) minmax(12rem, 1.4fr) minmax(22rem, 40rem) minmax(18rem, 25rem);
-    grid-template-rows: auto minmax(0, 1fr) auto;
+    grid-template-columns:
+        clamp(220px, 13vw, 260px)
+        minmax(360px, 1.05fr)
+        minmax(440px, 1.25fr)
+        minmax(500px, 1.45fr);
+    grid-template-rows: minmax(0, 1fr) clamp(6rem, 9.5vh, 6.875rem);
     grid-template-areas:
-        "Header Header Header Header"
         "Left List Meters Settings"
         "Info Info Info Info";
+    column-gap: 1.125rem;
+    row-gap: 1rem;
     height: 100%;
     min-height: 0;
     min-width: 0;
     background: var(--color-surface-1);
     box-sizing: border-box;
-    padding: 1rem;
+    padding: 1rem 1.25rem 1.25rem;
     overflow: hidden;
-    gap: 1rem;
     margin-top: 0;
     align-items: stretch;
 }
@@ -52,10 +56,10 @@
     background: var(--color-surface-2);
     border-radius: 10px;
     box-shadow: 0 2px 8px var(--shadow-secondary);
-    padding: 1rem 0.7rem;
+    padding: 0.8rem 0.65rem;
     display: flex;
     flex-direction: column;
-    gap: 1rem;
+    gap: 0.75rem;
     overflow: hidden;
 }
 
@@ -68,10 +72,7 @@
 
 /* Header */
 .HeaderProduction {
-    grid-area: Header;
-    display: flex;
-    align-items: center;
-    min-height: 2.5rem;
+    display: none;
 }
 .HeaderText {
     color: var(--color-light-text);
@@ -91,11 +92,13 @@
     border-radius: 12px 12px 0 0;
     box-shadow: 0 2px 8px var(--shadow-soft);
     min-height: 0;
+    min-width: 0;
     overflow: hidden;
+    padding: 0.5rem 0.25rem;
 }
 
 .Flame {
-    flex: 0 0 clamp(4.5rem, 10vh, 7rem);
+    flex: 0 0 clamp(4.25rem, 8vh, 5.5rem);
     display: flex;
     justify-content: center;
     align-items: center;
@@ -103,7 +106,7 @@
     border-radius: 0 0 12px 12px;
     box-shadow: 0 2px 8px var(--shadow-error-soft);
     overflow: visible;
-    min-height: 4.5rem;
+    min-height: 4.25rem;
     padding: var(--spacing-xs) 0;
 }
 
@@ -121,12 +124,12 @@
 }
 
 .Agitator {
-    flex-wrap: wrap;
-    gap: 2rem;
+    flex-wrap: nowrap;
+    gap: 0.75rem;
 }
 
 .Temp {
-    padding: 0 1rem;
+    padding: 0 0.75rem;
 }
 
 /* Settings Panel */
@@ -134,40 +137,49 @@
     grid-area: Settings;
     background: var(--color-brew-bg);
     border-radius: 12px;
-    padding: 1.3rem 1.3rem 1.7rem 1.3rem;
+    padding: 0.9rem 1rem 1rem;
     min-width: 0;
     box-shadow: 0 2px 16px var(--shadow-medium);
     display: flex;
     flex-direction: column;
-    gap: 1.5rem;
-    overflow-y: auto;
+    gap: 0.85rem;
+    overflow: hidden;
 }
+
+.Settings h3 {
+    margin: 0;
+    font-size: 1.35rem;
+    line-height: 1.15;
+}
+
 .Info {
     grid-area: Info;
     background: var(--color-brew-bg);
     border-radius: 10px;
-    padding: 1.2rem;
+    padding: 0.75rem 1rem;
     margin-top: 0;
     display: flex;
-    flex-wrap: wrap;
+    flex-wrap: nowrap;
     align-items: center;
+    gap: 1rem;
     min-height: 0;
-    overflow-y: auto;
-    overflow-x: hidden;
+    min-width: 0;
+    overflow: hidden;
 }
 
 /* Zeit- und Label-Anzeigen */
 .timeContainer {
-    margin: 0.6rem 0.5rem 0 0;
+    margin: 0;
     display: flex;
     flex-direction: column;
     align-items: flex-start;
     background-color: var(--color-gray-quiet);
     border-radius: 6px;
+    flex: 0 0 auto;
 }
 .frame {
     border: 2px solid var(--color-dark-bg);
-    padding: 1rem;
+    padding: 0.65rem 1rem;
     display: flex;
     flex-direction: column;
     align-items: center;
@@ -176,31 +188,53 @@
 }
 .label {
     color: var(--color-light-text);
-    font-size: 1rem;
+    font-size: 0.95rem;
     font-weight: bold;
-    margin-bottom: 0.5rem;
+    margin-bottom: 0.35rem;
 }
 .time {
     color: var(--color-light-text);
-    font-size: 1.4rem;
+    font-size: 1.25rem;
 }
 .progressLabel {
-    margin-top: -1rem;
-    margin-left: 0.625rem;
+    margin: 0 0 0.35rem 0;
     color: var(--color-light-text);
 }
 
+.Info .container {
+    width: 100%;
+    max-width: none;
+    margin: 0 !important;
+    padding: 0;
+    min-width: 0;
+}
+
 /* Bedienelemente/Settings innen */
-.settingsRow, .settingsRowWater {
+.settingsRow,
+.settingsRowWater {
     display: flex;
     justify-content: space-between;
-    align-items: center;
-    gap: 1.4rem;
+    align-items: flex-start;
+    gap: 1rem;
 }
-.rightAligned { margin-right: 1rem; }
-.leftAligned { margin-left: 1rem; }
+.rightAligned,
+.leftAligned {
+    margin: 0;
+    min-width: 0;
+}
 
-.quantityPickerItem { margin-top: 1rem; }
+.leftAligned label {
+    display: block;
+    margin: 0 0 0.25rem;
+    color: var(--color-light-text);
+    line-height: 1.2;
+}
+
+.leftAligned label:not(:first-child) {
+    margin-top: 0.6rem;
+}
+
+.quantityPickerItem { margin-top: 0.45rem; }
 
 /* Buttons */
 .startBtnDiv {
@@ -209,7 +243,7 @@
     justify-content: center;
 }
 .startBtn {
-    height: 3rem;
+    height: 2.75rem;
     width: 12rem;
     font-size: 1rem;
     padding: 0.3rem 1.2rem;
@@ -254,16 +288,32 @@
     background-color: var(--color-surface-alt-dark);
 }
 
+.startPollingBtnDiv {
+    display: flex;
+    justify-content: center;
+}
+
+.startPollingBtn {
+    min-width: 3rem;
+    min-height: 2.5rem;
+}
+
 /* Gauge-Container */
 .GaugeContainer {
-    padding: 1.1rem;
+    padding: 0.45rem;
+    min-width: 0;
+}
+
+.GaugeContainer svg {
+    max-width: 100%;
+    height: auto;
 }
 
 .recipeWaterButtons {
     display: flex;
-    gap: 1rem;
+    gap: 0.75rem;
     justify-content: center;
-    margin-top: 0.75rem;
+    margin-top: 0;
 }
 
 .recipeWaterBtn {
@@ -273,8 +323,8 @@
     color: var(--color-white);
     cursor: pointer;
     font-size: 1rem;
-    min-width: 8rem;
-    padding: 0.5rem 1rem;
+    min-width: 7.25rem;
+    padding: 0.45rem 0.85rem;
 }
 
 .recipeWaterBtn:hover:not(:disabled) {
@@ -296,17 +346,32 @@
     min-width: 0;
 }
 
+@media (max-width: 1700px) {
+    .containerProduction {
+        grid-template-columns:
+            clamp(200px, 12vw, 230px)
+            minmax(300px, 1.05fr)
+            minmax(360px, 1.2fr)
+            minmax(420px, 1.4fr);
+        column-gap: 0.875rem;
+        padding: 0.875rem;
+    }
+}
+
 @media (max-width: 1280px) {
     .containerProduction {
         grid-template-columns: minmax(12rem, 18rem) minmax(12rem, 1fr) minmax(18rem, 1fr);
-        grid-template-rows: auto minmax(28rem, auto) minmax(20rem, auto) auto;
+        grid-template-rows: minmax(24rem, 1fr) minmax(18rem, auto) auto;
         grid-template-areas:
-            "Header Header Header"
             "Left List Settings"
             "Meters Meters Settings"
             "Info Info Info";
         height: 100%;
         overflow: auto;
+    }
+
+    .Settings {
+        overflow-y: auto;
     }
 }
 
@@ -315,7 +380,6 @@
         grid-template-columns: 1fr;
         grid-template-rows: auto;
         grid-template-areas:
-            "Header"
             "Left"
             "List"
             "Meters"


### PR DESCRIPTION
### Motivation
- Reduce the large unused vertical gap below the global header so the Production cards start ~16–20 px under the header at 1920×1080. 
- Make the water column narrower and free more horizontal space for Process, Meters and Settings while keeping the four main cards equal height. 
- Remove unnecessary internal scrolling and large paddings/gaps so the full Production view is visible without scrollbars at Full HD while preserving all business logic and Redux wiring.

### Description
- Reworked the Production grid in `src/containers/Production/Production.css` to a single four-card row plus a compact bottom summary row by removing the in-view `HeaderProduction` grid row and using `grid-template-columns` with `clamp(...)` and `minmax(...)` for the requested column proportions. 
- Compacted vertical spacing and paddings, tightened gaps, set `min-width: 0`/`min-height: 0` safeguards, and switched `.Settings`/`.Info` to `overflow: hidden` at desktop sizes to remove the unnecessary settings scrollbar. 
- Tuned the water card and inner graphic by updating `src/components/Controlls/WaterControll/WaterControll.css` to a narrower `watercontainer` (`clamp(8.5rem, 74%, 11rem)`) and adjusted water/meter/gauge paddings so the water area no longer displaces other cards. 
- Added a `@media (max-width: 1700px)` breakpoint with milder column sizes and adjusted smaller-width fallbacks (existing 1280px / 900px rules) so 1600/1366 validation widths avoid overflow while preserving the responsive stacked layout.

### Testing
- Ran `git diff --check` to validate whitespace/merge issues and it completed cleanly. 
- Attempted `npx tsc --noEmit` but it was blocked by existing TypeScript deprecation warnings in `tsconfig.json` (`target=ES5`, `moduleResolution=node10`). 
- Attempted to run unit tests with `npm test` / `react-scripts test` but `node_modules` were not available and `npm install` failed due to a registry `403` for `@types/react`, so Jest/browser tests and screenshot validation could not be executed. 
- Manual CSS review and responsive calculations were performed for viewports: `1920×1080`, `1600×1200`, `1600×900`, and `1366×768`, with the layout changes designed to meet the requested spacing and scrollbar constraints (visual screenshot could not be produced due to the blocked install).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5f2d2ccb70832f8a0f551f12a9f63c)