### PR TITLE
Refactor WaterControl component and overhaul water-gauge styling; add water color variables

### DIFF
--- a/src/colors.css
+++ b/src/colors.css
@@ -71,7 +71,9 @@
   --color-gold-deep: #b8860b;
   --color-brown-deep: #5d3300;
   --color-teal-strong: #00796b;
-  --color-water-blue: #00aaff;
+  --color-water-light: #76b9ec;
+  --color-water-blue: #4a98dc;
+  --color-water-deep: #2d75bc;
   --color-gradient-start: #f9d423;
   --color-gradient-end: #ff4e50;
   --color-waiting-orange: #ffa733;

--- a/src/components/Controlls/WaterControll/WaterControl.tsx
+++ b/src/components/Controlls/WaterControll/WaterControl.tsx
@@ -1,7 +1,5 @@
 import React from 'react';
 import './WaterControll.css';
-import { ToggleState } from "../../../enums/eToggleState";
-import { COLOR_SURFACE_LIGHT } from '../../../colors';
 
 export interface WaterStatus {
     liters: number
@@ -13,83 +11,96 @@ interface WaterControllProps {
     agitatorSpeed: number;
 }
 
-interface WaterControllState {
-    isAnimating: boolean;
-}
+class WaterControl extends React.Component<WaterControllProps> {
+    private readonly MAX_WATER_LITERS = 70;
+    private readonly MIN_AGITATOR_DURATION_SECONDS = 1.5;
+    private readonly MAX_AGITATOR_DURATION_SECONDS = 30;
 
-class WaterControl extends React.Component<WaterControllProps, WaterControllState> {
-    private agitatorRef: React.RefObject<HTMLDivElement>;
+    private getWaterLevel(liters: number): { numericLiters: number; waterLevel: number } {
+        const numericLiters = Number.isFinite(liters) ? liters : 0;
+        const waterLevel = Math.max(
+            0,
+            Math.min(100, (numericLiters / this.MAX_WATER_LITERS) * 100),
+        );
 
-    constructor(props: WaterControllProps) {
-        super(props);
-        this.agitatorRef = React.createRef();
-        this.state = {
-            isAnimating: props.agitatorState === true,
-        };
+        return { numericLiters, waterLevel };
     }
 
-    componentDidUpdate(prevProps: WaterControllProps) {
-        if (prevProps.agitatorState !== this.props.agitatorState) {
-            this.setState({ isAnimating: this.props.agitatorState === true }, () => {
-                // Setze die Position des Bildes nach der Änderung der Animationszustands neu
-                if (!this.state.isAnimating && this.agitatorRef.current) {
-                    this.agitatorRef.current.style.animation = 'none'; // Animation stoppen
-                    this.agitatorRef.current.style.left = '50%'; // Zurück zur Mitte verschieben
-                } else if (this.state.isAnimating && this.agitatorRef.current) {
-                    const agitatorSpeed = this.props.agitatorSpeed;
-                    const agitatorAnimationSpeed = this.state.isAnimating ? 60 / agitatorSpeed : 20;
-                    this.agitatorRef.current.style.animation = `spin ${agitatorAnimationSpeed}s linear infinite`; // Animation neu starten
-                }
-            });
+    private getAgitatorAnimationDuration(): number {
+        const { agitatorSpeed } = this.props;
+        const safeSpeed = Number.isFinite(agitatorSpeed) && agitatorSpeed > 0 ? agitatorSpeed : 0;
+
+        if (safeSpeed === 0) {
+            return this.MAX_AGITATOR_DURATION_SECONDS;
         }
+
+        return Math.max(
+            this.MIN_AGITATOR_DURATION_SECONDS,
+            Math.min(this.MAX_AGITATOR_DURATION_SECONDS, 60 / safeSpeed),
+        );
     }
 
-    render() {
-        const { liters } = this.props;
-        const isAnimating = this.state.isAnimating;
-        const agitatorAnimationSpeed = 30; // Speed immer auf 30 gesetzt
-        const waterLevel = (liters / 70) * 100;
-        const scaleItems = [];
-        for (let i = 70; i >= 0; i--) {
-            const scaleItemStyle = {
-                height: `${100 / 70}%`,
-                borderBottom: i === 0 ? 'none' : `1px solid ${COLOR_SURFACE_LIGHT}`,
-                opacity: waterLevel >= i ? 1 : 0.5,
-            };
-            scaleItems.push(
-                <div className="scale-item" style={scaleItemStyle} key={i}>
-                    {i % 10 === 0 && <span className="scale-label">{i}</span>}
+    private renderScaleMarks(): React.ReactNode[] {
+        const scaleMarks: React.ReactNode[] = [];
+
+        for (let liters = 0; liters <= this.MAX_WATER_LITERS; liters += 5) {
+            const isMajorMark = liters % 10 === 0;
+            const markPosition = (liters / this.MAX_WATER_LITERS) * 100;
+
+            const markClassName = isMajorMark
+                ? 'water-gauge__mark water-gauge__mark--major'
+                : 'water-gauge__mark water-gauge__mark--minor';
+
+            scaleMarks.push(
+                <div
+                    className={markClassName}
+                    key={liters}
+                    style={{ bottom: `${markPosition}%` }}
+                >
+                    {isMajorMark && (
+                        <span className="water-gauge__mark-label">{liters}</span>
+                    )}
                 </div>
             );
         }
 
+        return scaleMarks;
+    }
+
+    render() {
+        const { liters, agitatorState } = this.props;
+        const { numericLiters, waterLevel } = this.getWaterLevel(liters);
+        const agitatorAnimationDuration = this.getAgitatorAnimationDuration();
+        const agitatorImageClassName = agitatorState
+            ? 'water-gauge__agitator-image water-gauge__agitator-image--running'
+            : 'water-gauge__agitator-image';
+
         return (
-            <div className="watercontainer">
-                <div className="water-level" style={{ height: `${waterLevel}%` }}>
-                    <div className="waves" />
+            <div className="water-gauge">
+                <div className="water-gauge__tank">
+                    <div className="water-gauge__fill" style={{ height: `${waterLevel}%` }}>
+                        <div className="water-gauge__surface" />
+                    </div>
+
+                    <div className="water-gauge__glass" />
+
+                    <div className="water-gauge__scale" aria-hidden="true">
+                        {this.renderScaleMarks()}
+                    </div>
+
+                    <div className="water-gauge__agitator">
+                        <img
+                            className={agitatorImageClassName}
+                            src={`${process.env.PUBLIC_URL}/rührwerk.png`}
+                            alt=""
+                            style={{ animationDuration: `${agitatorAnimationDuration}s` }}
+                        />
+                    </div>
                 </div>
-                <div className="agitator" ref={this.agitatorRef} style={{
-                    position: 'absolute',
-                    bottom: '15px',
-                    left: '50%',
-                    transform: 'translate(-50%, 0)', // Korrigiert: zentriert exakt horizontal
-                    width: '80px',
-                    display: 'flex',
-                    justifyContent: 'center',
-                    alignItems: 'flex-end',
-                }}>
-                    {/* Animation direkt auf das Bild anwenden */}
-                    <img
-                        src={process.env.PUBLIC_URL + '/rührwerk.png'}
-                        alt="Wasser"
-                        style={{
-                            width: '80px',
-                            height: '80px',
-                            animation: isAnimating && agitatorAnimationSpeed > 0 ? `spin ${agitatorAnimationSpeed}s linear infinite` : 'none',
-                            display: 'block',
-                            margin: '0 auto',
-                        }}
-                    />
+
+                <div className="water-gauge__reading">
+                    <span>Aktuell</span>
+                    <strong>{numericLiters.toFixed(1)} L</strong>
                 </div>
             </div>
         );

--- a/src/components/Controlls/WaterControll/WaterControll.css
+++ b/src/components/Controlls/WaterControll/WaterControll.css
@@ -1,45 +1,302 @@
-.watercontainer {
-    width: clamp(8.5rem, 74%, 11rem);
-    height: 92%;
-    position: relative;
-    background: white;
-    box-shadow: 0 0 10px var(--shadow-water);
+.water-gauge {
+    width: 100%;
+    height: 100%;
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 0.45rem;
+    box-sizing: border-box;
 }
 
-.water-level {
+.water-gauge__tank {
+    position: relative;
+    width: clamp(8rem, 76%, 11rem);
+    height: min(100%, 34rem);
+    min-height: 18rem;
+    overflow: hidden;
+    box-sizing: border-box;
+
+    background:
+        linear-gradient(
+            90deg,
+            #c7cdd1 0%,
+            #e8ecef 8%,
+            var(--color-white) 34%,
+            #f8fafb 55%,
+            #dce1e4 84%,
+            #b9c0c5 100%
+        );
+
+    border: 3px solid var(--color-border-strong);
+    border-radius: 16px;
+
+    box-shadow:
+        inset 10px 0 16px rgb(0 0 0 / 10%),
+        inset -10px 0 16px rgb(0 0 0 / 14%),
+        inset 0 2px 3px rgb(255 255 255 / 85%),
+        inset 0 -6px 10px rgb(0 0 0 / 12%),
+        0 10px 22px rgb(0 0 0 / 30%);
+}
+
+.water-gauge__tank::before {
+    content: "";
     position: absolute;
+    right: 4px;
+    bottom: 3px;
+    left: 4px;
+    z-index: 2;
+    height: 1.45rem;
+    pointer-events: none;
+    border-radius: 50% 50% 12px 12px;
+    background:
+        radial-gradient(
+            ellipse at center,
+            rgb(255 255 255 / 28%) 0%,
+            rgb(255 255 255 / 10%) 42%,
+            rgb(0 0 0 / 16%) 100%
+        );
+    box-shadow:
+        inset 0 2px 4px rgb(255 255 255 / 32%),
+        inset 0 -3px 5px rgb(0 0 0 / 16%);
+}
+
+.water-gauge__tank::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    z-index: 4;
+    pointer-events: none;
+    border-radius: 13px;
+    box-shadow:
+        inset 3px 0 0 rgb(255 255 255 / 38%),
+        inset -3px 0 0 rgb(0 0 0 / 10%),
+        inset 0 0 0 1px rgb(255 255 255 / 22%);
+}
+
+.water-gauge__fill {
+    position: absolute;
+    right: 0;
     bottom: 0;
     left: 0;
-    right: 0;
-    height: 0;
-    background-color: var(--color-water-blue);
-    transition: height 0.5s;
+    z-index: 1;
+    overflow: visible;
+    border-radius: 0 0 11px 11px;
+
+    background:
+        linear-gradient(
+            90deg,
+            rgb(0 0 0 / 18%) 0%,
+            transparent 18%,
+            rgb(255 255 255 / 18%) 48%,
+            transparent 76%,
+            rgb(0 0 0 / 14%) 100%
+        ),
+        linear-gradient(
+            180deg,
+            var(--color-water-light) 0%,
+            var(--color-water-blue) 35%,
+            var(--color-water-deep) 100%
+        );
+
+    transition: height 500ms ease;
 }
 
-.waves {
+.water-gauge__surface {
     position: absolute;
-    top: -10px;
+    top: -0.55rem;
+    left: -10%;
+    width: 120%;
+    height: 1.1rem;
+    overflow: hidden;
+    border-radius: 50%;
+
+    background:
+        linear-gradient(
+            180deg,
+            rgb(255 255 255 / 42%),
+            rgb(106 181 235 / 82%) 48%,
+            rgb(47 124 215 / 95%) 100%
+        );
+
+    box-shadow:
+        inset 0 2px 2px rgb(255 255 255 / 35%),
+        0 2px 5px rgb(0 72 135 / 22%);
+}
+
+.water-gauge__surface::before,
+.water-gauge__surface::after {
+    content: "";
+    position: absolute;
+    top: 0.12rem;
+    width: 62%;
+    height: 0.42rem;
+    border-radius: 50%;
+    pointer-events: none;
+    background: rgb(255 255 255 / 24%);
+    transform: translateX(-8%);
+    animation: water-surface-drift 6.5s ease-in-out infinite alternate;
+}
+
+.water-gauge__surface::before {
+    left: 4%;
+}
+
+.water-gauge__surface::after {
+    right: 2%;
+    opacity: 0.7;
+    animation-duration: 8s;
+    animation-direction: alternate-reverse;
+}
+
+.water-gauge__glass {
+    position: absolute;
+    inset: 3px;
+    z-index: 3;
+    pointer-events: none;
+    border-radius: 12px;
+
+    background:
+        linear-gradient(
+            105deg,
+            rgb(255 255 255 / 26%) 0%,
+            rgb(255 255 255 / 8%) 24%,
+            transparent 43%,
+            transparent 72%,
+            rgb(255 255 255 / 10%) 100%
+        );
+
+    box-shadow:
+        inset 1px 0 rgb(255 255 255 / 55%),
+        inset -1px 0 rgb(0 0 0 / 12%);
+}
+
+.water-gauge__scale {
+    position: absolute;
+    inset: 0.85rem 0.7rem 0.85rem 0.55rem;
+    z-index: 5;
+    pointer-events: none;
+}
+
+.water-gauge__mark {
+    position: absolute;
     left: 0;
-    right: 0;
-    height: 10px;
-    background-image: linear-gradient(transparent, var(--color-water-blue));
-    animation: waves 1s infinite linear;
+    display: flex;
+    align-items: center;
+    color: var(--color-gray-deep);
+    font-size: 0.7rem;
+    font-weight: 700;
+    line-height: 1;
+    text-shadow: 0 1px 1px rgb(255 255 255 / 72%);
+    transform: translateY(50%);
 }
 
-@keyframes waves {
+.water-gauge__mark::before {
+    content: "";
+    display: block;
+    flex: 0 0 auto;
+    height: 1px;
+    margin-right: 0.35rem;
+    background: var(--color-gray-very-dark);
+    box-shadow: 0 1px 0 rgb(255 255 255 / 38%);
+}
+
+.water-gauge__mark--major::before {
+    width: 1rem;
+    height: 2px;
+}
+
+.water-gauge__mark--minor::before {
+    width: 0.48rem;
+    opacity: 0.82;
+}
+
+.water-gauge__mark-label {
+    min-width: 1.15rem;
+}
+
+.water-gauge__agitator {
+    position: absolute;
+    bottom: 0.9rem;
+    left: 50%;
+    z-index: 6;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: clamp(3.8rem, 48%, 5rem);
+    pointer-events: none;
+    transform: translateX(-50%);
+}
+
+.water-gauge__agitator-image {
+    display: block;
+    width: 100%;
+    height: auto;
+    transform-origin: 50% 50%;
+    animation-name: agitator-spin;
+    animation-timing-function: linear;
+    animation-iteration-count: infinite;
+    animation-play-state: paused;
+}
+
+.water-gauge__agitator-image--running {
+    animation-play-state: running;
+}
+
+.water-gauge__reading {
+    display: flex;
+    align-items: baseline;
+    justify-content: center;
+    gap: 0.35rem;
+    min-height: 1.55rem;
+    padding: 0.12rem 0.5rem;
+    color: var(--color-light-text);
+    font-size: 0.72rem;
+    line-height: 1.1;
+    text-shadow: 0 1px 2px rgb(0 0 0 / 36%);
+}
+
+.water-gauge__reading strong {
+    color: var(--color-white);
+    font-size: 0.95rem;
+    letter-spacing: 0.01em;
+}
+
+@keyframes water-surface-drift {
     0% {
-        background-position: 0 0;
+        transform: translateX(-8%);
     }
+
     100% {
-        background-position: 100% 0;
+        transform: translateX(10%);
     }
 }
 
-@keyframes spin {
+@keyframes agitator-spin {
     0% {
-        transform: translateX(-50%) rotate(0deg);
+        transform: rotate(0deg);
     }
+
     100% {
-        transform: translateX(-50%) rotate(360deg);
+        transform: rotate(360deg);
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .water-gauge__fill {
+        transition: none;
+    }
+
+    .water-gauge__surface::before,
+    .water-gauge__surface::after,
+    .water-gauge__agitator-image {
+        animation: none;
+    }
+}
+
+@media (max-width: 1280px) {
+    .water-gauge__tank {
+        min-height: 16rem;
     }
 }


### PR DESCRIPTION
### Motivation
- Modernize the water control UI with a clearer DOM structure and safer numeric handling for water level and agitator speed.
- Replace fragile manual animation state and DOM refs with declarative CSS-driven animation and duration calculation.
- Improve visual fidelity and theming by expanding water color tokens and redesigning the water gauge styles.

### Description
- Added three new color tokens in `src/colors.css`: `--color-water-light`, `--color-water-blue` (updated), and `--color-water-deep`, replacing the single `--color-water-blue` value.
- Rewrote `src/components/Controlls/WaterControll/WaterControl.tsx` to remove instance state and refs, introduce `MAX_WATER_LITERS`, `MIN_AGITATOR_DURATION_SECONDS`, `MAX_AGITATOR_DURATION_SECONDS`, and to compute a safe `waterLevel` via `getWaterLevel` and a bounded agitator animation duration via `getAgitatorAnimationDuration`.
- Replaced the previous scale and agitator layout with declarative render methods including `renderScaleMarks`, a new `water-gauge` structure, and an agitator image whose `animationDuration` is set via inline style when running.
- Completely redesigned `WaterControll.css` into `water-gauge` scoped styles including tank, fill, surface, scale marks, agitator, keyframes (renamed to `agitator-spin`), responsive rules, and `prefers-reduced-motion` support.
- Removed unused imports and legacy code paths that manipulated DOM styles directly (no more `agitatorRef` or manual `animation` toggles).

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5f3058e218832fbd7715c508e6cc0a)