### PR TITLE
Refactor recipe water filling state machine, add WaterControl label, and update tests

### DIFF
--- a/src/components/Controlls/WaterControll/WaterControl.tsx
+++ b/src/components/Controlls/WaterControll/WaterControl.tsx
@@ -7,6 +7,7 @@ export interface WaterStatus {
 }
 interface WaterControllProps {
     liters: number;
+    label?: string;
     agitatorState: boolean;
     agitatorSpeed: number;
 }
@@ -68,7 +69,7 @@ class WaterControl extends React.Component<WaterControllProps> {
     }
 
     render() {
-        const { liters, agitatorState } = this.props;
+        const { liters, label = 'Aktuell', agitatorState } = this.props;
         const { numericLiters, waterLevel } = this.getWaterLevel(liters);
         const agitatorAnimationDuration = this.getAgitatorAnimationDuration();
         const agitatorImageClassName = agitatorState
@@ -99,7 +100,7 @@ class WaterControl extends React.Component<WaterControllProps> {
                 </div>
 
                 <div className="water-gauge__reading">
-                    <span>Aktuell</span>
+                    <span>{label}</span>
                     <strong>{numericLiters.toFixed(1)} L</strong>
                 </div>
             </div>

--- a/src/containers/Production/Production.test.tsx
+++ b/src/containers/Production/Production.test.tsx
@@ -213,74 +213,154 @@ describe('Production next button', () => {
 });
 
 describe('Production recipe water filling', () => {
-    it('sends the recipe mash water volume when Hauptguss is clicked', () => {
-        const {props} = renderProduction({selectedBeer: createBeer(21, 9)});
-        fireEvent.click(screen.getByRole('button', {name: 'Hauptguss'}));
-        expect(props.startWaterFilling).toHaveBeenCalledWith(21);
+    const getSpargeButton = () => screen.getByRole('button', {name: /Nachguss/});
+    const getMashButton = () => screen.getByRole('button', {name: /Hauptguss/});
+
+    it('starts with Nachguss enabled and Hauptguss disabled', () => {
+        renderProduction({selectedBeer: createBeer(21, 9)});
+        expect(getSpargeButton()).not.toBeDisabled();
+        expect(getMashButton()).toBeDisabled();
+        expect(screen.getByText('Aktueller Füllvorgang')).toBeInTheDocument();
+        expect(screen.getByText('0.0 L')).toBeInTheDocument();
     });
 
-    it('sends the recipe sparge water volume when Nachguss is clicked', () => {
+    it('does not allow Hauptguss before Nachguss completed', () => {
         const {props} = renderProduction({selectedBeer: createBeer(21, 9)});
-        fireEvent.click(screen.getByRole('button', {name: 'Nachguss'}));
+        fireEvent.click(getMashButton());
+        expect(props.startWaterFilling).not.toHaveBeenCalled();
+    });
+
+    it('starts Nachguss from the recipe sparge water volume and guards fast double clicks', () => {
+        const {props} = renderProduction({selectedBeer: createBeer(21, 9)});
+        fireEvent.click(getSpargeButton());
+        fireEvent.click(getSpargeButton());
+        expect(props.startWaterFilling).toHaveBeenCalledTimes(1);
         expect(props.startWaterFilling).toHaveBeenCalledWith(9);
+        expect(getSpargeButton()).toBeDisabled();
+        expect(getMashButton()).toBeDisabled();
+        expect(screen.getAllByText('Nachguss').length).toBeGreaterThan(0);
+        expect(screen.getByText('0.0 L')).toBeInTheDocument();
     });
 
-    it('disables both recipe water buttons while water filling is active', () => {
-        renderProduction({waterStatus: {liters: 3, openClose: true}});
-        expect(screen.getByRole('button', {name: 'Hauptguss'})).toBeDisabled();
-        expect(screen.getByRole('button', {name: 'Nachguss'})).toBeDisabled();
+    it('does not complete Nachguss from the initial openClose false status', () => {
+        renderProduction({selectedBeer: createBeer(21, 9), waterStatus: {liters: 0, openClose: false}});
+        expect(getSpargeButton()).not.toBeDisabled();
+        expect(getMashButton()).toBeDisabled();
+        expect(screen.queryByRole('button', {name: '✓ Nachguss fertig'})).not.toBeInTheDocument();
     });
 
-    it('keeps Hauptguss disabled after completed mash water filling and leaves Nachguss available', () => {
+    it('marks Nachguss completed only after openClose was true and then false', () => {
         const {rerender, props} = renderProduction({selectedBeer: createBeer(21, 9), waterStatus: {liters: 0, openClose: false}});
-        fireEvent.click(screen.getByRole('button', {name: 'Hauptguss'}));
+        fireEvent.click(getSpargeButton());
         rerender(<Production {...props} waterStatus={{liters: 2, openClose: true}} />);
-        rerender(<Production {...props} waterStatus={{liters: 21, openClose: false}} />);
-        expect(screen.getByRole('button', {name: 'Hauptguss'})).toBeDisabled();
-        expect(screen.getByRole('button', {name: 'Nachguss'})).not.toBeDisabled();
-    });
-
-    it('keeps Nachguss disabled after completed sparge water filling and leaves Hauptguss available', () => {
-        const {rerender, props} = renderProduction({selectedBeer: createBeer(21, 9), waterStatus: {liters: 0, openClose: false}});
-        fireEvent.click(screen.getByRole('button', {name: 'Nachguss'}));
-        rerender(<Production {...props} waterStatus={{liters: 2, openClose: true}} />);
+        expect(getSpargeButton()).toBeDisabled();
+        expect(getMashButton()).toBeDisabled();
+        expect(screen.getByText('2.0 L')).toBeInTheDocument();
         rerender(<Production {...props} waterStatus={{liters: 9, openClose: false}} />);
-        expect(screen.getByRole('button', {name: 'Nachguss'})).toBeDisabled();
-        expect(screen.getByRole('button', {name: 'Hauptguss'})).not.toBeDisabled();
+        expect(screen.getByRole('button', {name: '✓ Nachguss fertig'})).toBeDisabled();
+        expect(getMashButton()).not.toBeDisabled();
+        expect(screen.getAllByText('Nachguss').length).toBeGreaterThan(0);
+        expect(screen.getByText('9.0 L')).toBeInTheDocument();
+    });
+
+    it('starts Hauptguss only after completed Nachguss and visibly resets the fill display to 0', () => {
+        const {rerender, props} = renderProduction({selectedBeer: createBeer(21, 9), waterStatus: {liters: 0, openClose: false}});
+        fireEvent.click(getSpargeButton());
+        rerender(<Production {...props} waterStatus={{liters: 9, openClose: true}} />);
+        rerender(<Production {...props} waterStatus={{liters: 9, openClose: false}} />);
+        fireEvent.click(getMashButton());
+        expect(props.startWaterFilling).toHaveBeenLastCalledWith(21);
+        expect(screen.getAllByText('Hauptguss').length).toBeGreaterThan(0);
+        expect(screen.getByText('0.0 L')).toBeInTheDocument();
+        expect(screen.queryByText('9.0 L')).not.toBeInTheDocument();
+    });
+
+    it('shows only Hauptguss during and after Hauptguss until Abmaischen is confirmed', () => {
+        const {rerender, props} = renderProduction({selectedBeer: createBeer(21, 9), waterStatus: {liters: 0, openClose: false}});
+        fireEvent.click(getSpargeButton());
+        rerender(<Production {...props} waterStatus={{liters: 9, openClose: true}} />);
+        rerender(<Production {...props} waterStatus={{liters: 9, openClose: false}} />);
+        fireEvent.click(getMashButton());
+        rerender(<Production {...props} waterStatus={{liters: 12, openClose: true}} />);
+        expect(screen.getByText('12.0 L')).toBeInTheDocument();
+        rerender(<Production {...props} waterStatus={{liters: 21, openClose: false}} />);
+        expect(screen.getByRole('button', {name: '✓ Nachguss fertig'})).toBeDisabled();
+        expect(screen.getByRole('button', {name: '✓ Hauptguss fertig'})).toBeDisabled();
+        expect(screen.getAllByText('Hauptguss').length).toBeGreaterThan(0);
+        expect(screen.getByText('21.0 L')).toBeInTheDocument();
+        expect(screen.queryByText('30.0 L')).not.toBeInTheDocument();
+    });
+
+    it('adds Nachguss exactly once after the process leaves MASHING_OUT_CONFIRMATION for a later phase', () => {
+        const waitingForMashingOut = createBrewingStatus(ProcessState.ACTIVE);
+        waitingForMashingOut.currentStep.phase = ProcessPhase.MASHING_OUT;
+        waitingForMashingOut.currentStep.mode = ProcessMode.WAITING;
+        waitingForMashingOut.waiting = {waitingFor: WaitingFor.MASHING_OUT_CONFIRMATION, canConfirm: true};
+        const cooking = createBrewingStatus(ProcessState.ACTIVE);
+        cooking.currentStep.phase = ProcessPhase.COOKING;
+        cooking.currentStep.mode = ProcessMode.HEATING;
+        const {rerender, props} = renderProduction({selectedBeer: createBeer(21, 9), waterStatus: {liters: 0, openClose: false}, brewingStatus: waitingForMashingOut});
+        fireEvent.click(getSpargeButton());
+        rerender(<Production {...props} brewingStatus={waitingForMashingOut} waterStatus={{liters: 9, openClose: true}} />);
+        rerender(<Production {...props} brewingStatus={waitingForMashingOut} waterStatus={{liters: 9, openClose: false}} />);
+        fireEvent.click(getMashButton());
+        rerender(<Production {...props} brewingStatus={waitingForMashingOut} waterStatus={{liters: 21, openClose: true}} />);
+        rerender(<Production {...props} brewingStatus={waitingForMashingOut} waterStatus={{liters: 21, openClose: false}} />);
+        expect(screen.queryByText('30.0 L')).not.toBeInTheDocument();
+        rerender(<Production {...props} brewingStatus={cooking} waterStatus={{liters: 21, openClose: false}} />);
+        expect(screen.getByText('Brauwasser gesamt')).toBeInTheDocument();
+        expect(screen.getByText('30.0 L')).toBeInTheDocument();
+        rerender(<Production {...props} brewingStatus={cooking} waterStatus={{liters: 21, openClose: false}} />);
+        expect(screen.getByText('30.0 L')).toBeInTheDocument();
+        expect(screen.queryByText('39.0 L')).not.toBeInTheDocument();
     });
 
     it('disables recipe water buttons with missing or invalid volumes', () => {
         renderProduction({selectedBeer: createBeer(0, -1)});
-        expect(screen.getByRole('button', {name: 'Hauptguss'})).toBeDisabled();
-        expect(screen.getByRole('button', {name: 'Nachguss'})).toBeDisabled();
+        expect(getSpargeButton()).toBeDisabled();
+        expect(getMashButton()).toBeDisabled();
     });
 
-    it('does not mark recipe water filling complete when the request fails before water starts', async () => {
+    it('does not mark recipe water filling complete when the request fails before water starts and allows a retry', async () => {
         const {rerender, props} = renderProduction({selectedBeer: createBeer(21, 9), waterStatus: {liters: 0, openClose: false}});
-        fireEvent.click(screen.getByRole('button', {name: 'Hauptguss'}));
+        fireEvent.click(getSpargeButton());
         rerender(<Production {...props} isWaterFillingSuccessful={false} waterStatus={{liters: 0, openClose: false}} />);
-        await waitFor(() => expect(screen.getByRole('button', {name: 'Hauptguss'})).not.toBeDisabled());
+        await waitFor(() => expect(getSpargeButton()).not.toBeDisabled());
+        expect(getMashButton()).toBeDisabled();
+        expect(screen.queryByRole('button', {name: '✓ Nachguss fertig'})).not.toBeInTheDocument();
+    });
+
+    it('keeps Nachguss completed and allows Hauptguss retry after a Hauptguss failure', async () => {
+        const {rerender, props} = renderProduction({selectedBeer: createBeer(21, 9), waterStatus: {liters: 0, openClose: false}});
+        fireEvent.click(getSpargeButton());
+        rerender(<Production {...props} waterStatus={{liters: 9, openClose: true}} />);
+        rerender(<Production {...props} waterStatus={{liters: 9, openClose: false}} />);
+        fireEvent.click(getMashButton());
+        rerender(<Production {...props} isWaterFillingSuccessful={false} waterStatus={{liters: 0, openClose: false}} />);
+        await waitFor(() => expect(screen.getByRole('button', {name: '✓ Nachguss fertig'})).toBeDisabled());
+        expect(getMashButton()).not.toBeDisabled();
     });
 
     it('resets completed recipe water filling when the recipe changes', () => {
         const {rerender, props} = renderProduction({selectedBeer: createBeer(21, 9, '1'), waterStatus: {liters: 0, openClose: false}});
-        fireEvent.click(screen.getByRole('button', {name: 'Hauptguss'}));
-        rerender(<Production {...props} waterStatus={{liters: 2, openClose: true}} />);
-        rerender(<Production {...props} waterStatus={{liters: 21, openClose: false}} />);
-        expect(screen.getByRole('button', {name: 'Hauptguss'})).toBeDisabled();
+        fireEvent.click(getSpargeButton());
+        rerender(<Production {...props} waterStatus={{liters: 9, openClose: true}} />);
+        rerender(<Production {...props} waterStatus={{liters: 9, openClose: false}} />);
+        expect(screen.getByRole('button', {name: '✓ Nachguss fertig'})).toBeDisabled();
         rerender(<Production {...props} selectedBeer={createBeer(22, 10, '2')} waterStatus={{liters: 0, openClose: false}} />);
-        expect(screen.getByRole('button', {name: 'Hauptguss'})).not.toBeDisabled();
+        expect(screen.getByRole('button', {name: 'Nachguss'})).not.toBeDisabled();
+        expect(screen.getByRole('button', {name: 'Hauptguss'})).toBeDisabled();
     });
-
 
     it('resets completed recipe water filling when a new brew starts', () => {
         const {rerender, props} = renderProduction({selectedBeer: createBeer(21, 9), waterStatus: {liters: 0, openClose: false}});
-        fireEvent.click(screen.getByRole('button', {name: 'Hauptguss'}));
-        rerender(<Production {...props} waterStatus={{liters: 2, openClose: true}} />);
-        rerender(<Production {...props} waterStatus={{liters: 21, openClose: false}} />);
-        expect(screen.getByRole('button', {name: 'Hauptguss'})).toBeDisabled();
+        fireEvent.click(getSpargeButton());
+        rerender(<Production {...props} waterStatus={{liters: 9, openClose: true}} />);
+        rerender(<Production {...props} waterStatus={{liters: 9, openClose: false}} />);
+        expect(screen.getByRole('button', {name: '✓ Nachguss fertig'})).toBeDisabled();
         fireEvent.click(screen.getByRole('button', {name: 'Start'}));
-        expect(screen.getByRole('button', {name: 'Hauptguss'})).not.toBeDisabled();
+        expect(screen.getByRole('button', {name: 'Nachguss'})).not.toBeDisabled();
+        expect(screen.getByRole('button', {name: 'Hauptguss'})).toBeDisabled();
     });
 
     it('keeps the existing manual water filling control unchanged', () => {

--- a/src/containers/Production/Production.tsx
+++ b/src/containers/Production/Production.tsx
@@ -17,7 +17,7 @@ import QuantityPicker from '../../components/Controlls/QuantityPicker/QuantityPi
 import {BrewingData} from "../../model/BrewingData";
 import {mapBeerToBrewingData} from "../../utils/productionRecipe";
 import {HeatingStates} from "../../model/BrewingStatus";
-import {BrewingStatus, ProcessMode, ProcessPhase, ProcessState} from "../../model/brewingStatus.types";
+import {BrewingStatus, ProcessMode, ProcessPhase, ProcessState, WaitingFor} from "../../model/brewingStatus.types";
 import {TimeFormatter} from "../../utils/TimeFormatter";
 import ModalDialog, {DialogType} from "../../components/ModalDialog/ModalDialog";
 import {ProgressBar} from "react-bootstrap";
@@ -50,7 +50,7 @@ export interface ProductionProps {
     brewingStatus?: BrewingStatus;
     startPolling: () => void;
     stopPolling: () => void;
-    isBackenAvailable: BackendAvailable;
+    isBackenAvailable: BackendAvailable | boolean;
     waterStatus: WaterStatus;
     addFinishedBrew: (finishedBrew: FinishedBrew) => void;
     nextProcedureStep: () => void;
@@ -58,7 +58,9 @@ export interface ProductionProps {
 }
 
 type RecipeWaterFill = 'mash' | 'sparge';
-type RecipeWaterFillResetState = Pick<ProductionState, 'completedMashWaterFill' | 'completedSpargeWaterFill' | 'pendingRecipeWaterFill' | 'waterFillHasStarted'>;
+type WaterFillType = 'SPARGE' | 'MASH';
+type WaterFillState = 'IDLE' | 'FILLING' | 'COMPLETED' | 'ERROR';
+type RecipeWaterFillResetState = Pick<ProductionState, 'activeFillType' | 'spargeState' | 'mashState' | 'completedSpargeLiters' | 'completedMashLiters' | 'currentFillLiters' | 'activeFillWasOpened' | 'isSpargeIncluded'>;
 
 interface ProductionState {
     agitatorState: ToggleState;
@@ -84,10 +86,14 @@ interface ProductionState {
     indexOfCurrentStep: number;
     brewingIsRunning: boolean;
     announcedHopTimes: number[];
-    completedMashWaterFill: boolean;
-    completedSpargeWaterFill: boolean;
-    pendingRecipeWaterFill: RecipeWaterFill | undefined;
-    waterFillHasStarted: boolean;
+    activeFillType: WaterFillType | undefined;
+    spargeState: WaterFillState;
+    mashState: WaterFillState;
+    completedSpargeLiters: number;
+    completedMashLiters: number;
+    currentFillLiters: number;
+    activeFillWasOpened: boolean;
+    isSpargeIncluded: boolean;
 }
 
 export class Production extends React.Component<ProductionProps, ProductionState> {
@@ -128,10 +134,14 @@ export class Production extends React.Component<ProductionProps, ProductionState
             indexOfCurrentStep: 0,
             brewingIsRunning: false,
             announcedHopTimes: [],
-            completedMashWaterFill: false,
-            completedSpargeWaterFill: false,
-            pendingRecipeWaterFill: undefined,
-            waterFillHasStarted: false
+            activeFillType: undefined,
+            spargeState: 'IDLE',
+            mashState: 'IDLE',
+            completedSpargeLiters: 0,
+            completedMashLiters: 0,
+            currentFillLiters: 0,
+            activeFillWasOpened: false,
+            isSpargeIncluded: false
         }
     }
 
@@ -145,7 +155,7 @@ export class Production extends React.Component<ProductionProps, ProductionState
 
 
     componentDidUpdate(prevProps: Readonly<ProductionProps>, prevState: Readonly<ProductionState>) {
-        const {toggleAgitator, brewingStatus,isBackenAvailable,temperature,isToggleAgitatorSuccess,isWaterFillingSuccessful, waterStatus} = this.props;
+        const {toggleAgitator, brewingStatus,isToggleAgitatorSuccess,isWaterFillingSuccessful, waterStatus} = this.props;
         const {intervalSwitchState, mainSwitchState, waterSwitchState,heatingAndStirringSwitchState,showHopsDialog,showFinishDialog, indexOfCurrentStep} = this.state;
 
 
@@ -164,12 +174,16 @@ export class Production extends React.Component<ProductionProps, ProductionState
             this.setState({brewingIsRunning: false});
         }
 
-        if (waterStatus?.openClose === true && !prevProps.waterStatus?.openClose) {
-            this.setState({waterFillHasStarted: true});
+        if (this.state.activeFillType !== undefined && waterStatus?.openClose === true && !prevProps.waterStatus?.openClose) {
+            this.setState({activeFillWasOpened: true});
         }
 
         if (prevProps.waterStatus?.openClose === true && waterStatus?.openClose === false) {
             this.completePendingRecipeWaterFill();
+        }
+
+        if (!this.state.isSpargeIncluded && this.shouldIncludeSpargeAfterMashingOut(prevProps.brewingStatus, brewingStatus)) {
+            this.setState({isSpargeIncluded: true});
         }
 
 
@@ -191,7 +205,7 @@ export class Production extends React.Component<ProductionProps, ProductionState
         if (!isWaterFillingSuccessful && waterSwitchState) {
             const delay = 300;
             setTimeout(() => {
-                this.setState({waterSwitchState: false, waterFillingError: true});
+                this.failActiveRecipeWaterFill();
             }, delay);
         }
         if (brewingStatus && brewingStatus.currentStep?.mode !== prevProps?.brewingStatus?.currentStep?.mode) {
@@ -323,26 +337,47 @@ export class Production extends React.Component<ProductionProps, ProductionState
 
     resetRecipeWaterFillState = (aAdditionalState?: Pick<ProductionState, 'indexOfCurrentStep'>): void => {
         const resetState: RecipeWaterFillResetState = {
-            completedMashWaterFill: false,
-            completedSpargeWaterFill: false,
-            pendingRecipeWaterFill: undefined,
-            waterFillHasStarted: false
+            activeFillType: undefined,
+            spargeState: 'IDLE',
+            mashState: 'IDLE',
+            completedSpargeLiters: 0,
+            completedMashLiters: 0,
+            currentFillLiters: 0,
+            activeFillWasOpened: false,
+            isSpargeIncluded: false
         };
         this.setState(aAdditionalState === undefined ? resetState : {...resetState, ...aAdditionalState});
     }
 
     completePendingRecipeWaterFill = (): void => {
-        const {pendingRecipeWaterFill, waterFillHasStarted} = this.state;
-        if (!waterFillHasStarted || pendingRecipeWaterFill === undefined) {
-            this.setState({waterSwitchState: false, waterFillHasStarted: false});
+        const {activeFillType, activeFillWasOpened} = this.state;
+        if (!activeFillWasOpened || activeFillType === undefined) {
+            this.setState({waterSwitchState: false, activeFillWasOpened: false});
             return;
         }
+        const completedLiters = this.getSafeWaterStatusLiters();
         this.setState({
             waterSwitchState: false,
-            waterFillHasStarted: false,
-            pendingRecipeWaterFill: undefined,
-            completedMashWaterFill: pendingRecipeWaterFill === 'mash' ? true : this.state.completedMashWaterFill,
-            completedSpargeWaterFill: pendingRecipeWaterFill === 'sparge' ? true : this.state.completedSpargeWaterFill
+            activeFillWasOpened: false,
+            activeFillType: undefined,
+            currentFillLiters: completedLiters,
+            completedMashLiters: activeFillType === 'MASH' ? completedLiters : this.state.completedMashLiters,
+            completedSpargeLiters: activeFillType === 'SPARGE' ? completedLiters : this.state.completedSpargeLiters,
+            mashState: activeFillType === 'MASH' ? 'COMPLETED' : this.state.mashState,
+            spargeState: activeFillType === 'SPARGE' ? 'COMPLETED' : this.state.spargeState
+        });
+    }
+
+    failActiveRecipeWaterFill = (): void => {
+        const {activeFillType} = this.state;
+        this.setState({
+            waterSwitchState: false,
+            waterFillingError: true,
+            activeFillType: undefined,
+            activeFillWasOpened: false,
+            currentFillLiters: 0,
+            spargeState: activeFillType === 'SPARGE' ? 'ERROR' : this.state.spargeState,
+            mashState: activeFillType === 'MASH' ? 'ERROR' : this.state.mashState
         });
     }
 
@@ -356,21 +391,104 @@ export class Production extends React.Component<ProductionProps, ProductionState
     }
 
     isWaterFillingActive = (): boolean => {
-        return this.state.waterSwitchState || this.props.waterStatus?.openClose === true;
+        return this.state.waterSwitchState || this.state.activeFillType !== undefined || this.props.waterStatus?.openClose === true;
+    }
+
+    isControllerAvailable = (): boolean => {
+        const {isBackenAvailable} = this.props;
+        if (typeof isBackenAvailable === 'boolean') {
+            return isBackenAvailable;
+        }
+        return isBackenAvailable?.isBackenAvailable === true;
     }
 
     startRecipeWaterFilling = (aRecipeWaterFill: RecipeWaterFill): void => {
         const volume = this.getRecipeWaterVolume(aRecipeWaterFill);
-        if (volume === undefined || this.isWaterFillingActive()) {
+        if (volume === undefined || this.isRecipeWaterButtonDisabled(aRecipeWaterFill)) {
             return;
         }
+        const activeFillType: WaterFillType = aRecipeWaterFill === 'mash' ? 'MASH' : 'SPARGE';
         this.setState({
             waterSwitchState: true,
             liters: volume,
-            pendingRecipeWaterFill: aRecipeWaterFill,
-            waterFillHasStarted: false
+            activeFillType,
+            currentFillLiters: 0,
+            activeFillWasOpened: false,
+            waterFillingError: false,
+            mashState: activeFillType === 'MASH' ? 'FILLING' : this.state.mashState,
+            spargeState: activeFillType === 'SPARGE' ? 'FILLING' : this.state.spargeState
         });
         this.props.startWaterFilling(volume);
+    }
+
+    getSafeWaterStatusLiters = (): number => {
+        const waterStatusLiters = Number(this.props.waterStatus?.liters);
+        return Number.isFinite(waterStatusLiters) ? waterStatusLiters : 0;
+    }
+
+    getCurrentWaterFillLiters = (): number => {
+        if (this.state.activeFillType !== undefined && !this.state.activeFillWasOpened) {
+            return this.state.currentFillLiters;
+        }
+        if (this.state.activeFillType !== undefined || this.props.waterStatus?.openClose === true) {
+            return this.getSafeWaterStatusLiters();
+        }
+        if (this.state.mashState === 'COMPLETED') {
+            return this.state.completedMashLiters;
+        }
+        return this.state.currentFillLiters;
+    }
+
+    getDisplayedWaterLiters = (): number => {
+        return this.state.isSpargeIncluded
+            ? this.state.completedMashLiters + this.state.completedSpargeLiters
+            : this.getCurrentWaterFillLiters();
+    }
+
+    getDisplayedWaterLabel = (): string => {
+        if (this.state.isSpargeIncluded) {
+            return 'Brauwasser gesamt';
+        }
+        if (this.state.activeFillType === 'SPARGE' || (this.state.spargeState === 'COMPLETED' && this.state.mashState === 'IDLE')) {
+            return 'Nachguss';
+        }
+        if (this.state.activeFillType === 'MASH' || this.state.mashState === 'COMPLETED') {
+            return 'Hauptguss';
+        }
+        return 'Aktueller Füllvorgang';
+    }
+
+    shouldIncludeSpargeAfterMashingOut = (aPreviousStatus?: BrewingStatus, aCurrentStatus?: BrewingStatus): boolean => {
+        if (this.state.spargeState !== 'COMPLETED' || this.state.mashState !== 'COMPLETED') {
+            return false;
+        }
+        const previousWaitingFor = aPreviousStatus?.waiting?.waitingFor;
+        const currentPhase = aCurrentStatus?.currentStep?.phase;
+        const currentProcessState = aCurrentStatus?.process?.state;
+        const wasWaitingForMashingOut = previousWaitingFor === WaitingFor.MASHING_OUT_CONFIRMATION;
+        const isAfterMashingOutPhase = currentPhase === ProcessPhase.COOKING || currentPhase === ProcessPhase.COOLING || currentPhase === ProcessPhase.FINISHED || currentProcessState === ProcessState.FINISHED;
+        return wasWaitingForMashingOut && isAfterMashingOutPhase;
+    }
+
+    isRecipeWaterButtonDisabled = (aRecipeWaterFill: RecipeWaterFill): boolean => {
+        const volume = this.getRecipeWaterVolume(aRecipeWaterFill);
+        if (volume === undefined || !this.isControllerAvailable() || this.isWaterFillingActive()) {
+            return true;
+        }
+        if (aRecipeWaterFill === 'sparge') {
+            return this.state.spargeState === 'COMPLETED' || this.state.mashState !== 'IDLE';
+        }
+        return this.state.spargeState !== 'COMPLETED' || this.state.mashState === 'COMPLETED';
+    }
+
+    getRecipeWaterButtonLabel = (aRecipeWaterFill: RecipeWaterFill): string => {
+        if (aRecipeWaterFill === 'sparge' && this.state.spargeState === 'COMPLETED') {
+            return '✓ Nachguss fertig';
+        }
+        if (aRecipeWaterFill === 'mash' && this.state.mashState === 'COMPLETED') {
+            return '✓ Hauptguss fertig';
+        }
+        return aRecipeWaterFill === 'sparge' ? 'Nachguss' : 'Hauptguss';
     }
 
     startMashWaterFilling = (): void => {
@@ -406,9 +524,9 @@ export class Production extends React.Component<ProductionProps, ProductionState
         if (this.isStartButtonDisabled()) {
             return;
         }
+        this.resetRecipeWaterFillState();
         this.isBrewingStartRequestPending = true;
         dataCollector.reset();
-        this.resetRecipeWaterFillState();
         console.log('Starting brewing with data:', sendBrewingData);
         const result = mapBeerToBrewingData(selectedBeer);
         console.log('Starting brewing with data:', result);
@@ -534,16 +652,10 @@ export class Production extends React.Component<ProductionProps, ProductionState
             intervalSwitchState,
             heatingAndStirringSwitchState,
             waterSwitchState,
-            liters,
-            waterFillingError,
-            mainAgitatorError
+            liters
         } = this.state;
-        const {currentAgitatorSpeed, agitatorIsRunning, agitatorSpeed, waterStatus,selectedBeer} = this.props;
-        const waterFillingActive = this.isWaterFillingActive();
-        const mashWaterVolume = this.getRecipeWaterVolume('mash');
-        const spargeWaterVolume = this.getRecipeWaterVolume('sparge');
-        const mashWaterDisabled = waterFillingActive || this.state.completedMashWaterFill || mashWaterVolume === undefined;
-        const spargeWaterDisabled = waterFillingActive || this.state.completedSpargeWaterFill || spargeWaterVolume === undefined;
+        const mashWaterDisabled = this.isRecipeWaterButtonDisabled('mash');
+        const spargeWaterDisabled = this.isRecipeWaterButtonDisabled('sparge');
         return (
             <div className="Settings">
                 <h3>Settings</h3>
@@ -593,8 +705,8 @@ export class Production extends React.Component<ProductionProps, ProductionState
 
                 </div>
                 <div className="recipeWaterButtons">
-                    <button className="recipeWaterBtn" disabled={mashWaterDisabled} onClick={this.startMashWaterFilling}>Hauptguss</button>
-                    <button className="recipeWaterBtn" disabled={spargeWaterDisabled} onClick={this.startSpargeWaterFilling}>Nachguss</button>
+                    <button className="recipeWaterBtn" disabled={spargeWaterDisabled} onClick={this.startSpargeWaterFilling}>{this.getRecipeWaterButtonLabel('sparge')}</button>
+                    <button className="recipeWaterBtn" disabled={mashWaterDisabled} onClick={this.startMashWaterFilling}>{this.getRecipeWaterButtonLabel('mash')}</button>
                 </div>
                 <div className="startBtnDiv">
                     <button className="startBtn" disabled={this.isStartButtonDisabled()} onClick={this.startBrewing}>Start</button>
@@ -610,11 +722,11 @@ export class Production extends React.Component<ProductionProps, ProductionState
     renderAgitator() {
         const infinitySymbol = '\u221E';
         const {liters} = this.state;
-        const {currentAgitatorSpeed, agitatorIsRunning, agitatorSpeed, waterStatus} = this.props;
+        const {currentAgitatorSpeed, agitatorSpeed} = this.props;
         // Werte absichern
         const gaugeValue = isNaN(Number(agitatorSpeed)) ? 0 : Number(agitatorSpeed);
         const gaugeTarget = isNaN(Number(currentAgitatorSpeed)) ? 0 : Number(currentAgitatorSpeed);
-        const waterValue = isNaN(Number(waterStatus?.liters)) ? 0 : Number(waterStatus?.liters);
+        const waterValue = this.getDisplayedWaterLiters();
         const waterTarget = isNaN(Number(liters)) ? 0 : Number(liters);
         return (<div className="Agitator">
 
@@ -631,12 +743,13 @@ export class Production extends React.Component<ProductionProps, ProductionState
     }
 
     renderWater() {
-        const {currentAgitatorSpeed, agitatorIsRunning, brewingStatus, waterStatus} = this.props;
+        const {currentAgitatorSpeed, brewingStatus} = this.props;
+        const displayedWaterLiters = this.getDisplayedWaterLiters();
 
         return (
 
             <div className="Water">
-                <WaterControl liters={waterStatus.liters} agitatorSpeed={currentAgitatorSpeed}
+                <WaterControl liters={displayedWaterLiters} label={this.getDisplayedWaterLabel()} agitatorSpeed={currentAgitatorSpeed}
                               agitatorState={brewingStatus?.hardware?.agitator === "ON"}></WaterControl>
 
             </div>);
@@ -734,7 +847,8 @@ export class Production extends React.Component<ProductionProps, ProductionState
     renderErrorDialog() {
         const {showErrorDialog, errorDialogContent} = this.state
         const {isBackenAvailable} = this.props
-        const contentText = errorDialogContent || ('Die Brau-Steuerung ist nicht erreichbar\n\n' + isBackenAvailable.statusText)
+        const statusText = typeof isBackenAvailable === 'boolean' ? '' : isBackenAvailable.statusText;
+        const contentText = errorDialogContent || ('Die Brau-Steuerung ist nicht erreichbar\n\n' + statusText)
         return (<div>
             <ModalDialog onConfirm={this.confirmErrorDialog} type={DialogType.ERROR} open={showErrorDialog}
                          content={contentText} header={"Fehler!"}></ModalDialog>

--- a/src/containers/index.test.tsx
+++ b/src/containers/index.test.tsx
@@ -52,7 +52,7 @@ describe('Index waiting confirmation dialog', () => {
         renderIndex(makeStatus());
 
         expect(screen.getByRole('dialog')).toBeInTheDocument();
-        expect(screen.getByText('Abmaischen: Bestätigung nötig')).toBeInTheDocument();
+        expect(screen.getByText('Abmaischen und Nachguss abgeschlossen?')).toBeInTheDocument();
     });
 
     it('sends exactly one Mashup confirmation when the Abmaischen dialog is confirmed', () => {

--- a/src/utils/brewingStatus/selectors.ts
+++ b/src/utils/brewingStatus/selectors.ts
@@ -66,7 +66,7 @@ export const getBrewingStatusLabel = (aStatus?: BrewingStatus) => {
     if (aMode === ProcessMode.WAITING && aPhase === ProcessPhase.MASHING_IN && aWaitingFor === WaitingFor.MASHING_IN_CONFIRMATION) return 'Einmaischen: bitte bestätigen';
     if (aMode === ProcessMode.WAITING && aPhase === ProcessPhase.RAST && aWaitingFor === WaitingFor.IODINE_TEST) return 'Warten auf Iodine-Test';
     if (aMode === ProcessMode.WAITING && aPhase === ProcessPhase.RAST && aWaitingFor === WaitingFor.DECOCTION_CONFIRMATION) return 'Warten auf Dickmaische-Bestätigung';
-    if (aMode === ProcessMode.WAITING && aPhase === ProcessPhase.MASHING_OUT && aWaitingFor === WaitingFor.MASHING_OUT_CONFIRMATION) return 'Abmaischen: Bestätigung nötig';
+    if (aMode === ProcessMode.WAITING && aPhase === ProcessPhase.MASHING_OUT && aWaitingFor === WaitingFor.MASHING_OUT_CONFIRMATION) return 'Abmaischen und Nachguss abgeschlossen?';
     if (aMode === ProcessMode.WAITING && aPhase === ProcessPhase.COOKING && aWaitingFor === WaitingFor.BOILING_CONFIRMATION) return 'Warten auf Siedepunkt-Bestätigung';
     if (aPhase === ProcessPhase.MASHING_IN && aMode === ProcessMode.HEATING) return 'Einmaischen: Aufheizen läuft';
     if (aPhase === ProcessPhase.RAST && aMode === ProcessMode.HEATING) return 'Rast: Aufheizen auf Solltemperatur';


### PR DESCRIPTION
### Motivation
- Simplify and harden the recipe water filling flow by tracking sparge/mash as explicit states and making the UI reflect in-progress, completed, and error states.
- Make the water gauge label configurable from parent components.
- Ensure the waiting/confirmation text matches the new flow and surface clearer UI states for testing.

### Description
- Reworked water filling logic in `Production.tsx` to use explicit `WaterFillType` and `WaterFillState` with state fields `activeFillType`, `spargeState`, `mashState`, `completedSpargeLiters`, `completedMashLiters`, `currentFillLiters`, `activeFillWasOpened`, and `isSpargeIncluded` instead of the previous boolean flags.
- Implemented helper functions to compute displayed liters, the display label, button enablement, and safety helpers (`getDisplayedWaterLiters`, `getDisplayedWaterLabel`, `isRecipeWaterButtonDisabled`, `getRecipeWaterButtonLabel`, `getSafeWaterStatusLiters`, `getCurrentWaterFillLiters`, `isControllerAvailable`, `shouldIncludeSpargeAfterMashingOut`, `failActiveRecipeWaterFill`).
- Updated water filling lifecycle: start with `startRecipeWaterFilling`, set `activeFillType`, update states on open/close events, mark fills completed only if the valve opened first, and handle failures by moving a fill into `ERROR` and allowing retries.
- Adjusted `isBackenAvailable` prop handling to accept boolean or `BackendAvailable` and surface status text safely in error dialogs.
- Added `label?: string` prop to `WaterControl` and used it in the UI with default `'Aktuell'`.
- Updated UI to show contextual button labels (e.g. `✓ Nachguss fertig`) and swapped the order of recipe buttons to match enabled/disabled logic.
- Adjusted related gauge and water rendering to use the new computed displayed liters and label.
- Updated selector text for mashing-out waiting message in `selectors.ts` to the new message.
- Extended and refactored tests in `Production.test.tsx` and `index.test.tsx` to cover new states, button labels, double-click guarding, error/retry flows, sparge inclusion after mashing-out confirmation, and updated dialog text expectations.

### Testing
- Ran the unit test suite including `src/containers/Production/Production.test.tsx` and `src/containers/index.test.tsx`, which were updated to reflect the new behaviors and messages, and all tests passed.
- Verified new and adjusted tests cover button enable/disable states, single-click guarding, completion transitions, failure/retry behavior, and waiting-dialog label changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5f3956df80832f9bf13933dba5b599)