### PR TITLE
Visualize vessel content (Water / Mash / Wort) based on brewing phase

### DIFF
--- a/src/components/Controlls/WaterControll/WaterControl.test.tsx
+++ b/src/components/Controlls/WaterControll/WaterControl.test.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import {render, screen} from '@testing-library/react';
+import WaterControl from './WaterControl';
+import {VesselContentType} from '../../../model/VesselContentType';
+
+const renderWaterControl = (contentType: VesselContentType, agitatorState = false) => render(
+    <WaterControl liters={35} label="Füllstand" agitatorState={agitatorState} agitatorSpeed={10} contentType={contentType} />
+);
+
+describe('WaterControl vessel content display', () => {
+    it('sets content modifier classes for water, mash, and wort', () => {
+        expect(renderWaterControl(VesselContentType.WATER).container.querySelector('.water-gauge--water')).not.toBeNull();
+        expect(renderWaterControl(VesselContentType.MASH).container.querySelector('.water-gauge--mash')).not.toBeNull();
+        expect(renderWaterControl(VesselContentType.WORT).container.querySelector('.water-gauge--wort')).not.toBeNull();
+    });
+
+    it('renders a decorative particle layer inside the fill', () => {
+        const {container} = renderWaterControl(VesselContentType.MASH);
+        const fill = container.querySelector('.water-gauge__fill');
+        const particles = container.querySelector('.water-gauge__particles');
+        expect(particles).not.toBeNull();
+        expect(particles).toHaveAttribute('aria-hidden', 'true');
+        expect(fill?.contains(particles)).toBe(true);
+    });
+
+    it('activates particle movement only when the agitator is running', () => {
+        expect(renderWaterControl(VesselContentType.MASH, false).container.querySelector('.water-gauge--agitator-running')).toBeNull();
+        expect(renderWaterControl(VesselContentType.MASH, true).container.querySelector('.water-gauge--agitator-running')).not.toBeNull();
+    });
+
+    it('keeps scale, liter value, agitator, and fill height in all states', () => {
+        [VesselContentType.WATER, VesselContentType.MASH, VesselContentType.WORT].forEach((contentType) => {
+            const {container, unmount} = renderWaterControl(contentType);
+            expect(container.querySelector('.water-gauge__scale')).not.toBeNull();
+            expect(container.querySelector('.water-gauge__agitator')).not.toBeNull();
+            expect(screen.getByText('35.0 L')).toBeInTheDocument();
+            expect(container.querySelector('.water-gauge__fill')).toHaveStyle({height: '50%'});
+            unmount();
+        });
+    });
+});

--- a/src/components/Controlls/WaterControll/WaterControl.tsx
+++ b/src/components/Controlls/WaterControll/WaterControl.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import './WaterControll.css';
+import {VesselContentType} from '../../../model/VesselContentType';
 
 export interface WaterStatus {
     liters: number
@@ -9,6 +10,7 @@ interface WaterControllProps {
     liters: number;
     label?: string;
     agitatorState: boolean;
+    contentType: VesselContentType;
     agitatorSpeed: number;
 }
 
@@ -68,18 +70,34 @@ class WaterControl extends React.Component<WaterControllProps> {
         return scaleMarks;
     }
 
+    private getContentLabel(aContentType: VesselContentType): string {
+        switch (aContentType) {
+            case VesselContentType.MASH:
+                return 'Maische';
+            case VesselContentType.WORT:
+                return 'Würze';
+            case VesselContentType.WATER:
+            default:
+                return 'Wasser';
+        }
+    }
+
     render() {
-        const { liters, label = 'Aktuell', agitatorState } = this.props;
+        const { liters, label = 'Aktuell', agitatorState, contentType } = this.props;
         const { numericLiters, waterLevel } = this.getWaterLevel(liters);
         const agitatorAnimationDuration = this.getAgitatorAnimationDuration();
         const agitatorImageClassName = agitatorState
             ? 'water-gauge__agitator-image water-gauge__agitator-image--running'
             : 'water-gauge__agitator-image';
 
+        const contentClassName = `water-gauge--${contentType.toLowerCase()}`;
+        const agitatorClassName = agitatorState ? 'water-gauge--agitator-running' : '';
+
         return (
-            <div className="water-gauge">
+            <div className={['water-gauge', contentClassName, agitatorClassName].filter(Boolean).join(' ')}>
                 <div className="water-gauge__tank">
                     <div className="water-gauge__fill" style={{ height: `${waterLevel}%` }}>
+                        <div className="water-gauge__particles" aria-hidden="true" />
                         <div className="water-gauge__surface" />
                     </div>
 
@@ -101,6 +119,7 @@ class WaterControl extends React.Component<WaterControllProps> {
 
                 <div className="water-gauge__reading">
                     <span>{label}</span>
+                    <span className="water-gauge__content-label">Inhalt: {this.getContentLabel(contentType)}</span>
                     <strong>{numericLiters.toFixed(1)} L</strong>
                 </div>
             </div>

--- a/src/components/Controlls/WaterControll/WaterControll.css
+++ b/src/components/Controlls/WaterControll/WaterControll.css
@@ -81,7 +81,7 @@
     bottom: 0;
     left: 0;
     z-index: 1;
-    overflow: visible;
+    overflow: hidden;
     border-radius: 0 0 11px 11px;
 
     background:
@@ -105,11 +105,12 @@
 
 .water-gauge__surface {
     position: absolute;
-    top: -0.55rem;
+    top: 0;
     left: -10%;
     width: 120%;
     height: 1.1rem;
     overflow: hidden;
+    z-index: 3;
     border-radius: 50%;
 
     background:
@@ -288,6 +289,7 @@
         transition: none;
     }
 
+    .water-gauge__particles,
     .water-gauge__surface::before,
     .water-gauge__surface::after,
     .water-gauge__agitator-image {
@@ -298,5 +300,144 @@
 @media (max-width: 1280px) {
     .water-gauge__tank {
         min-height: 16rem;
+    }
+}
+
+.water-gauge--water .water-gauge__fill {
+    background:
+        linear-gradient(
+            90deg,
+            rgb(19 84 145 / 35%) 0%,
+            transparent 20%,
+            rgb(255 255 255 / 18%) 48%,
+            transparent 72%,
+            rgb(12 65 120 / 28%) 100%
+        ),
+        linear-gradient(
+            180deg,
+            var(--color-water-light) 0%,
+            var(--color-water-blue) 35%,
+            var(--color-water-deep) 100%
+        );
+}
+
+.water-gauge--mash .water-gauge__fill {
+    background:
+        linear-gradient(
+            90deg,
+            rgb(73 39 13 / 38%) 0%,
+            transparent 22%,
+            rgb(255 224 158 / 20%) 48%,
+            transparent 74%,
+            rgb(66 34 10 / 32%) 100%
+        ),
+        linear-gradient(
+            180deg,
+            #d2a15d 0%,
+            #bd8140 42%,
+            #975a27 100%
+        );
+}
+
+.water-gauge--wort .water-gauge__fill {
+    background:
+        linear-gradient(
+            90deg,
+            rgb(86 45 7 / 34%) 0%,
+            transparent 22%,
+            rgb(255 226 137 / 24%) 48%,
+            transparent 74%,
+            rgb(72 35 4 / 30%) 100%
+        ),
+        linear-gradient(
+            180deg,
+            #e3ae43 0%,
+            #c8821e 48%,
+            #9e5913 100%
+        );
+}
+
+.water-gauge__particles {
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: -2rem;
+    left: 0;
+    z-index: 2;
+    opacity: 0;
+    overflow: hidden;
+    pointer-events: none;
+    background-image:
+        radial-gradient(circle, rgb(91 55 21 / 75%) 0 2px, transparent 3px),
+        radial-gradient(circle, rgb(164 105 43 / 70%) 0 1.5px, transparent 2.5px),
+        radial-gradient(circle, rgb(74 42 16 / 60%) 0 1px, transparent 2px);
+    background-position:
+        4px 8px,
+        17px 22px,
+        31px 11px;
+    background-size:
+        31px 37px,
+        43px 29px,
+        23px 41px;
+    transform: translate3d(0, 0, 0);
+}
+
+.water-gauge--mash .water-gauge__particles {
+    opacity: 0.55;
+}
+
+.water-gauge--wort .water-gauge__particles,
+.water-gauge--water .water-gauge__particles {
+    opacity: 0;
+}
+
+.water-gauge--mash.water-gauge--agitator-running .water-gauge__particles {
+    animation: mash-particle-drift 12s linear infinite;
+}
+
+.water-gauge--water .water-gauge__surface {
+    background:
+        linear-gradient(
+            180deg,
+            rgb(255 255 255 / 42%),
+            rgb(106 181 235 / 82%) 48%,
+            rgb(47 124 215 / 95%) 100%
+        );
+    box-shadow:
+        inset 0 2px 2px rgb(255 255 255 / 35%),
+        0 2px 5px rgb(0 72 135 / 22%);
+}
+
+.water-gauge--mash .water-gauge__surface {
+    background:
+        linear-gradient(180deg, rgb(255 246 213 / 48%), rgb(218 166 83 / 86%) 48%, rgb(153 90 39 / 94%) 100%);
+    box-shadow: inset 0 2px 2px rgb(255 255 255 / 28%), 0 2px 5px rgb(111 63 24 / 22%);
+}
+
+.water-gauge--wort .water-gauge__surface {
+    background:
+        linear-gradient(180deg, rgb(255 245 196 / 48%), rgb(228 174 67 / 86%) 48%, rgb(180 103 25 / 94%) 100%);
+    box-shadow: inset 0 2px 2px rgb(255 255 255 / 30%), 0 2px 5px rgb(125 70 12 / 20%);
+}
+
+.water-gauge__content-label {
+    opacity: 0.9;
+}
+
+@keyframes mash-particle-drift {
+    from {
+        transform: translate3d(0, 0, 0);
+    }
+
+    to {
+        transform: translate3d(0, -2rem, 0);
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .water-gauge__particles,
+    .water-gauge__surface::before,
+    .water-gauge__surface::after {
+        animation: none;
     }
 }

--- a/src/containers/Production/Production.test.tsx
+++ b/src/containers/Production/Production.test.tsx
@@ -411,3 +411,30 @@ describe('Production layout structure', () => {
         expect(screen.getByText('Zielzeit')).toBeInTheDocument();
     });
 });
+
+describe('Production vessel content mapping', () => {
+    const makePhaseStatus = (aPhase: ProcessPhase, aWaitingFor = WaitingFor.NONE): BrewingStatus => {
+        const status = createBrewingStatus(ProcessState.ACTIVE);
+        status.currentStep.phase = aPhase;
+        status.waiting = {waitingFor: aWaitingFor, canConfirm: aWaitingFor !== WaitingFor.NONE};
+        return status;
+    };
+
+    it('renders water before successful mashing-in and while waiting for mashing-in confirmation', () => {
+        expect(renderProduction({brewingStatus: makePhaseStatus(ProcessPhase.NONE)}).container.querySelector('.water-gauge--water')).not.toBeNull();
+        expect(renderProduction({brewingStatus: makePhaseStatus(ProcessPhase.MASHING_IN)}).container.querySelector('.water-gauge--water')).not.toBeNull();
+        expect(renderProduction({brewingStatus: makePhaseStatus(ProcessPhase.MASHING_IN, WaitingFor.MASHING_IN_CONFIRMATION)}).container.querySelector('.water-gauge--water')).not.toBeNull();
+    });
+
+    it('renders mash during rests, mashing-out, and pending mashing-out confirmation', () => {
+        expect(renderProduction({brewingStatus: makePhaseStatus(ProcessPhase.RAST)}).container.querySelector('.water-gauge--mash')).not.toBeNull();
+        expect(renderProduction({brewingStatus: makePhaseStatus(ProcessPhase.MASHING_OUT)}).container.querySelector('.water-gauge--mash')).not.toBeNull();
+        expect(renderProduction({brewingStatus: makePhaseStatus(ProcessPhase.MASHING_OUT, WaitingFor.MASHING_OUT_CONFIRMATION)}).container.querySelector('.water-gauge--mash')).not.toBeNull();
+    });
+
+    it('renders wort after mashing-out has been confirmed and the process moved on', () => {
+        expect(renderProduction({brewingStatus: makePhaseStatus(ProcessPhase.COOKING)}).container.querySelector('.water-gauge--wort')).not.toBeNull();
+        expect(renderProduction({brewingStatus: makePhaseStatus(ProcessPhase.COOLING)}).container.querySelector('.water-gauge--wort')).not.toBeNull();
+        expect(renderProduction({brewingStatus: makePhaseStatus(ProcessPhase.FINISHED)}).container.querySelector('.water-gauge--wort')).not.toBeNull();
+    });
+});

--- a/src/containers/Production/Production.tsx
+++ b/src/containers/Production/Production.tsx
@@ -32,6 +32,7 @@ import {BackendAvailable} from "../../reducers/productionReducer";
 import {ProcessList, createProcessSteps} from "./ProcessList/ProcessList";
 import { dataCollector } from '../../utils/DataCollector/dataCollector';
 import {getBrewingStatusLabel, isBrewingProcessActive, isProcessActive} from "../../utils/brewingStatus/selectors";
+import {getVesselContentType} from "../../utils/brewingStatus/vesselContent";
 
 export interface ProductionProps {
     selectedBeer: Beer;
@@ -750,7 +751,8 @@ export class Production extends React.Component<ProductionProps, ProductionState
 
             <div className="Water">
                 <WaterControl liters={displayedWaterLiters} label={this.getDisplayedWaterLabel()} agitatorSpeed={currentAgitatorSpeed}
-                              agitatorState={brewingStatus?.hardware?.agitator === "ON"}></WaterControl>
+                              agitatorState={brewingStatus?.hardware?.agitator === "ON"}
+                              contentType={getVesselContentType(brewingStatus)}></WaterControl>
 
             </div>);
     }

--- a/src/model/VesselContentType.ts
+++ b/src/model/VesselContentType.ts
@@ -1,0 +1,5 @@
+export enum VesselContentType {
+    WATER = 'WATER',
+    MASH = 'MASH',
+    WORT = 'WORT',
+}

--- a/src/utils/brewingStatus/vesselContent.test.ts
+++ b/src/utils/brewingStatus/vesselContent.test.ts
@@ -1,0 +1,40 @@
+import {BrewingStatus, ProcessMode, ProcessPhase, ProcessState, WaitingFor} from '../../model/brewingStatus.types';
+import {VesselContentType} from '../../model/VesselContentType';
+import {getVesselContentType} from './vesselContent';
+
+const makeStatus = (aPhase: ProcessPhase = ProcessPhase.NONE, aWaitingFor = WaitingFor.NONE): BrewingStatus => ({
+    elapsedTime: 0,
+    currentTime: 0,
+    process: {state: ProcessState.ACTIVE},
+    currentStep: {phase: aPhase, mode: ProcessMode.NONE},
+    temperature: {},
+    hardware: {},
+    waiting: {waitingFor: aWaitingFor, canConfirm: aWaitingFor !== WaitingFor.NONE},
+    error: {}
+});
+
+describe('getVesselContentType', () => {
+    it('maps initial, water filling, and mashing-in confirmation states to water', () => {
+        expect(getVesselContentType(undefined)).toBe(VesselContentType.WATER);
+        expect(getVesselContentType(makeStatus(ProcessPhase.NONE))).toBe(VesselContentType.WATER);
+        expect(getVesselContentType(makeStatus(ProcessPhase.MASHING_IN))).toBe(VesselContentType.WATER);
+        expect(getVesselContentType(makeStatus(ProcessPhase.MASHING_IN, WaitingFor.MASHING_IN_CONFIRMATION))).toBe(VesselContentType.WATER);
+    });
+
+    it('maps successful mashing-in, rests, mashing-out, and mashing-out confirmation to mash', () => {
+        expect(getVesselContentType(makeStatus(ProcessPhase.RAST))).toBe(VesselContentType.MASH);
+        expect(getVesselContentType(makeStatus(ProcessPhase.MASHING_OUT))).toBe(VesselContentType.MASH);
+        expect(getVesselContentType(makeStatus(ProcessPhase.MASHING_OUT, WaitingFor.MASHING_OUT_CONFIRMATION))).toBe(VesselContentType.MASH);
+    });
+
+    it('maps states after confirmed mashing-out to wort', () => {
+        expect(getVesselContentType(makeStatus(ProcessPhase.COOKING))).toBe(VesselContentType.WORT);
+        expect(getVesselContentType(makeStatus(ProcessPhase.COOLING))).toBe(VesselContentType.WORT);
+        expect(getVesselContentType(makeStatus(ProcessPhase.FINISHED))).toBe(VesselContentType.WORT);
+    });
+
+    it('falls back safely to water for unknown statuses', () => {
+        const status = makeStatus('UNKNOWN' as ProcessPhase);
+        expect(getVesselContentType(status)).toBe(VesselContentType.WATER);
+    });
+});

--- a/src/utils/brewingStatus/vesselContent.ts
+++ b/src/utils/brewingStatus/vesselContent.ts
@@ -1,0 +1,21 @@
+import {BrewingStatus, ProcessPhase, WaitingFor} from '../../model/brewingStatus.types';
+import {VesselContentType} from '../../model/VesselContentType';
+
+export function getVesselContentType(aBrewingStatus: BrewingStatus | undefined): VesselContentType {
+    const phase = aBrewingStatus?.currentStep?.phase;
+    const waitingFor = aBrewingStatus?.waiting?.waitingFor;
+
+    if (waitingFor === WaitingFor.MASHING_OUT_CONFIRMATION) {
+        return VesselContentType.MASH;
+    }
+
+    if (phase === ProcessPhase.RAST || phase === ProcessPhase.MASHING_OUT) {
+        return VesselContentType.MASH;
+    }
+
+    if (phase === ProcessPhase.COOKING || phase === ProcessPhase.COOLING || phase === ProcessPhase.FINISHED) {
+        return VesselContentType.WORT;
+    }
+
+    return VesselContentType.WATER;
+}


### PR DESCRIPTION
### Motivation
- Provide a typed visual representation of the tank content (water, mash, wort) that follows the brewing process without embedding process logic into the visual component. 
- Keep existing features (liter display, fill calculation, agitator animation, sparge/mash water flow, and existing water-fill logic) intact while adding distinct visuals for the three content states. 

### Description
- Introduce `VesselContentType` (`WATER`, `MASH`, `WORT`) in `src/model/VesselContentType.ts` and a pure mapping function `getVesselContentType` in `src/utils/brewingStatus/vesselContent.ts` that derives the content type from `BrewingStatus` without adding component-local process state. 
- Pass the derived content type from `Production` to `WaterControl` via a new typed prop `contentType` and keep `WaterControl` as a presentation-only component (`contentType` prop: `VesselContentType`). 
- Extend `WaterControl` UI: add a decorative particle layer inside the fill (`.water-gauge__particles`), inject a content label, and set modifier classes (`.water-gauge--water`, `.water-gauge--mash`, `.water-gauge--wort`, and `.water-gauge--agitator-running`) to switch visuals via CSS only. 
- Implement CSS for distinct water/mash/wort fills, content-specific surface color, particle styling and a single transform-based particle animation that runs only when the agitator is active, and add `prefers-reduced-motion` handling for reduced-motion environments (`src/components/Controlls/WaterControll/WaterControll.css`). 

### Testing
- Added unit tests: `src/utils/brewingStatus/vesselContent.test.ts`, `src/components/Controlls/WaterControll/WaterControl.test.tsx`, and extended `src/containers/Production/Production.test.tsx` to assert mapping and rendering of the three content states. 
- Static checks (`git diff --check`) passed in the workspace. 
- Running the repository test/build in this environment failed because local dependency installation and the test/build toolchain could not be executed (`react-scripts` not available and `npm install` blocked by registry/access errors), so the newly added tests were not executed here and a visual build was not produced. 
- Recommended next steps: run `npm install` (or `npm ci`) in a development environment with registry access and then run `npm test -- --watchAll=false` and `npm run build` to verify all tests and produce screenshots at 1920×1080 for the four visual states requested.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5f4286b5bc832f8ed05c8dcb411ae7)