### PR TITLE
Revise Production process card: single countdown, highlighted current step, scrollable upcoming steps

### DIFF
--- a/src/containers/Production/ProcessList/ProcessList.css
+++ b/src/containers/Production/ProcessList/ProcessList.css
@@ -47,11 +47,12 @@
 }
 
 .current-process-step {
-    background: linear-gradient(135deg, rgba(255, 153, 0, 0.18), rgba(255, 153, 0, 0.05));
+    background: linear-gradient(135deg, rgba(255, 255, 255, 0.045), rgba(255, 255, 255, 0.018));
+    border: 1px solid rgba(255, 255, 255, 0.09);
     border-left: 0.35rem solid var(--color-accent);
     border-radius: 0.8rem;
     padding: 0.9rem 1rem;
-    box-shadow: 0 2px 12px var(--shadow-secondary);
+    box-shadow: inset 0 0 0 1px rgba(255, 153, 0, 0.06), 0 2px 12px var(--shadow-secondary);
     flex: 0 0 auto;
 }
 
@@ -125,7 +126,7 @@
 }
 
 .current-step-progress-fill {
-    background: var(--color-accent);
+    background: linear-gradient(90deg, var(--color-accent), rgba(255, 153, 0, 0.78));
     border-radius: inherit;
     height: 100%;
     transition: width 0.25s ease;

--- a/src/containers/Production/ProcessList/ProcessList.css
+++ b/src/containers/Production/ProcessList/ProcessList.css
@@ -38,6 +38,14 @@
     white-space: nowrap;
 }
 
+.current-process-label {
+    color: var(--color-accent);
+    font-size: 0.82rem;
+    font-weight: 700;
+    margin-bottom: 0.35rem;
+    flex: 0 0 auto;
+}
+
 .current-process-step {
     background: linear-gradient(135deg, rgba(255, 153, 0, 0.18), rgba(255, 153, 0, 0.05));
     border-left: 0.35rem solid var(--color-accent);
@@ -45,6 +53,13 @@
     padding: 0.9rem 1rem;
     box-shadow: 0 2px 12px var(--shadow-secondary);
     flex: 0 0 auto;
+}
+
+.current-step-heading {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 1rem;
 }
 
 .current-process-step h4,
@@ -68,10 +83,11 @@
 .current-step-meta {
     display: flex;
     align-items: baseline;
-    justify-content: space-between;
+    justify-content: flex-end;
     flex-wrap: wrap;
     gap: 0.75rem;
-    margin-top: 0.95rem;
+    margin-top: 0;
+    text-align: right;
 }
 
 .current-step-temperature {
@@ -84,6 +100,35 @@
     font-size: 1.05rem;
     color: var(--color-light-text);
     white-space: nowrap;
+}
+
+.current-step-progress {
+    border-top: 1px solid rgba(255, 255, 255, 0.10);
+    margin-top: 0.9rem;
+    padding-top: 0.65rem;
+}
+
+.current-step-progress-header {
+    display: flex;
+    justify-content: space-between;
+    color: var(--color-accent);
+    font-size: 0.78rem;
+    font-weight: 700;
+    margin-bottom: 0.35rem;
+}
+
+.current-step-progress-track {
+    background: rgba(255, 255, 255, 0.16);
+    border-radius: 999px;
+    height: 0.5rem;
+    overflow: hidden;
+}
+
+.current-step-progress-fill {
+    background: var(--color-accent);
+    border-radius: inherit;
+    height: 100%;
+    transition: width 0.25s ease;
 }
 
 .upcoming-process {
@@ -205,4 +250,16 @@
 .process-list-scroll,
 .process-list-legacy {
     display: none;
+}
+
+@media (max-width: 520px) {
+    .current-step-heading {
+        flex-direction: column;
+        gap: 0.75rem;
+    }
+
+    .current-step-meta {
+        justify-content: flex-start;
+        text-align: left;
+    }
 }

--- a/src/containers/Production/ProcessList/ProcessList.css
+++ b/src/containers/Production/ProcessList/ProcessList.css
@@ -104,7 +104,6 @@
 }
 
 .current-step-remaining {
-    border-top: 1px solid rgba(255, 255, 255, 0.10);
     display: flex;
     justify-content: space-between;
     align-items: baseline;
@@ -125,10 +124,39 @@
     white-space: nowrap;
 }
 
-.current-step-progress {
+.current-step-status {
     border-top: 1px solid rgba(255, 255, 255, 0.10);
+    display: flex;
+    flex-direction: column;
+    gap: 0.45rem;
     margin-top: 0.9rem;
+    min-height: clamp(5.6rem, 9vh, 7rem);
     padding-top: 0.65rem;
+}
+
+.current-step-status--reserved {
+    visibility: hidden;
+}
+
+.current-step-status-label,
+.current-step-status-detail {
+    color: var(--color-accent);
+    font-size: 0.78rem;
+    font-weight: 700;
+}
+
+.current-step-status-value {
+    color: var(--color-light-text);
+    font-size: 1.02rem;
+}
+
+.current-step-status-detail {
+    color: rgba(255, 255, 255, 0.78);
+    font-weight: 500;
+}
+
+.current-step-progress {
+    margin-top: 0;
 }
 
 .current-step-progress-header {
@@ -291,5 +319,9 @@
         align-items: flex-start;
         flex-direction: column;
         gap: 0.25rem;
+    }
+
+    .current-step-status {
+        min-height: 6.75rem;
     }
 }

--- a/src/containers/Production/ProcessList/ProcessList.css
+++ b/src/containers/Production/ProcessList/ProcessList.css
@@ -1,83 +1,208 @@
 .process-list {
     width: 100%;
     height: 100%;
-    padding: 0.5rem 0.7rem 4.5rem;
+    padding: 0.35rem 0.45rem 3.3rem;
     position: relative;
     min-height: 0;
     display: flex;
     flex-direction: column;
     box-sizing: border-box;
+    color: var(--color-light-text);
 }
 
-.process-title {
-    margin: 0 0 0.8rem 0;
-    color: var(--color-accent);
-    font-size: 1.18rem;
-    letter-spacing: 0.03em;
-    font-weight: bold;
+.process-card-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+    margin-bottom: 0.85rem;
     flex: 0 0 auto;
 }
 
-.process-list ul {
+.process-title {
+    margin: 0;
+    color: var(--color-light-text);
+    font-size: 1.18rem;
+    letter-spacing: 0.02em;
+    font-weight: 700;
+}
+
+.process-progress-count {
+    background: var(--color-accent);
+    color: var(--color-white);
+    border-radius: 999px;
+    font-size: 0.95rem;
+    font-weight: 700;
+    line-height: 1;
+    padding: 0.35rem 0.6rem;
+    white-space: nowrap;
+}
+
+.current-process-step {
+    background: linear-gradient(135deg, rgba(255, 153, 0, 0.18), rgba(255, 153, 0, 0.05));
+    border-left: 0.35rem solid var(--color-accent);
+    border-radius: 0.8rem;
+    padding: 0.9rem 1rem;
+    box-shadow: 0 2px 12px var(--shadow-secondary);
+    flex: 0 0 auto;
+}
+
+.current-process-step h4,
+.upcoming-process h4 {
+    margin: 0;
+    color: var(--color-light-text);
+    font-size: 1rem;
+    font-weight: 700;
+    line-height: 1.25;
+    overflow-wrap: anywhere;
+}
+
+.current-step-badge {
+    display: inline-block;
+    margin-top: 0.2rem;
+    color: var(--color-accent);
+    font-size: 0.78rem;
+    font-weight: 700;
+}
+
+.current-step-meta {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    margin-top: 0.95rem;
+}
+
+.current-step-temperature {
+    font-size: 1.2rem;
+    font-weight: 700;
+    color: var(--color-light-text);
+}
+
+.current-step-time {
+    font-size: 1.05rem;
+    color: var(--color-light-text);
+    white-space: nowrap;
+}
+
+.upcoming-process {
+    display: flex;
+    flex: 1 1 auto;
+    flex-direction: column;
+    min-height: 0;
+    margin-top: 1rem;
+}
+
+.upcoming-process h4 {
+    color: var(--color-accent);
+    font-size: 0.9rem;
+    margin-bottom: 0.45rem;
+    flex: 0 0 auto;
+}
+
+.upcoming-process-scroll {
+    max-height: clamp(8rem, 32vh, 18rem);
+    min-height: 0;
+    overflow-y: auto;
+    overflow-x: hidden;
+    padding-right: 0.25rem;
+    scrollbar-width: thin;
+    scrollbar-color: rgba(255, 255, 255, 0.35) transparent;
+}
+
+.upcoming-process-scroll::-webkit-scrollbar {
+    width: 0.35rem;
+}
+
+.upcoming-process-scroll::-webkit-scrollbar-track {
+    background: transparent;
+}
+
+.upcoming-process-scroll::-webkit-scrollbar-thumb {
+    background: rgba(255, 255, 255, 0.22);
+    border-radius: 999px;
+}
+
+.upcoming-process-scroll:hover::-webkit-scrollbar-thumb {
+    background: rgba(255, 255, 255, 0.36);
+}
+
+.upcoming-process-scroll ul {
     list-style: none;
     margin: 0;
     padding: 0;
 }
 
-.process-step {
-    padding: 0.6rem 0.7rem;
-    margin-bottom: 0.4rem;
-    border-radius: 7px;
-    background: var(--color-gray-very-dark);
-    color: var(--color-white);
+.upcoming-process-step {
+    display: grid;
+    grid-template-columns: 1rem minmax(0, 1fr);
+    gap: 0.55rem;
+    align-items: start;
+    padding: 0.35rem 0;
+    color: var(--color-light-text);
+}
+
+.upcoming-step-marker {
+    width: 0.65rem;
+    height: 0.65rem;
+    border: 2px solid rgba(255, 255, 255, 0.42);
+    border-radius: 50%;
+    margin-top: 0.25rem;
+}
+
+.upcoming-step-content {
+    min-width: 0;
     display: flex;
-    align-items: center;
-    font-size: 1.1rem;
-    transition: background 0.2s, color 0.2s;
+    flex-direction: column;
+    gap: 0.1rem;
 }
 
-.process-step.active {
-    background: var(--color-surface-alt);
-    color: var(--color-white);
-    font-weight: bold;
-    border-left: 6px solid var(--color-accent);
+.upcoming-step-name {
+    font-size: 0.92rem;
+    line-height: 1.2;
+    overflow-wrap: anywhere;
 }
 
-.step-number {
-    margin-right: 0.7rem;
-    font-weight: bold;
-    color: var(--color-accent);
+.process-step-meta {
+    color: rgba(255, 255, 255, 0.72);
+    font-size: 0.78rem;
+    line-height: 1.2;
+}
+
+.process-empty-state,
+.process-complete-state {
+    color: rgba(255, 255, 255, 0.72);
+    background: rgba(255, 255, 255, 0.04);
+    border-radius: 0.65rem;
+    padding: 0.9rem;
+    margin: 0;
 }
 
 .next-step-separator {
     border: none;
-    border-top: 2px solid var(--color-accent);
-    margin: 25px 0 0 0;
+    border-top: 1px solid rgba(255, 153, 0, 0.4);
+    margin: 0.9rem 0 0 0;
     width: 100%;
     flex: 0 0 auto;
 }
 
 .next-step-btn-container {
     position: absolute;
-    left: 8px;
-    right: 0;
-    bottom: 0px;
-    width: 100%;
+    left: 0.45rem;
+    right: 0.45rem;
+    bottom: 0;
     display: flex;
-    justify-content: left;
+    justify-content: stretch;
     padding: 0;
     background: transparent;
 }
 
-.process-list-scroll {
-    flex: 1 1 auto;
-    min-height: 0;
-    margin: 0 auto;
-    width: 95%;
-    box-sizing: border-box;
-    --simplebar-scrollbar-width: 0px;
+.nextStepBtn {
+    width: 100%;
 }
 
-.process-list-scroll .simplebar-scrollbar {
-    display: none !important;
+.process-list-scroll,
+.process-list-legacy {
+    display: none;
 }

--- a/src/containers/Production/ProcessList/ProcessList.css
+++ b/src/containers/Production/ProcessList/ProcessList.css
@@ -103,6 +103,28 @@
     white-space: nowrap;
 }
 
+.current-step-remaining {
+    border-top: 1px solid rgba(255, 255, 255, 0.10);
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    gap: 1rem;
+    margin-top: 0.75rem;
+    padding-top: 0.65rem;
+}
+
+.current-step-remaining-label {
+    color: var(--color-accent);
+    font-size: 0.78rem;
+    font-weight: 700;
+}
+
+.current-step-remaining-value {
+    color: var(--color-light-text);
+    font-size: 1.05rem;
+    white-space: nowrap;
+}
+
 .current-step-progress {
     border-top: 1px solid rgba(255, 255, 255, 0.10);
     margin-top: 0.9rem;
@@ -259,8 +281,15 @@
         gap: 0.75rem;
     }
 
-    .current-step-meta {
+    .current-step-meta,
+    .current-step-remaining {
         justify-content: flex-start;
         text-align: left;
+    }
+
+    .current-step-remaining {
+        align-items: flex-start;
+        flex-direction: column;
+        gap: 0.25rem;
     }
 }

--- a/src/containers/Production/ProcessList/ProcessList.test.tsx
+++ b/src/containers/Production/ProcessList/ProcessList.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import {render, screen} from '@testing-library/react';
 import '@testing-library/jest-dom';
 import {Beer} from '../../../model/Beer';
-import {ProcessMode, ProcessPhase} from '../../../model/brewingStatus.types';
+import {BrewingStatus, ProcessMode, ProcessPhase, ProcessState, WaitingFor} from '../../../model/brewingStatus.types';
 import {createProcessSteps, getActiveProcessStepIndex, ProcessList} from './ProcessList';
 
 const selectedBeer = {
@@ -39,16 +39,16 @@ const getActiveStepText = (controlStepIndex: number) => {
 describe('ProcessList current-step mapping', () => {
     it('builds visible process rows with shared control indices for heating and process entries', () => {
         expect(createProcessSteps(selectedBeer).map(step => `${step.controlStepIndex ?? '-'}:${step.name}`)).toEqual([
-            '1:Aufheizen für Einmaischen -> 57°C',
+            '1:Aufheizen für Einmaischen',
             '1:Einmaischen',
-            '2:Aufheizen für Rast 1 -> 63°C',
+            '2:Aufheizen für Rast 1',
             '2:Rast 1',
-            '3:Aufheizen für Rast 2 -> 68°C',
+            '3:Aufheizen für Rast 2',
             '3:Rast 2',
-            '4:Aufheizen für Rast 3 -> 72°C',
+            '4:Aufheizen für Rast 3',
             '4:Rast 3',
             '-:Jod Probe',
-            '5:Aufheizen für Abmaischen -> 78°C',
+            '5:Aufheizen für Abmaischen',
             '5:Abmaischen',
             '6:Aufheizen auf Kochen',
             '6:Kochen',
@@ -67,9 +67,9 @@ describe('ProcessList current-step mapping', () => {
     it('uses currentStep.mode to choose between heating and execution rows for the same control index', () => {
         const steps = createProcessSteps(selectedBeer);
 
-        expect(steps[getActiveProcessStepIndex(steps, 1, {index: 1, phase: ProcessPhase.MASHING_IN, mode: ProcessMode.HEATING})].name).toBe('Aufheizen für Einmaischen -> 57°C');
+        expect(steps[getActiveProcessStepIndex(steps, 1, {index: 1, phase: ProcessPhase.MASHING_IN, mode: ProcessMode.HEATING})].name).toBe('Aufheizen für Einmaischen');
         expect(steps[getActiveProcessStepIndex(steps, 1, {index: 1, phase: ProcessPhase.MASHING_IN, mode: ProcessMode.TIMER_RUNNING})].name).toBe('Einmaischen');
-        expect(steps[getActiveProcessStepIndex(steps, 2, {index: 2, phase: ProcessPhase.RAST, mode: ProcessMode.HEATING})].name).toBe('Aufheizen für Rast 1 -> 63°C');
+        expect(steps[getActiveProcessStepIndex(steps, 2, {index: 2, phase: ProcessPhase.RAST, mode: ProcessMode.HEATING})].name).toBe('Aufheizen für Rast 1');
         expect(steps[getActiveProcessStepIndex(steps, 2, {index: 2, phase: ProcessPhase.RAST, mode: ProcessMode.TIMER_RUNNING})].name).toBe('Rast 1');
     });
 
@@ -140,5 +140,103 @@ describe('ProcessList current-step mapping', () => {
         expect(screen.getAllByText(/Rast 3/).length).toBeGreaterThan(0);
         expect(screen.getAllByText(/Abmaischen/).length).toBeGreaterThan(0);
         expect(screen.getAllByText(/Kochen/).length).toBeGreaterThan(0);
+    });
+});
+
+describe('ProcessList compact production overview', () => {
+    const activeStatus = (index: number, mode: ProcessMode = ProcessMode.TIMER_RUNNING, remainingTime = 1176): BrewingStatus => ({
+        elapsedTime: 0,
+        currentTime: 0,
+        process: {state: ProcessState.ACTIVE},
+        currentStep: {
+            index,
+            count: 6,
+            phase: index === 6 ? ProcessPhase.COOKING : ProcessPhase.RAST,
+            mode,
+            name: 'Rast 2',
+            duration: 1800,
+            elapsedTime: 624,
+            remainingTime
+        },
+        temperature: {target: 68},
+        hardware: {},
+        waiting: {waitingFor: WaitingFor.NONE, canConfirm: false},
+        error: {}
+    });
+
+    it('shows current visible step position and total visible steps', () => {
+        render(<ProcessList selectedBeer={selectedBeer} currentStepIndex={3} currentStep={{index: 3, phase: ProcessPhase.RAST, mode: ProcessMode.TIMER_RUNNING}} brewingStatus={activeStatus(3)} remainingSeconds={1176} />);
+
+        expect(screen.getByText('6 / 13')).toBeInTheDocument();
+    });
+
+    it('shows all remaining process steps in order with details', () => {
+        const {container} = render(<ProcessList selectedBeer={selectedBeer} currentStepIndex={3} currentStep={{index: 3, phase: ProcessPhase.RAST, mode: ProcessMode.TIMER_RUNNING}} brewingStatus={activeStatus(3)} remainingSeconds={1176} />);
+        const names = Array.from(container.querySelectorAll('.upcoming-step-name')).map(node => node.textContent);
+
+        expect(names).toEqual([
+            'Aufheizen für Rast 3',
+            'Rast 3',
+            'Jod Probe',
+            'Aufheizen für Abmaischen',
+            'Abmaischen',
+            'Aufheizen auf Kochen',
+            'Kochen'
+        ]);
+        expect(screen.getAllByText(/72 °C/).length).toBeGreaterThan(0);
+        expect(screen.getByText('Bestätigung erforderlich')).toBeInTheDocument();
+        expect(screen.getByText('100 °C · 60 min')).toBeInTheDocument();
+    });
+
+    it('renders the remaining time as a single countdown value', () => {
+        render(<ProcessList selectedBeer={selectedBeer} currentStepIndex={3} currentStep={{index: 3, phase: ProcessPhase.RAST, mode: ProcessMode.TIMER_RUNNING}} brewingStatus={activeStatus(3)} remainingSeconds={1176} />);
+
+        expect(screen.getByText('Restzeit 00:19:36')).toBeInTheDocument();
+        expect(screen.queryByText('Laufzeit')).not.toBeInTheDocument();
+        expect(screen.queryByText('Zielzeit')).not.toBeInTheDocument();
+    });
+
+    it('does not invent countdowns for waiting or durationless steps', () => {
+        const waitingStatus = activeStatus(3, ProcessMode.WAITING);
+        waitingStatus.waiting = {waitingFor: WaitingFor.IODINE_TEST, canConfirm: true};
+        const {rerender} = render(<ProcessList selectedBeer={selectedBeer} currentStepIndex={3} currentStep={{index: 3, phase: ProcessPhase.RAST, mode: ProcessMode.WAITING}} brewingStatus={waitingStatus} remainingSeconds={1176} />);
+        expect(screen.getByText('Wartet auf Bestätigung')).toBeInTheDocument();
+
+        const durationlessStatus = activeStatus(3, ProcessMode.HEATING);
+        durationlessStatus.currentStep.duration = 0;
+        durationlessStatus.waiting = {waitingFor: WaitingFor.NONE, canConfirm: false};
+        rerender(<ProcessList selectedBeer={selectedBeer} currentStepIndex={3} currentStep={{index: 3, phase: ProcessPhase.RAST, mode: ProcessMode.HEATING}} brewingStatus={durationlessStatus} />);
+        expect(screen.getByText('Keine feste Dauer')).toBeInTheDocument();
+    });
+
+    it('handles missing optional temperature and duration values without placeholders', () => {
+        const beerWithoutOptionalValues = {...selectedBeer, cookingTemperatur: 0, cookingTime: 0, fermentation: [{type: 'Einmaischen', temperature: 0}, {type: 'Rast 1', temperature: 0}, {type: 'Abmaischen', temperature: 0}]} as Beer;
+        render(<ProcessList selectedBeer={beerWithoutOptionalValues} currentStepIndex={2} currentStep={{index: 2, phase: ProcessPhase.RAST, mode: ProcessMode.TIMER_RUNNING}} brewingStatus={activeStatus(2)} />);
+
+        expect(screen.queryByText(/0 °C/)).not.toBeInTheDocument();
+        expect(screen.queryByText(/0 min/)).not.toBeInTheDocument();
+    });
+
+    it('shows the finished state without additional steps', () => {
+        const finishedStatus = activeStatus(6);
+        finishedStatus.process.state = ProcessState.FINISHED;
+        render(<ProcessList selectedBeer={selectedBeer} currentStepIndex={6} currentStep={{index: 6, phase: ProcessPhase.COOKING, mode: ProcessMode.TIMER_RUNNING}} brewingStatus={finishedStatus} remainingSeconds={0} />);
+
+        expect(screen.getByText('Restzeit 00:00:00')).toBeInTheDocument();
+        expect(screen.getByText('Keine weiteren Schritte.')).toBeInTheDocument();
+    });
+
+    it('shows an empty state without an active brewing process', () => {
+        render(<ProcessList selectedBeer={selectedBeer} currentStepIndex={0} />);
+
+        expect(screen.getByText('Noch kein Brauvorgang gestartet.')).toBeInTheDocument();
+        expect(screen.queryByText(/\d+ \/ \d+/)).not.toBeInTheDocument();
+    });
+
+    it('keeps only the following steps in the scrollable area', () => {
+        const {container} = render(<ProcessList selectedBeer={selectedBeer} currentStepIndex={1} currentStep={{index: 1, phase: ProcessPhase.MASHING_IN, mode: ProcessMode.TIMER_RUNNING}} brewingStatus={activeStatus(1)} />);
+
+        expect(container.querySelector('.upcoming-process-scroll')).toBeInTheDocument();
+        expect(container.querySelector('.current-process-step .upcoming-step-name')).not.toBeInTheDocument();
     });
 });

--- a/src/containers/Production/ProcessList/ProcessList.test.tsx
+++ b/src/containers/Production/ProcessList/ProcessList.test.tsx
@@ -192,6 +192,8 @@ describe('ProcessList compact production overview', () => {
         render(<ProcessList selectedBeer={selectedBeer} currentStepIndex={3} currentStep={{index: 3, phase: ProcessPhase.RAST, mode: ProcessMode.TIMER_RUNNING}} brewingStatus={activeStatus(3)} remainingSeconds={1176} />);
 
         expect(screen.getByText('Restzeit 00:19:36')).toBeInTheDocument();
+        expect(screen.getByText('Verbleibende Laufzeit')).toBeInTheDocument();
+        expect(screen.getByLabelText('Verbleibende Laufzeit')).toHaveClass('current-step-remaining');
         expect(screen.getByText('Fortschritt')).toBeInTheDocument();
         expect(screen.getByText('35 %')).toBeInTheDocument();
         expect(screen.queryByText('Laufzeit')).not.toBeInTheDocument();

--- a/src/containers/Production/ProcessList/ProcessList.test.tsx
+++ b/src/containers/Production/ProcessList/ProcessList.test.tsx
@@ -192,6 +192,8 @@ describe('ProcessList compact production overview', () => {
         render(<ProcessList selectedBeer={selectedBeer} currentStepIndex={3} currentStep={{index: 3, phase: ProcessPhase.RAST, mode: ProcessMode.TIMER_RUNNING}} brewingStatus={activeStatus(3)} remainingSeconds={1176} />);
 
         expect(screen.getByText('Restzeit 00:19:36')).toBeInTheDocument();
+        expect(screen.getByText('Fortschritt')).toBeInTheDocument();
+        expect(screen.getByText('35 %')).toBeInTheDocument();
         expect(screen.queryByText('Laufzeit')).not.toBeInTheDocument();
         expect(screen.queryByText('Zielzeit')).not.toBeInTheDocument();
     });

--- a/src/containers/Production/ProcessList/ProcessList.test.tsx
+++ b/src/containers/Production/ProcessList/ProcessList.test.tsx
@@ -191,13 +191,37 @@ describe('ProcessList compact production overview', () => {
     it('renders the remaining time as a single countdown value', () => {
         render(<ProcessList selectedBeer={selectedBeer} currentStepIndex={3} currentStep={{index: 3, phase: ProcessPhase.RAST, mode: ProcessMode.TIMER_RUNNING}} brewingStatus={activeStatus(3)} remainingSeconds={1176} />);
 
-        expect(screen.getByText('Restzeit 00:19:36')).toBeInTheDocument();
-        expect(screen.getByText('Verbleibende Laufzeit')).toBeInTheDocument();
-        expect(screen.getByLabelText('Verbleibende Laufzeit')).toHaveClass('current-step-remaining');
+        expect(screen.getByText('Restzeit')).toBeInTheDocument();
+        expect(screen.getByText('00:19:36')).toBeInTheDocument();
+        expect(screen.getByLabelText('Restzeit')).toHaveClass('current-step-remaining');
         expect(screen.getByText('Fortschritt')).toBeInTheDocument();
         expect(screen.getByText('35 %')).toBeInTheDocument();
+        expect(screen.queryByText('Verbleibende Laufzeit')).not.toBeInTheDocument();
         expect(screen.queryByText('Laufzeit')).not.toBeInTheDocument();
         expect(screen.queryByText('Zielzeit')).not.toBeInTheDocument();
+    });
+
+    it('shows heating status without progress or remaining time', () => {
+        const heatingStatus = activeStatus(3, ProcessMode.HEATING);
+        heatingStatus.temperature = {current: 32.8, target: 68};
+        render(<ProcessList selectedBeer={selectedBeer} currentStepIndex={3} currentStep={{index: 3, phase: ProcessPhase.RAST, mode: ProcessMode.HEATING}} brewingStatus={heatingStatus} remainingSeconds={1176} />);
+
+        expect(screen.getByText('Zieltemperatur wird erreicht')).toBeInTheDocument();
+        expect(screen.getByText('32,8 °C von 68 °C')).toBeInTheDocument();
+        expect(screen.queryByText('Fortschritt')).not.toBeInTheDocument();
+        expect(screen.queryByText('Restzeit')).not.toBeInTheDocument();
+        expect(screen.queryByText(/00:19:36/)).not.toBeInTheDocument();
+    });
+
+    it('does not show heating temperature progress without reliable values', () => {
+        const heatingStatus = activeStatus(3, ProcessMode.HEATING);
+        heatingStatus.temperature = {target: 68};
+        render(<ProcessList selectedBeer={selectedBeer} currentStepIndex={3} currentStep={{index: 3, phase: ProcessPhase.RAST, mode: ProcessMode.HEATING}} brewingStatus={heatingStatus} />);
+
+        expect(screen.getByText('Zieltemperatur wird erreicht')).toBeInTheDocument();
+        expect(screen.queryByText(/von 68 °C/)).not.toBeInTheDocument();
+        expect(screen.queryByText('undefined')).not.toBeInTheDocument();
+        expect(screen.queryByText('NaN')).not.toBeInTheDocument();
     });
 
     it('does not invent countdowns for waiting or durationless steps', () => {
@@ -205,12 +229,15 @@ describe('ProcessList compact production overview', () => {
         waitingStatus.waiting = {waitingFor: WaitingFor.IODINE_TEST, canConfirm: true};
         const {rerender} = render(<ProcessList selectedBeer={selectedBeer} currentStepIndex={3} currentStep={{index: 3, phase: ProcessPhase.RAST, mode: ProcessMode.WAITING}} brewingStatus={waitingStatus} remainingSeconds={1176} />);
         expect(screen.getByText('Wartet auf Bestätigung')).toBeInTheDocument();
+        expect(screen.queryByText('Fortschritt')).not.toBeInTheDocument();
+        expect(screen.queryByText('Restzeit')).not.toBeInTheDocument();
 
-        const durationlessStatus = activeStatus(3, ProcessMode.HEATING);
+        const durationlessStatus = activeStatus(3, ProcessMode.HOLDING);
         durationlessStatus.currentStep.duration = 0;
         durationlessStatus.waiting = {waitingFor: WaitingFor.NONE, canConfirm: false};
-        rerender(<ProcessList selectedBeer={selectedBeer} currentStepIndex={3} currentStep={{index: 3, phase: ProcessPhase.RAST, mode: ProcessMode.HEATING}} brewingStatus={durationlessStatus} />);
-        expect(screen.getByText('Keine feste Dauer')).toBeInTheDocument();
+        rerender(<ProcessList selectedBeer={selectedBeer} currentStepIndex={3} currentStep={{index: 3, phase: ProcessPhase.RAST, mode: ProcessMode.HOLDING}} brewingStatus={durationlessStatus} />);
+        expect(screen.getByText('Schritt wird ausgeführt')).toBeInTheDocument();
+        expect(screen.queryByText('Restzeit')).not.toBeInTheDocument();
     });
 
     it('handles missing optional temperature and duration values without placeholders', () => {
@@ -226,7 +253,8 @@ describe('ProcessList compact production overview', () => {
         finishedStatus.process.state = ProcessState.FINISHED;
         render(<ProcessList selectedBeer={selectedBeer} currentStepIndex={6} currentStep={{index: 6, phase: ProcessPhase.COOKING, mode: ProcessMode.TIMER_RUNNING}} brewingStatus={finishedStatus} remainingSeconds={0} />);
 
-        expect(screen.getByText('Restzeit 00:00:00')).toBeInTheDocument();
+        expect(screen.getByText('Brauvorgang abgeschlossen')).toBeInTheDocument();
+        expect(screen.queryByText('Restzeit')).not.toBeInTheDocument();
         expect(screen.getByText('Keine weiteren Schritte.')).toBeInTheDocument();
     });
 
@@ -245,6 +273,17 @@ describe('ProcessList compact production overview', () => {
 
         expect(screen.getByText('Kein Bier für den Brauvorgang ausgewählt.')).toBeInTheDocument();
         expect(screen.queryByText(/\d+ \/ \d+/)).not.toBeInTheDocument();
+    });
+
+    it('uses the same reserved status area for heating and timed rests', () => {
+        const heatingStatus = activeStatus(3, ProcessMode.HEATING);
+        const {container, rerender} = render(<ProcessList selectedBeer={selectedBeer} currentStepIndex={3} currentStep={{index: 3, phase: ProcessPhase.RAST, mode: ProcessMode.HEATING}} brewingStatus={heatingStatus} />);
+        expect(container.querySelector('.current-step-status')).toBeInTheDocument();
+        expect(container.querySelector('.upcoming-process-scroll')).toBeInTheDocument();
+
+        rerender(<ProcessList selectedBeer={selectedBeer} currentStepIndex={3} currentStep={{index: 3, phase: ProcessPhase.RAST, mode: ProcessMode.TIMER_RUNNING}} brewingStatus={activeStatus(3)} remainingSeconds={1176} />);
+        expect(container.querySelector('.current-step-status')).toBeInTheDocument();
+        expect(container.querySelector('.upcoming-process-scroll')).toBeInTheDocument();
     });
 
     it('keeps only the following steps in the scrollable area', () => {

--- a/src/containers/Production/ProcessList/ProcessList.test.tsx
+++ b/src/containers/Production/ProcessList/ProcessList.test.tsx
@@ -226,10 +226,20 @@ describe('ProcessList compact production overview', () => {
         expect(screen.getByText('Keine weiteren Schritte.')).toBeInTheDocument();
     });
 
-    it('shows an empty state without an active brewing process', () => {
+    it('shows the selected beer process before an active brewing process starts', () => {
         render(<ProcessList selectedBeer={selectedBeer} currentStepIndex={0} />);
 
-        expect(screen.getByText('Noch kein Brauvorgang gestartet.')).toBeInTheDocument();
+        expect(screen.getByText('Noch kein Brauvorgang gestartet')).toBeInTheDocument();
+        expect(screen.getByText('Geplanter Ablauf')).toBeInTheDocument();
+        expect(screen.getByText('Bereit zum Start')).toBeInTheDocument();
+        expect(screen.getAllByText('Aufheizen für Einmaischen').length).toBeGreaterThan(0);
+        expect(screen.queryByText(/\d+ \/ \d+/)).not.toBeInTheDocument();
+    });
+
+    it('shows a clear empty state if no recipe process is available', () => {
+        render(<ProcessList selectedBeer={{...selectedBeer, fermentation: []} as Beer} currentStepIndex={0} />);
+
+        expect(screen.getByText('Kein Bier für den Brauvorgang ausgewählt.')).toBeInTheDocument();
         expect(screen.queryByText(/\d+ \/ \d+/)).not.toBeInTheDocument();
     });
 

--- a/src/containers/Production/ProcessList/ProcessList.tsx
+++ b/src/containers/Production/ProcessList/ProcessList.tsx
@@ -4,13 +4,21 @@ import 'simplebar-react/dist/simplebar.min.css';
 import './ProcessList.css';
 import {Beer, FermentationSteps} from "../../../model/Beer";
 import {RestExecutionMode} from "../../../enums/eRestExecutionMode";
-import {ProcessMode, ProcessPhase} from "../../../model/brewingStatus.types";
+import {BrewingStatus, ProcessMode, ProcessPhase, ProcessState, WaitingFor} from "../../../model/brewingStatus.types";
+import {TimeFormatter} from "../../../utils/TimeFormatter";
 
 export enum ProcessListEntryType {
     HEATING = "HEATING",
     PROCESS = "PROCESS",
     DISPLAY = "DISPLAY"
 }
+
+export interface ProcessStepDetail {
+    temperature?: number;
+    duration?: number;
+    confirmationRequired?: boolean;
+}
+
 
 export interface ProcessListCurrentStep {
     index?: number;
@@ -29,6 +37,7 @@ export interface ProcessListStep {
      */
     controlStepIndex?: number;
     phase?: ProcessPhase;
+    detail?: ProcessStepDetail;
 }
 
 export interface ProcessListProps {
@@ -37,6 +46,8 @@ export interface ProcessListProps {
     currentStep?: ProcessListCurrentStep;
     onNextStep?: () => void;
     isNextStepDisabled?: boolean;
+    brewingStatus?: BrewingStatus;
+    remainingSeconds?: number;
 }
 
 interface ProcessListState {
@@ -101,35 +112,113 @@ export class ProcessList extends React.Component<ProcessListProps, ProcessListSt
         });
     };
 
+    renderStepDetails(step: ProcessListStep): React.ReactNode {
+        const details: string[] = [];
+        if (typeof step.detail?.temperature === 'number' && Number.isFinite(step.detail.temperature) && step.detail.temperature > 0) {
+            details.push(`${step.detail.temperature} °C`);
+        }
+        if (typeof step.detail?.duration === 'number' && Number.isFinite(step.detail.duration) && step.detail.duration > 0) {
+            details.push(`${Math.round(step.detail.duration / 60)} min`);
+        }
+        if (step.detail?.confirmationRequired) {
+            details.push('Bestätigung erforderlich');
+        }
+
+        return details.length > 0 ? <span className="process-step-meta">{details.join(' · ')}</span> : null;
+    }
+
+    getCurrentStepTitle(activeStep: ProcessListStep | undefined): string {
+        return activeStep?.name ?? this.props.currentStep?.name ?? 'Kein aktiver Prozessschritt';
+    }
+
+    getCurrentStepMeta(activeStep: ProcessListStep | undefined): React.ReactNode {
+        const {brewingStatus, remainingSeconds} = this.props;
+        const targetTemperature = brewingStatus?.temperature?.target ?? activeStep?.detail?.temperature;
+        const isFinished = brewingStatus?.process?.state === ProcessState.FINISHED;
+        const hasDuration = typeof brewingStatus?.currentStep?.duration === 'number' && brewingStatus.currentStep.duration > 0;
+        const isWaiting = brewingStatus?.currentStep?.mode === ProcessMode.WAITING || (brewingStatus?.waiting?.waitingFor !== undefined && brewingStatus.waiting.waitingFor !== WaitingFor.NONE);
+        const metaItems: React.ReactNode[] = [];
+
+        if (typeof targetTemperature === 'number' && Number.isFinite(targetTemperature) && targetTemperature > 0) {
+            metaItems.push(<span key="temperature" className="current-step-temperature">{targetTemperature} °C</span>);
+        }
+
+        if (isFinished) {
+            metaItems.push(<span key="remaining" className="current-step-time">Restzeit {TimeFormatter.formatSecondsToHMS(0)}</span>);
+        } else if (isWaiting) {
+            metaItems.push(<span key="waiting" className="current-step-time">Wartet auf Bestätigung</span>);
+        } else if (hasDuration && typeof remainingSeconds === 'number') {
+            metaItems.push(<span key="remaining" className="current-step-time">Restzeit {TimeFormatter.formatSecondsToHMS(remainingSeconds)}</span>);
+        } else {
+            metaItems.push(<span key="no-duration" className="current-step-time">Keine feste Dauer</span>);
+        }
+
+        return <div className="current-step-meta">{metaItems}</div>;
+    }
+
     render() {
-        const { selectedBeer, onNextStep, isNextStepDisabled = false } = this.props;
+        const { selectedBeer, onNextStep, isNextStepDisabled = false, brewingStatus } = this.props;
         const steps = createProcessSteps(selectedBeer);
-        const stepIndex = this.effectiveStepIndex;
+        const isIdle = brewingStatus === undefined || brewingStatus.process?.state === ProcessState.IDLE || steps.length === 0;
+        const stepIndex = isIdle ? -1 : this.effectiveStepIndex;
+        const activeStep = stepIndex >= 0 ? steps[stepIndex] : undefined;
+        const upcomingSteps = stepIndex >= 0 ? steps.slice(stepIndex + 1) : [];
+        const progressLabel = stepIndex >= 0 ? `${stepIndex + 1} / ${steps.length}` : '';
 
         return (
             <div className="process-list">
-                <h3 className="process-title">Process</h3>
+                <div className="process-card-header">
+                    <h3 className="process-title">Prozess</h3>
+                    {progressLabel && <span className="process-progress-count">{progressLabel}</span>}
+                </div>
 
-                <SimpleBar
-                    className="process-list-scroll"
-                    scrollableNodeProps={{ ref: this.simpleBarRef }}
-                >
-                    <ul>
-                        {steps.map((step, idx) => (
-                            <li
-                                key={step.name + idx}
-                                ref={idx === stepIndex ? this.activeStepRef : undefined}
-                                className={
-                                    "process-step" + (idx === stepIndex ? " active" : "")
-                                }
-                            >
-                                <span className="step-number">{idx + 1}.</span> {step.name}
-                            </li>
-                        ))}
-                    </ul>
-                </SimpleBar>
+                <ul className="process-list-legacy" aria-hidden="true">
+                    {steps.map((step, idx) => (
+                        <li
+                            key={`legacy-${step.name}-${idx}`}
+                            ref={idx === stepIndex ? this.activeStepRef : undefined}
+                            className={"process-step" + (idx === stepIndex ? " active" : "")}
+                        >
+                            <span className="step-number">{idx + 1}.</span> {step.name}
+                        </li>
+                    ))}
+                </ul>
 
-                {/* regulärer Next-Button aus Parent/Redux */}
+                {isIdle ? (
+                    <div className="process-empty-state">Noch kein Brauvorgang gestartet.</div>
+                ) : (
+                    <>
+                        <section className="current-process-step" aria-label="Aktueller Prozessschritt">
+                            <div>
+                                <h4>{this.getCurrentStepTitle(activeStep)}</h4>
+                                <span className="current-step-badge">Aktiver Schritt</span>
+                            </div>
+                            {this.getCurrentStepMeta(activeStep)}
+                        </section>
+
+                        <section className="upcoming-process" aria-label="Weiterer Ablauf">
+                            <h4>Weiterer Ablauf</h4>
+                            <div className="upcoming-process-scroll">
+                                {upcomingSteps.length > 0 ? (
+                                    <ul>
+                                        {upcomingSteps.map((step, idx) => (
+                                            <li key={`${step.name}-${idx}`} className="upcoming-process-step">
+                                                <span className="upcoming-step-marker" aria-hidden="true" />
+                                                <span className="upcoming-step-content">
+                                                    <span className="upcoming-step-name">{step.name}</span>
+                                                    {this.renderStepDetails(step)}
+                                                </span>
+                                            </li>
+                                        ))}
+                                    </ul>
+                                ) : (
+                                    <p className="process-complete-state">Keine weiteren Schritte.</p>
+                                )}
+                            </div>
+                        </section>
+                    </>
+                )}
+
                 {onNextStep && (
                     <>
                         <hr className="next-step-separator" />
@@ -167,8 +256,8 @@ export function createProcessSteps(selectedBeer: Beer): ProcessListStep[] {
     // Einmaischen
     const einmaischen = fermentation.find(step => step.type === 'Einmaischen');
     if (einmaischen) {
-        processSteps.push({ name: `Aufheizen für Einmaischen -> ${einmaischen.temperature}°C`, entryType: ProcessListEntryType.HEATING, controlStepIndex, phase: ProcessPhase.MASHING_IN });
-        processSteps.push({ name: 'Einmaischen', entryType: ProcessListEntryType.PROCESS, controlStepIndex, phase: ProcessPhase.MASHING_IN });
+        processSteps.push({ name: `Aufheizen für Einmaischen`, entryType: ProcessListEntryType.HEATING, controlStepIndex, phase: ProcessPhase.MASHING_IN, detail: {temperature: einmaischen.temperature} });
+        processSteps.push({ name: 'Einmaischen', entryType: ProcessListEntryType.PROCESS, controlStepIndex, phase: ProcessPhase.MASHING_IN, detail: {temperature: einmaischen.temperature, confirmationRequired: true} });
         controlStepIndex++;
     }
 
@@ -179,8 +268,8 @@ export function createProcessSteps(selectedBeer: Beer): ProcessListStep[] {
         const isRastName = /^Rast\s*\d+$/i.test(step.type);
         const isConfirmationHold = (step.executionMode ?? RestExecutionMode.TIMED) === RestExecutionMode.CONFIRMATION_HOLD;
         if (isRastName || isConfirmationHold) {
-            processSteps.push({ name: `Aufheizen für ${step.type} -> ${step.temperature}°C`, entryType: ProcessListEntryType.HEATING, controlStepIndex, phase: ProcessPhase.RAST });
-            processSteps.push({ name: step.type, entryType: ProcessListEntryType.PROCESS, controlStepIndex, phase: ProcessPhase.RAST });
+            processSteps.push({ name: `Aufheizen für ${step.type}`, entryType: ProcessListEntryType.HEATING, controlStepIndex, phase: ProcessPhase.RAST, detail: {temperature: step.temperature} });
+            processSteps.push({ name: step.type, entryType: ProcessListEntryType.PROCESS, controlStepIndex, phase: ProcessPhase.RAST, detail: {temperature: step.temperature, duration: step.time, confirmationRequired: isConfirmationHold} });
             controlStepIndex++;
             lastRastIndex = processSteps.length - 1;
         }
@@ -188,20 +277,20 @@ export function createProcessSteps(selectedBeer: Beer): ProcessListStep[] {
 
     // Jod-Probe nach letzter Rast
     if (lastRastIndex !== -1) {
-        processSteps.splice(lastRastIndex + 1, 0, { name: 'Jod Probe', entryType: ProcessListEntryType.DISPLAY });
+        processSteps.splice(lastRastIndex + 1, 0, { name: 'Jod Probe', entryType: ProcessListEntryType.DISPLAY, detail: {confirmationRequired: true} });
     }
 
     // Abmaischen
     const abmaischen = fermentation.find(step => step.type === 'Abmaischen');
     if (abmaischen) {
-        processSteps.push({ name: `Aufheizen für Abmaischen -> ${abmaischen.temperature}°C`, entryType: ProcessListEntryType.HEATING, controlStepIndex, phase: ProcessPhase.MASHING_OUT });
-        processSteps.push({ name: 'Abmaischen', entryType: ProcessListEntryType.PROCESS, controlStepIndex, phase: ProcessPhase.MASHING_OUT });
+        processSteps.push({ name: `Aufheizen für Abmaischen`, entryType: ProcessListEntryType.HEATING, controlStepIndex, phase: ProcessPhase.MASHING_OUT, detail: {temperature: abmaischen.temperature} });
+        processSteps.push({ name: 'Abmaischen', entryType: ProcessListEntryType.PROCESS, controlStepIndex, phase: ProcessPhase.MASHING_OUT, detail: {temperature: abmaischen.temperature, confirmationRequired: true} });
         controlStepIndex++;
     }
 
     // Kochen
-    processSteps.push({ name: 'Aufheizen auf Kochen', entryType: ProcessListEntryType.HEATING, controlStepIndex, phase: ProcessPhase.COOKING });
-    processSteps.push({ name: 'Kochen', entryType: ProcessListEntryType.PROCESS, controlStepIndex, phase: ProcessPhase.COOKING });
+    processSteps.push({ name: 'Aufheizen auf Kochen', entryType: ProcessListEntryType.HEATING, controlStepIndex, phase: ProcessPhase.COOKING, detail: {temperature: selectedBeer.cookingTemperatur} });
+    processSteps.push({ name: 'Kochen', entryType: ProcessListEntryType.PROCESS, controlStepIndex, phase: ProcessPhase.COOKING, detail: {temperature: selectedBeer.cookingTemperatur, duration: selectedBeer.cookingTime * 60} });
     controlStepIndex++;
 
     return processSteps;

--- a/src/containers/Production/ProcessList/ProcessList.tsx
+++ b/src/containers/Production/ProcessList/ProcessList.tsx
@@ -1,6 +1,4 @@
 import React from "react";
-import SimpleBar from 'simplebar-react';
-import 'simplebar-react/dist/simplebar.min.css';
 import './ProcessList.css';
 import {Beer, FermentationSteps} from "../../../model/Beer";
 import {RestExecutionMode} from "../../../enums/eRestExecutionMode";
@@ -131,13 +129,18 @@ export class ProcessList extends React.Component<ProcessListProps, ProcessListSt
         return activeStep?.name ?? this.props.currentStep?.name ?? 'Kein aktiver Prozessschritt';
     }
 
-    getCurrentStepMeta(activeStep: ProcessListStep | undefined): React.ReactNode {
+    getCurrentStepMeta(activeStep: ProcessListStep | undefined, isProcessStarted: boolean): React.ReactNode {
         const {brewingStatus, remainingSeconds} = this.props;
         const targetTemperature = brewingStatus?.temperature?.target ?? activeStep?.detail?.temperature;
         const isFinished = brewingStatus?.process?.state === ProcessState.FINISHED;
         const hasDuration = typeof brewingStatus?.currentStep?.duration === 'number' && brewingStatus.currentStep.duration > 0;
         const isWaiting = brewingStatus?.currentStep?.mode === ProcessMode.WAITING || (brewingStatus?.waiting?.waitingFor !== undefined && brewingStatus.waiting.waitingFor !== WaitingFor.NONE);
         const metaItems: React.ReactNode[] = [];
+
+        if (!isProcessStarted) {
+            metaItems.push(<span key="ready" className="current-step-time">Bereit zum Start</span>);
+            return <div className="current-step-meta">{metaItems}</div>;
+        }
 
         if (typeof targetTemperature === 'number' && Number.isFinite(targetTemperature) && targetTemperature > 0) {
             metaItems.push(<span key="temperature" className="current-step-temperature">{targetTemperature} °C</span>);
@@ -159,10 +162,11 @@ export class ProcessList extends React.Component<ProcessListProps, ProcessListSt
     render() {
         const { selectedBeer, onNextStep, isNextStepDisabled = false, brewingStatus } = this.props;
         const steps = createProcessSteps(selectedBeer);
-        const isIdle = brewingStatus === undefined || brewingStatus.process?.state === ProcessState.IDLE || steps.length === 0;
-        const stepIndex = isIdle ? -1 : this.effectiveStepIndex;
+        const hasRecipeProcess = steps.length > 0;
+        const isProcessStarted = brewingStatus !== undefined && brewingStatus.process?.state !== ProcessState.IDLE;
+        const stepIndex = isProcessStarted && hasRecipeProcess ? this.effectiveStepIndex : -1;
         const activeStep = stepIndex >= 0 ? steps[stepIndex] : undefined;
-        const upcomingSteps = stepIndex >= 0 ? steps.slice(stepIndex + 1) : [];
+        const upcomingSteps = stepIndex >= 0 ? steps.slice(stepIndex + 1) : steps;
         const progressLabel = stepIndex >= 0 ? `${stepIndex + 1} / ${steps.length}` : '';
 
         return (
@@ -184,16 +188,16 @@ export class ProcessList extends React.Component<ProcessListProps, ProcessListSt
                     ))}
                 </ul>
 
-                {isIdle ? (
-                    <div className="process-empty-state">Noch kein Brauvorgang gestartet.</div>
+                {!hasRecipeProcess ? (
+                    <div className="process-empty-state">Kein Bier für den Brauvorgang ausgewählt.</div>
                 ) : (
                     <>
                         <section className="current-process-step" aria-label="Aktueller Prozessschritt">
                             <div>
-                                <h4>{this.getCurrentStepTitle(activeStep)}</h4>
-                                <span className="current-step-badge">Aktiver Schritt</span>
+                                <h4>{isProcessStarted ? this.getCurrentStepTitle(activeStep) : 'Noch kein Brauvorgang gestartet'}</h4>
+                                <span className="current-step-badge">{isProcessStarted ? 'Aktiver Schritt' : 'Geplanter Ablauf'}</span>
                             </div>
-                            {this.getCurrentStepMeta(activeStep)}
+                            {this.getCurrentStepMeta(activeStep, isProcessStarted)}
                         </section>
 
                         <section className="upcoming-process" aria-label="Weiterer Ablauf">

--- a/src/containers/Production/ProcessList/ProcessList.tsx
+++ b/src/containers/Production/ProcessList/ProcessList.tsx
@@ -146,33 +146,109 @@ export class ProcessList extends React.Component<ProcessListProps, ProcessListSt
         return <div className="current-step-meta">{metaItems}</div>;
     }
 
-    getRemainingTimeText(): string {
-        const {brewingStatus, remainingSeconds} = this.props;
-        const isFinished = brewingStatus?.process?.state === ProcessState.FINISHED;
-        const hasDuration = typeof brewingStatus?.currentStep?.duration === 'number' && brewingStatus.currentStep.duration > 0;
-        const isWaiting = brewingStatus?.currentStep?.mode === ProcessMode.WAITING || (brewingStatus?.waiting?.waitingFor !== undefined && brewingStatus.waiting.waitingFor !== WaitingFor.NONE);
-
-        if (isFinished) {
-            return TimeFormatter.formatSecondsToHMS(0);
-        }
-        if (isWaiting) {
-            return 'Wartet auf Bestätigung';
-        }
-        if (hasDuration && typeof remainingSeconds === 'number') {
-            return TimeFormatter.formatSecondsToHMS(remainingSeconds);
-        }
-        return 'Keine feste Dauer';
+    isHeatingStatus(): boolean {
+        return this.props.brewingStatus?.currentStep?.mode === ProcessMode.HEATING;
     }
 
-    renderRemainingTimeSection(isProcessStarted: boolean): React.ReactNode {
-        if (!isProcessStarted) {
+    isWaitingStatus(): boolean {
+        const waitingFor = this.props.brewingStatus?.waiting?.waitingFor;
+        return this.props.brewingStatus?.currentStep?.mode === ProcessMode.WAITING || (waitingFor !== undefined && waitingFor !== WaitingFor.NONE);
+    }
+
+    isTimedStatus(): boolean {
+        const duration = Number(this.props.brewingStatus?.currentStep?.duration);
+        return this.props.brewingStatus?.process?.state === ProcessState.ACTIVE
+            && this.props.brewingStatus.currentStep?.mode === ProcessMode.TIMER_RUNNING
+            && Number.isFinite(duration)
+            && duration > 0;
+    }
+
+    formatTemperature(value: number): string {
+        return value.toLocaleString('de-DE', {maximumFractionDigits: 1});
+    }
+
+    renderTemperatureProgress(): React.ReactNode {
+        const currentTemperature = Number(this.props.brewingStatus?.temperature?.current);
+        const targetTemperature = Number(this.props.brewingStatus?.temperature?.target);
+        if (!Number.isFinite(currentTemperature) || currentTemperature <= 0 || !Number.isFinite(targetTemperature) || targetTemperature <= 0) {
             return null;
         }
 
+        return <span className="current-step-status-detail">{this.formatTemperature(currentTemperature)} °C von {this.formatTemperature(targetTemperature)} °C</span>;
+    }
+
+    getRemainingTimeText(): string | undefined {
+        const {remainingSeconds} = this.props;
+        if (!this.isTimedStatus() || typeof remainingSeconds !== 'number') {
+            return undefined;
+        }
+        return TimeFormatter.formatSecondsToHMS(Math.max(0, remainingSeconds));
+    }
+
+    renderStatusSection(isProcessStarted: boolean): React.ReactNode {
+        if (!isProcessStarted) {
+            return <div className="current-step-status current-step-status--reserved" aria-label="Statusbereich" />;
+        }
+        if (this.props.brewingStatus?.process?.state === ProcessState.FINISHED) {
+            return (
+                <div className="current-step-status" aria-label="Statusbereich">
+                    <span className="current-step-status-label">Status</span>
+                    <span className="current-step-status-value">Brauvorgang abgeschlossen</span>
+                </div>
+            );
+        }
+        if (this.isHeatingStatus()) {
+            return (
+                <div className="current-step-status" aria-label="Statusbereich">
+                    <span className="current-step-status-label">Status</span>
+                    <span className="current-step-status-value">Zieltemperatur wird erreicht</span>
+                    {this.renderTemperatureProgress()}
+                </div>
+            );
+        }
+        if (this.isWaitingStatus()) {
+            return (
+                <div className="current-step-status" aria-label="Statusbereich">
+                    <span className="current-step-status-label">Status</span>
+                    <span className="current-step-status-value">Wartet auf Bestätigung</span>
+                </div>
+            );
+        }
+        if (!this.isTimedStatus()) {
+            return (
+                <div className="current-step-status" aria-label="Statusbereich">
+                    <span className="current-step-status-label">Status</span>
+                    <span className="current-step-status-value">Schritt wird ausgeführt</span>
+                </div>
+            );
+        }
+
+        const progressPercent = this.getStepProgressPercent();
+        const remainingTimeText = this.getRemainingTimeText();
+        if (progressPercent === undefined || remainingTimeText === undefined) {
+            return (
+                <div className="current-step-status" aria-label="Statusbereich">
+                    <span className="current-step-status-label">Status</span>
+                    <span className="current-step-status-value">Schritt wird ausgeführt</span>
+                </div>
+            );
+        }
+
         return (
-            <div className="current-step-remaining" aria-label="Verbleibende Laufzeit">
-                <span className="current-step-remaining-label">Verbleibende Laufzeit</span>
-                <span className="current-step-remaining-value">Restzeit {this.getRemainingTimeText()}</span>
+            <div className="current-step-status" aria-label="Statusbereich">
+                <div className="current-step-progress" aria-label={`Fortschritt ${progressPercent}%`}>
+                    <div className="current-step-progress-header">
+                        <span>Fortschritt</span>
+                        <span>{progressPercent} %</span>
+                    </div>
+                    <div className="current-step-progress-track">
+                        <div className="current-step-progress-fill" style={{width: `${progressPercent}%`}} />
+                    </div>
+                </div>
+                <div className="current-step-remaining" aria-label="Restzeit">
+                    <span className="current-step-remaining-label">Restzeit</span>
+                    <span className="current-step-remaining-value">{remainingTimeText}</span>
+                </div>
             </div>
         );
     }
@@ -195,27 +271,6 @@ export class ProcessList extends React.Component<ProcessListProps, ProcessListSt
         return Math.min(100, Math.max(0, Math.round(elapsedFromRemaining * 100 / duration)));
     }
 
-    renderCurrentProgress(isProcessStarted: boolean): React.ReactNode {
-        if (!isProcessStarted) {
-            return null;
-        }
-        const progressPercent = this.getStepProgressPercent();
-        if (progressPercent === undefined) {
-            return null;
-        }
-
-        return (
-            <div className="current-step-progress" aria-label={`Fortschritt ${progressPercent}%`}>
-                <div className="current-step-progress-header">
-                    <span>Fortschritt</span>
-                    <span>{progressPercent} %</span>
-                </div>
-                <div className="current-step-progress-track">
-                    <div className="current-step-progress-fill" style={{width: `${progressPercent}%`}} />
-                </div>
-            </div>
-        );
-    }
     render() {
         const { selectedBeer, onNextStep, isNextStepDisabled = false, brewingStatus } = this.props;
         const steps = createProcessSteps(selectedBeer);
@@ -258,8 +313,7 @@ export class ProcessList extends React.Component<ProcessListProps, ProcessListSt
                                 </div>
                                 {this.getCurrentStepMeta(activeStep, isProcessStarted)}
                             </div>
-                            {this.renderCurrentProgress(isProcessStarted)}
-                            {this.renderRemainingTimeSection(isProcessStarted)}
+                            {this.renderStatusSection(isProcessStarted)}
                         </section>
 
                         <section className="upcoming-process" aria-label="Weiterer Ablauf">

--- a/src/containers/Production/ProcessList/ProcessList.tsx
+++ b/src/containers/Production/ProcessList/ProcessList.tsx
@@ -159,6 +159,45 @@ export class ProcessList extends React.Component<ProcessListProps, ProcessListSt
         return <div className="current-step-meta">{metaItems}</div>;
     }
 
+
+    getStepProgressPercent(): number | undefined {
+        const {brewingStatus, remainingSeconds} = this.props;
+        const duration = Number(brewingStatus?.currentStep?.duration);
+        if (!Number.isFinite(duration) || duration <= 0) {
+            return undefined;
+        }
+
+        const elapsedFromRemaining = typeof remainingSeconds === 'number'
+            ? duration - remainingSeconds
+            : Number(brewingStatus?.currentStep?.elapsedTime);
+        if (!Number.isFinite(elapsedFromRemaining)) {
+            return undefined;
+        }
+
+        return Math.min(100, Math.max(0, Math.round(elapsedFromRemaining * 100 / duration)));
+    }
+
+    renderCurrentProgress(isProcessStarted: boolean): React.ReactNode {
+        if (!isProcessStarted) {
+            return null;
+        }
+        const progressPercent = this.getStepProgressPercent();
+        if (progressPercent === undefined) {
+            return null;
+        }
+
+        return (
+            <div className="current-step-progress" aria-label={`Fortschritt ${progressPercent}%`}>
+                <div className="current-step-progress-header">
+                    <span>Fortschritt</span>
+                    <span>{progressPercent} %</span>
+                </div>
+                <div className="current-step-progress-track">
+                    <div className="current-step-progress-fill" style={{width: `${progressPercent}%`}} />
+                </div>
+            </div>
+        );
+    }
     render() {
         const { selectedBeer, onNextStep, isNextStepDisabled = false, brewingStatus } = this.props;
         const steps = createProcessSteps(selectedBeer);
@@ -192,12 +231,16 @@ export class ProcessList extends React.Component<ProcessListProps, ProcessListSt
                     <div className="process-empty-state">Kein Bier für den Brauvorgang ausgewählt.</div>
                 ) : (
                     <>
+                        <div className="current-process-label">Aktueller Schritt</div>
                         <section className="current-process-step" aria-label="Aktueller Prozessschritt">
-                            <div>
-                                <h4>{isProcessStarted ? this.getCurrentStepTitle(activeStep) : 'Noch kein Brauvorgang gestartet'}</h4>
-                                <span className="current-step-badge">{isProcessStarted ? 'Aktiver Schritt' : 'Geplanter Ablauf'}</span>
+                            <div className="current-step-heading">
+                                <div>
+                                    <h4>{isProcessStarted ? this.getCurrentStepTitle(activeStep) : 'Noch kein Brauvorgang gestartet'}</h4>
+                                    <span className="current-step-badge">{isProcessStarted ? 'Aktiver Schritt' : 'Geplanter Ablauf'}</span>
+                                </div>
+                                {this.getCurrentStepMeta(activeStep, isProcessStarted)}
                             </div>
-                            {this.getCurrentStepMeta(activeStep, isProcessStarted)}
+                            {this.renderCurrentProgress(isProcessStarted)}
                         </section>
 
                         <section className="upcoming-process" aria-label="Weiterer Ablauf">

--- a/src/containers/Production/ProcessList/ProcessList.tsx
+++ b/src/containers/Production/ProcessList/ProcessList.tsx
@@ -130,11 +130,8 @@ export class ProcessList extends React.Component<ProcessListProps, ProcessListSt
     }
 
     getCurrentStepMeta(activeStep: ProcessListStep | undefined, isProcessStarted: boolean): React.ReactNode {
-        const {brewingStatus, remainingSeconds} = this.props;
+        const {brewingStatus} = this.props;
         const targetTemperature = brewingStatus?.temperature?.target ?? activeStep?.detail?.temperature;
-        const isFinished = brewingStatus?.process?.state === ProcessState.FINISHED;
-        const hasDuration = typeof brewingStatus?.currentStep?.duration === 'number' && brewingStatus.currentStep.duration > 0;
-        const isWaiting = brewingStatus?.currentStep?.mode === ProcessMode.WAITING || (brewingStatus?.waiting?.waitingFor !== undefined && brewingStatus.waiting.waitingFor !== WaitingFor.NONE);
         const metaItems: React.ReactNode[] = [];
 
         if (!isProcessStarted) {
@@ -146,17 +143,38 @@ export class ProcessList extends React.Component<ProcessListProps, ProcessListSt
             metaItems.push(<span key="temperature" className="current-step-temperature">{targetTemperature} °C</span>);
         }
 
+        return <div className="current-step-meta">{metaItems}</div>;
+    }
+
+    getRemainingTimeText(): string {
+        const {brewingStatus, remainingSeconds} = this.props;
+        const isFinished = brewingStatus?.process?.state === ProcessState.FINISHED;
+        const hasDuration = typeof brewingStatus?.currentStep?.duration === 'number' && brewingStatus.currentStep.duration > 0;
+        const isWaiting = brewingStatus?.currentStep?.mode === ProcessMode.WAITING || (brewingStatus?.waiting?.waitingFor !== undefined && brewingStatus.waiting.waitingFor !== WaitingFor.NONE);
+
         if (isFinished) {
-            metaItems.push(<span key="remaining" className="current-step-time">Restzeit {TimeFormatter.formatSecondsToHMS(0)}</span>);
-        } else if (isWaiting) {
-            metaItems.push(<span key="waiting" className="current-step-time">Wartet auf Bestätigung</span>);
-        } else if (hasDuration && typeof remainingSeconds === 'number') {
-            metaItems.push(<span key="remaining" className="current-step-time">Restzeit {TimeFormatter.formatSecondsToHMS(remainingSeconds)}</span>);
-        } else {
-            metaItems.push(<span key="no-duration" className="current-step-time">Keine feste Dauer</span>);
+            return TimeFormatter.formatSecondsToHMS(0);
+        }
+        if (isWaiting) {
+            return 'Wartet auf Bestätigung';
+        }
+        if (hasDuration && typeof remainingSeconds === 'number') {
+            return TimeFormatter.formatSecondsToHMS(remainingSeconds);
+        }
+        return 'Keine feste Dauer';
+    }
+
+    renderRemainingTimeSection(isProcessStarted: boolean): React.ReactNode {
+        if (!isProcessStarted) {
+            return null;
         }
 
-        return <div className="current-step-meta">{metaItems}</div>;
+        return (
+            <div className="current-step-remaining" aria-label="Verbleibende Laufzeit">
+                <span className="current-step-remaining-label">Verbleibende Laufzeit</span>
+                <span className="current-step-remaining-value">Restzeit {this.getRemainingTimeText()}</span>
+            </div>
+        );
     }
 
 
@@ -241,6 +259,7 @@ export class ProcessList extends React.Component<ProcessListProps, ProcessListSt
                                 {this.getCurrentStepMeta(activeStep, isProcessStarted)}
                             </div>
                             {this.renderCurrentProgress(isProcessStarted)}
+                            {this.renderRemainingTimeSection(isProcessStarted)}
                         </section>
 
                         <section className="upcoming-process" aria-label="Weiterer Ablauf">

--- a/src/containers/Production/Production.test.tsx
+++ b/src/containers/Production/Production.test.tsx
@@ -480,26 +480,26 @@ describe('Production process overview countdown', () => {
     it('counts the remaining time down locally between controller status updates', () => {
         renderProduction({selectedBeer: createProcessBeer(), brewingStatus: createActiveTimedStatus(120)});
 
-        expect(screen.getByText('Restzeit 00:02:00')).toBeInTheDocument();
+        expect(screen.getByText('00:02:00')).toBeInTheDocument();
         jest.advanceTimersByTime(1000);
-        expect(screen.getByText('Restzeit 00:01:59')).toBeInTheDocument();
+        expect(screen.getByText('00:01:59')).toBeInTheDocument();
     });
 
     it('never displays a negative remaining time', () => {
         renderProduction({selectedBeer: createProcessBeer(), brewingStatus: createActiveTimedStatus(0)});
 
-        expect(screen.getByText('Restzeit 00:00:00')).toBeInTheDocument();
+        expect(screen.getByText('00:00:00')).toBeInTheDocument();
         jest.advanceTimersByTime(2000);
-        expect(screen.getByText('Restzeit 00:00:00')).toBeInTheDocument();
+        expect(screen.getByText('00:00:00')).toBeInTheDocument();
     });
 
     it('resynchronizes the countdown when a new controller status arrives', () => {
         const {rerender, props} = renderProduction({selectedBeer: createProcessBeer(), brewingStatus: createActiveTimedStatus(120)});
         jest.advanceTimersByTime(1000);
-        expect(screen.getByText('Restzeit 00:01:59')).toBeInTheDocument();
+        expect(screen.getByText('00:01:59')).toBeInTheDocument();
 
         rerender(<Production {...props} brewingStatus={createActiveTimedStatus(90)} />);
-        expect(screen.getByText('Restzeit 00:01:30')).toBeInTheDocument();
+        expect(screen.getByText('00:01:30')).toBeInTheDocument();
     });
 
     it('updates the active process card and remaining list on step changes', () => {

--- a/src/containers/Production/Production.test.tsx
+++ b/src/containers/Production/Production.test.tsx
@@ -438,3 +438,85 @@ describe('Production vessel content mapping', () => {
         expect(renderProduction({brewingStatus: makePhaseStatus(ProcessPhase.FINISHED)}).container.querySelector('.water-gauge--wort')).not.toBeNull();
     });
 });
+
+describe('Production process overview countdown', () => {
+    beforeEach(() => {
+        jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+        jest.useRealTimers();
+    });
+
+
+    const createProcessBeer = (): Beer => ({
+        ...createBeer(),
+        cookingTime: 60,
+        cookingTemperatur: 99,
+        fermentation: [
+            {type: 'Einmaischen', temperature: 57},
+            {type: 'Rast 1', temperature: 63, time: 1200},
+            {type: 'Rast 2', temperature: 72, time: 1800},
+            {type: 'Abmaischen', temperature: 78}
+        ]
+    });
+
+    const createActiveTimedStatus = (remainingTime: number, index = 2): BrewingStatus => ({
+        ...createBrewingStatus(ProcessState.ACTIVE),
+        currentStep: {
+            index,
+            count: 4,
+            phase: ProcessPhase.RAST,
+            mode: ProcessMode.TIMER_RUNNING,
+            name: 'Rast 1',
+            duration: 1200,
+            elapsedTime: 1200 - remainingTime,
+            remainingTime
+        },
+        temperature: {target: 63},
+        waiting: {waitingFor: WaitingFor.NONE, canConfirm: false}
+    });
+
+    it('counts the remaining time down locally between controller status updates', () => {
+        renderProduction({selectedBeer: createProcessBeer(), brewingStatus: createActiveTimedStatus(120)});
+
+        expect(screen.getByText('Restzeit 00:02:00')).toBeInTheDocument();
+        jest.advanceTimersByTime(1000);
+        expect(screen.getByText('Restzeit 00:01:59')).toBeInTheDocument();
+    });
+
+    it('never displays a negative remaining time', () => {
+        renderProduction({selectedBeer: createProcessBeer(), brewingStatus: createActiveTimedStatus(0)});
+
+        expect(screen.getByText('Restzeit 00:00:00')).toBeInTheDocument();
+        jest.advanceTimersByTime(2000);
+        expect(screen.getByText('Restzeit 00:00:00')).toBeInTheDocument();
+    });
+
+    it('resynchronizes the countdown when a new controller status arrives', () => {
+        const {rerender, props} = renderProduction({selectedBeer: createProcessBeer(), brewingStatus: createActiveTimedStatus(120)});
+        jest.advanceTimersByTime(1000);
+        expect(screen.getByText('Restzeit 00:01:59')).toBeInTheDocument();
+
+        rerender(<Production {...props} brewingStatus={createActiveTimedStatus(90)} />);
+        expect(screen.getByText('Restzeit 00:01:30')).toBeInTheDocument();
+    });
+
+    it('updates the active process card and remaining list on step changes', () => {
+        const {rerender, props} = renderProduction({selectedBeer: createProcessBeer(), brewingStatus: createActiveTimedStatus(120, 2)});
+        expect(screen.getAllByText('Rast 1').length).toBeGreaterThan(0);
+        expect(screen.getByText('4 / 11')).toBeInTheDocument();
+
+        rerender(<Production {...props} brewingStatus={createActiveTimedStatus(600, 3)} />);
+        expect(screen.getAllByText('Rast 2').length).toBeGreaterThan(0);
+        expect(screen.getByText('6 / 11')).toBeInTheDocument();
+    });
+
+    it('leaves the lower info bar free of runtime and target time labels', () => {
+        const {container} = renderProduction({selectedBeer: createProcessBeer(), brewingStatus: createActiveTimedStatus(120)});
+
+        expect(container.querySelector('.Info--empty')).toBeInTheDocument();
+        expect(screen.queryByText('Laufzeit')).not.toBeInTheDocument();
+        expect(screen.queryByText('Zielzeit')).not.toBeInTheDocument();
+    });
+});

--- a/src/containers/Production/Production.tsx
+++ b/src/containers/Production/Production.tsx
@@ -279,7 +279,7 @@ export class Production extends React.Component<ProductionProps, ProductionState
 
     shouldCountdownLocally = (aBrewingStatus?: BrewingStatus): boolean => {
         return aBrewingStatus?.process?.state === ProcessState.ACTIVE
-            && aBrewingStatus.currentStep?.mode !== ProcessMode.WAITING
+            && aBrewingStatus.currentStep?.mode === ProcessMode.TIMER_RUNNING
             && typeof aBrewingStatus.currentStep?.duration === 'number'
             && aBrewingStatus.currentStep.duration > 0;
     }

--- a/src/containers/Production/Production.tsx
+++ b/src/containers/Production/Production.tsx
@@ -95,6 +95,7 @@ interface ProductionState {
     currentFillLiters: number;
     activeFillWasOpened: boolean;
     isSpargeIncluded: boolean;
+    displayedRemainingSeconds: number | undefined;
 }
 
 export class Production extends React.Component<ProductionProps, ProductionState> {
@@ -108,6 +109,7 @@ export class Production extends React.Component<ProductionProps, ProductionState
     private readonly MIN_INTERVAL_TIME = 10;
     private readonly MAX_BREAK_TIME = 10;
     private readonly MAX_RUNNING_TIME = 10;
+    private remainingTimeInterval: NodeJS.Timeout | null = null;
 
     constructor(props: ProductionProps) {
         super(props);
@@ -142,7 +144,8 @@ export class Production extends React.Component<ProductionProps, ProductionState
             completedMashLiters: 0,
             currentFillLiters: 0,
             activeFillWasOpened: false,
-            isSpargeIncluded: false
+            isSpargeIncluded: false,
+            displayedRemainingSeconds: undefined
         }
     }
 
@@ -152,6 +155,15 @@ export class Production extends React.Component<ProductionProps, ProductionState
             this.calculateTheHopTimes();
         }
         getTemperatures();
+        this.syncRemainingTimeFromStatus();
+        this.remainingTimeInterval = setInterval(this.tickRemainingTime, 1000);
+    }
+
+    componentWillUnmount() {
+        if (this.remainingTimeInterval !== null) {
+            clearInterval(this.remainingTimeInterval);
+            this.remainingTimeInterval = null;
+        }
     }
 
 
@@ -159,6 +171,10 @@ export class Production extends React.Component<ProductionProps, ProductionState
         const {toggleAgitator, brewingStatus,isToggleAgitatorSuccess,isWaterFillingSuccessful, waterStatus} = this.props;
         const {intervalSwitchState, mainSwitchState, waterSwitchState,heatingAndStirringSwitchState,showHopsDialog,showFinishDialog, indexOfCurrentStep} = this.state;
 
+
+        if (prevProps.brewingStatus !== brewingStatus) {
+            this.syncRemainingTimeFromStatus();
+        }
 
         if (prevProps.selectedBeer !== this.props.selectedBeer) {
             this.resetRecipeWaterFillState({indexOfCurrentStep: 0});
@@ -240,6 +256,53 @@ export class Production extends React.Component<ProductionProps, ProductionState
 
     }
 
+
+    syncRemainingTimeFromStatus = (): void => {
+        const remainingSeconds = this.getRemainingSecondsFromStatus();
+        if (remainingSeconds !== this.state.displayedRemainingSeconds) {
+            this.setState({displayedRemainingSeconds: remainingSeconds});
+        }
+    }
+
+    tickRemainingTime = (): void => {
+        const {brewingStatus} = this.props;
+        if (!this.shouldCountdownLocally(brewingStatus)) {
+            return;
+        }
+        this.setState((prevState) => {
+            if (typeof prevState.displayedRemainingSeconds !== 'number') {
+                return null;
+            }
+            return {displayedRemainingSeconds: Math.max(0, prevState.displayedRemainingSeconds - 1)};
+        });
+    }
+
+    shouldCountdownLocally = (aBrewingStatus?: BrewingStatus): boolean => {
+        return aBrewingStatus?.process?.state === ProcessState.ACTIVE
+            && aBrewingStatus.currentStep?.mode !== ProcessMode.WAITING
+            && typeof aBrewingStatus.currentStep?.duration === 'number'
+            && aBrewingStatus.currentStep.duration > 0;
+    }
+
+    getRemainingSecondsFromStatus = (): number | undefined => {
+        const {brewingStatus} = this.props;
+        if (brewingStatus?.process?.state === ProcessState.FINISHED) {
+            return 0;
+        }
+        if (!this.shouldCountdownLocally(brewingStatus)) {
+            return undefined;
+        }
+        const statusRemainingTime = Number(brewingStatus?.currentStep?.remainingTime);
+        if (Number.isFinite(statusRemainingTime) && statusRemainingTime >= 0) {
+            return Math.max(0, Math.floor(statusRemainingTime));
+        }
+        const duration = Number(brewingStatus?.currentStep?.duration);
+        const elapsed = Number(brewingStatus?.currentStep?.elapsedTime);
+        if (Number.isFinite(duration) && Number.isFinite(elapsed)) {
+            return Math.max(0, Math.floor(duration - elapsed));
+        }
+        return undefined;
+    }
     checkForHopAddition() {
         const {hopsTimes, announcedHopTimes} = this.state;
         const {brewingStatus} = this.props;
@@ -604,42 +667,7 @@ export class Production extends React.Component<ProductionProps, ProductionState
     }
 
     renderInfo() {
-        const {brewingStatus} = this.props;
-        let elapsedTime = '----';
-        let targetTime = '----';
-       const currentElapsedTime = brewingStatus?.elapsedTime;
-       if(typeof currentElapsedTime === 'number' && !isNaN(currentElapsedTime))
-       {
-           elapsedTime = this.formatTime(currentElapsedTime);
-       }
-       const stepDuration = Number(brewingStatus?.currentStep?.duration);
-       if(Number.isFinite(stepDuration) && stepDuration > 0)
-       {
-           targetTime = this.formatTime(stepDuration);
-       }
-
-        if(targetTime )
-        return (
-            <div className="Info">
-                <div className="timeContainer">
-                    <div className="frame">
-                        <span className="label">Laufzeit</span>
-                        <span className="time">{elapsedTime}</span>
-                    </div>
-                </div>
-                <div className="timeContainer">
-                    <div className="frame">
-                        <span className="label">Zielzeit</span>
-                        <span className="time">{targetTime}</span>
-                    </div>
-                </div>
-                <div>
-                    {this.renderProgressBar()}
-                </div>
-                <div>
-
-                </div>
-            </div>);
+        return <div className="Info Info--empty" aria-label="Freier Produktionsbereich" />;
     }
 
     renderTemperature() {
@@ -878,7 +906,7 @@ export class Production extends React.Component<ProductionProps, ProductionState
     renderProcessList() {
         const { selectedBeer, brewingStatus } = this.props;
         return (
-            <ProcessList selectedBeer={selectedBeer} currentStepIndex={brewingStatus?.currentStep?.index ?? 0} currentStep={brewingStatus?.currentStep} onNextStep={this.handleNextProcedureStep} isNextStepDisabled={!this.isNextProcedureStepAvailable()} />
+            <ProcessList selectedBeer={selectedBeer} currentStepIndex={brewingStatus?.currentStep?.index ?? 0} currentStep={brewingStatus?.currentStep} brewingStatus={brewingStatus} remainingSeconds={this.state.displayedRemainingSeconds} onNextStep={this.handleNextProcedureStep} isNextStepDisabled={!this.isNextProcedureStepAvailable()} />
         );
     }
 

--- a/src/utils/TimeFormatter.ts
+++ b/src/utils/TimeFormatter.ts
@@ -8,6 +8,6 @@ export class TimeFormatter {
         const h = Math.floor(seconds / 3600);
         const m = Math.floor((seconds % 3600) / 60);
         const s = Math.floor(seconds % 60);
-        return `${h}:${m.toString().padStart(2, '0')}:${s.toString().padStart(2, '0')}`;
+        return `${h.toString().padStart(2, '0')}:${m.toString().padStart(2, '0')}:${s.toString().padStart(2, '0')}`;
     }
 }


### PR DESCRIPTION
### Motivation
- Replace the old dual `Laufzeit`/`Zielzeit` UI with a single backwards-counting remaining-time display and make the process card show the active step, its remaining time and the ordered upcoming steps in a compact visual style. 
- Keep all process ordering, timing and status logic derived from existing recipe data and normalized `brewingStatus` values without inventing new backend/state contracts.
- Ensure the card remains compact and scrollable for many subsequent steps and that waiting/confirmation and durationless steps are handled correctly.

### Description
- Implemented a compact process card component and visuals in `ProcessList` with a header `Prozess`, a dynamic progress label (`aktuelle Schrittnummer / Gesamtzahl`), a highlighted current step area and a vertically scrollable `Weiterer Ablauf` list showing remaining steps and per-step metadata (`temperature`, `duration`, `Bestätigung erforderlich`). (modified: `src/containers/Production/ProcessList/ProcessList.tsx`, `src/containers/Production/ProcessList/ProcessList.css`)
- Reused and extended `createProcessSteps(selectedBeer)` as the single source of visible process order and added non-invasive `detail` metadata (temperature, duration, confirmation flag) for list presentation only. (modified: `src/containers/Production/ProcessList/ProcessList.tsx`)
- Replaced bottom `Laufzeit`/`Zielzeit` cards in `Production` with an intentionally empty info area and added synchronization + a safe local 1s tick to decrement the displayed remaining time between controller updates while resyncing on each new controller status; remaining-time is computed from `currentStep.remainingTime` or `duration - elapsedTime` and clamped to >= 0. (modified: `src/containers/Production/Production.tsx`)
- Display rules: show `Restzeit HH:MM:SS` for timed steps, show `Wartet auf Bestätigung` for waiting/confirmation steps, show `Keine feste Dauer` for steps without duration; never display negative times. (modified: `src/containers/Production/ProcessList/ProcessList.tsx`, `src/containers/Production/Production.tsx`)
- Minor utility change: `TimeFormatter` now formats hours always with two digits to match `HH:MM:SS`. (modified: `src/utils/TimeFormatter.ts`)
- Tests: extended/added unit tests for the compact process overview and local countdown behavior with fake timers; tests cover progress label, upcoming-step ordering and details, single remaining-time display, waiting/durationless steps, finished/idle states, scroll area and that the bottom info bar no longer shows Laufzeit/Zielzeit. (modified: `src/containers/Production/ProcessList/ProcessList.test.tsx`, `src/containers/Production/Production.test.tsx`)

### Testing
- Ran repository checks: `git diff --check` passed and changes were committed; tests were updated and added as noted above. 
- Attempted unit test run `npm test -- --runTestsByPath src/containers/Production/ProcessList/ProcessList.test.tsx src/containers/Production/Production.test.tsx` but the environment lacked an installed `react-scripts` / full `node_modules`, so the test runner could not be executed here (dependency installation in this environment failed/was blocked). 
- Attempted TypeScript check `npx tsc --noEmit` but the run was blocked by existing tsconfig deprecation warnings in this environment (global TypeScript/tsconfig compatibility), so a full compile check was not completed here.

Notes: all runtime logic reads from existing `brewingStatus` fields and recipe-derived `createProcessSteps`; no API contracts were changed and no derived timing values are persisted in Redux. The tests use fake timers where a running countdown is asserted. Please run the full test suite and TypeScript compile (`npm install && npm test && npx tsc --noEmit`) in CI or a local environment to validate before merging.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a60ad6c2b74832fbeaa60bfacf340ae)