### PR TITLE
Fix beer form submit validation flow

### DIFF
--- a/src/containers/DatabaseOverview/BeerForm.test.tsx
+++ b/src/containers/DatabaseOverview/BeerForm.test.tsx
@@ -1,28 +1,69 @@
 import React from 'react';
 import {fireEvent, render, screen} from '@testing-library/react';
 import {BeerForm} from './BeerForm';
+import {HopUsage} from '../../enums/eHopUsage';
+import {HopTimeUnit} from '../../enums/eHopTimeUnit';
 
-const renderBeerForm = () => {
+const baseProps: React.ComponentProps<typeof BeerForm> = {
+    onSubmitBeer: jest.fn(),
+    getMalt: jest.fn(),
+    getHop: jest.fn(),
+    getYeast: jest.fn(),
+    getAdditionalIngredients: jest.fn(),
+    saveBeerFormState: jest.fn(),
+    malts: [{id: 'm1', name: 'Pilsner Malz', description: '', EBC: 4, quantity: 0}],
+    hops: [{id: 'h1', name: 'Hallertauer Mittelfrüh', description: '', alpha: 4, quantity: 0, time: 0}],
+    yeasts: [{id: 'y1', name: 'SafAle US-05', description: '', EVG: '75', temperature: '18', type: 'Obergärig', quantity: 0}],
+    additionalIngredients: [{id: 'a1', name: 'Koriandersamen', description: ''}],
+    isSubmitSuccessful: undefined,
+    messageType: '',
+    message: '',
+    beers: [],
+    importBeer: jest.fn(),
+    isSavingBeer: false,
+};
+
+const renderBeerForm = (overrides: Partial<React.ComponentProps<typeof BeerForm>> = {}) => {
     const props: React.ComponentProps<typeof BeerForm> = {
+        ...baseProps,
         onSubmitBeer: jest.fn(),
         getMalt: jest.fn(),
         getHop: jest.fn(),
         getYeast: jest.fn(),
         getAdditionalIngredients: jest.fn(),
         saveBeerFormState: jest.fn(),
-        malts: [{id: 'm1', name: 'Pilsner Malz', description: '', EBC: 4, quantity: 0}],
-        hops: [{id: 'h1', name: 'Hallertauer Mittelfrüh', description: '', alpha: 4, quantity: 0, time: 0}],
-        yeasts: [{id: 'y1', name: 'SafAle US-05', description: '', EVG: '75', temperature: '18', type: 'Obergärig', quantity: 0}],
-        additionalIngredients: [{id: 'a1', name: 'Koriandersamen', description: ''}],
-        isSubmitSuccessful: true,
-        messageType: '',
-        message: '',
-        beers: [],
         importBeer: jest.fn(),
-        isSavingBeer: false,
+        ...overrides,
     };
 
     return {props, ...render(<BeerForm {...props} />)};
+};
+
+const fillValidRecipe = () => {
+    fireEvent.change(screen.getByLabelText(/Name:/), {target: {value: 'Helles'}});
+    fireEvent.change(screen.getByLabelText(/Typ:/), {target: {value: 'Lager'}});
+    fireEvent.change(screen.getByLabelText(/Bitterkeit:/), {target: {value: '25'}});
+    fireEvent.change(screen.getByLabelText(/Alkoholgehalt:/), {target: {value: '5.2'}});
+    fireEvent.change(screen.getByLabelText(/Stammwürze:/), {target: {value: '12.5'}});
+    fireEvent.change(screen.getByLabelText(/Hauptguss/), {target: {value: '20'}});
+    fireEvent.change(screen.getByLabelText(/Nachguss/), {target: {value: '10'}});
+    fireEvent.change(screen.getByLabelText(/Kochzeit/), {target: {value: '60'}});
+    fireEvent.change(screen.getByLabelText(/Kochtemperatur/), {target: {value: '99'}});
+
+    fireEvent.click(screen.getByRole('button', {name: /Malze/}));
+    fireEvent.change(screen.getByDisplayValue('Malz'), {target: {value: 'Pilsner Malz'}});
+    fireEvent.change(screen.getAllByRole('spinbutton').find((input) => input.getAttribute('name') === 'quantity')!, {target: {value: '4000'}});
+
+    fireEvent.click(screen.getByRole('button', {name: /Hopfen/}));
+    fireEvent.change(screen.getByDisplayValue('Hopfen'), {target: {value: 'Hallertauer Mittelfrüh'}});
+    const hopQuantity = screen.getAllByRole('spinbutton').filter((input) => input.getAttribute('name') === 'quantity')[1];
+    fireEvent.change(hopQuantity, {target: {value: '50'}});
+    fireEvent.change(screen.getByDisplayValue('0'), {target: {value: '60'}});
+
+    fireEvent.click(screen.getByRole('button', {name: /Hefe/}));
+    fireEvent.change(screen.getByDisplayValue('Hefe'), {target: {value: 'SafAle US-05'}});
+    const yeastQuantity = screen.getAllByRole('spinbutton').filter((input) => input.getAttribute('name') === 'quantity')[2];
+    fireEvent.change(yeastQuantity, {target: {value: '1'}});
 };
 
 describe('BeerForm accordions', () => {
@@ -57,7 +98,66 @@ describe('BeerForm accordions', () => {
         expect(screen.getByRole('button', {name: /Malze.*Fehler/i})).toHaveAttribute('aria-expanded', 'true');
         expect(screen.getByRole('button', {name: /Hopfen.*Fehler/i})).toHaveAttribute('aria-expanded', 'true');
         expect(screen.getByRole('button', {name: /Hefe.*Fehler/i})).toHaveAttribute('aria-expanded', 'true');
+        expect(screen.getByText(/Bitte korrigiere die markierten Pflichtfelder/)).toBeInTheDocument();
         expect(props.onSubmitBeer).not.toHaveBeenCalled();
+    });
+
+    it('submits a new beer exactly once with the complete create/update payload', () => {
+        const {props} = renderBeerForm();
+        fillValidRecipe();
+
+        fireEvent.click(screen.getByRole('button', {name: /Rezept speichern/}));
+
+        expect(props.onSubmitBeer).toHaveBeenCalledTimes(1);
+        expect(props.onSubmitBeer).toHaveBeenCalledWith(expect.objectContaining({
+            id: '',
+            name: 'Helles',
+            type: 'Lager',
+            alcohol: 5.2,
+            originalwort: 12.5,
+            bitterness: 25,
+            mashVolume: 20,
+            spargeVolume: 10,
+            cookingTime: 60,
+            cookingTemperatur: 99,
+            malts: [{id: 'm1', name: 'Pilsner Malz', quantity: 4000}],
+            wortBoiling: {totalTime: 0, hops: [{id: 'h1', name: 'Hallertauer Mittelfrüh', quantity: 50, time: 60, usage: HopUsage.BOIL, timeUnit: HopTimeUnit.MINUTES}]},
+            fermentationMaturation: {fermentationTemperature: 0, carbonation: 0, yeast: [{id: 'y1', name: 'SafAle US-05', quantity: 1}]},
+        }));
+    });
+
+    it('submits an existing beer with its id after selecting it for editing', () => {
+        const existingBeer: React.ComponentProps<typeof BeerForm>['beers'][number] = {
+            id: 'beer-1', name: 'Alt', type: 'Ale', color: 'amber', alcohol: 5, originalwort: 12, bitterness: 30, description: '', rating: 3,
+            mashVolume: 18, spargeVolume: 8, cookingTime: 60, cookingTemperatur: 99,
+            fermentation: [{type: 'Einmaischen', temperature: 65, time: 0}, {type: 'Abmaischen', temperature: 78, time: 0}, {type: 'Kochen', temperature: 99, time: 0}],
+            malts: [{id: 'm1', name: 'Pilsner Malz', description: '', EBC: 4, quantity: 4000}],
+            wortBoiling: {totalTime: 60, hops: [{id: 'h1', name: 'Hallertauer Mittelfrüh', description: '', alpha: 4, quantity: 50, time: 60, usage: HopUsage.BOIL, timeUnit: HopTimeUnit.MINUTES}]},
+            fermentationMaturation: {fermentationTemperature: 18, carbonation: 5, yeast: [{id: 'y1', name: 'SafAle US-05', description: '', EVG: '75', temperature: '18', type: 'Obergärig', quantity: 1}]},
+            additionalIngredients: [],
+        };
+        const {props} = renderBeerForm({beers: [existingBeer]});
+
+        fireEvent.change(screen.getByLabelText(/Bier auswählen/), {target: {value: 'beer-1'}});
+        fireEvent.change(screen.getByLabelText(/Name:/), {target: {value: 'Altbier'}});
+        fireEvent.click(screen.getByRole('button', {name: /Rezept speichern/}));
+
+        expect(props.onSubmitBeer).toHaveBeenCalledTimes(1);
+        expect(props.onSubmitBeer).toHaveBeenCalledWith(expect.objectContaining({id: 'beer-1', name: 'Altbier'}));
+    });
+
+    it('keeps the submit button disabled while saving to prevent duplicate submits', () => {
+        renderBeerForm({isSavingBeer: true});
+
+        expect(screen.getByRole('button', {name: /Speichern/})).toBeDisabled();
+    });
+
+    it('shows success and error messages supplied by the save flow', () => {
+        const {rerender, props} = renderBeerForm({isSubmitSuccessful: true, message: 'Gespeichert'});
+        expect(screen.getByText('Gespeichert')).toBeInTheDocument();
+
+        rerender(<BeerForm {...props} isSubmitSuccessful={false} message="Fehler beim Speichern" />);
+        expect(screen.getByText('Fehler beim Speichern')).toBeInTheDocument();
     });
 
     it('keeps add and delete actions available in table sections', () => {

--- a/src/containers/DatabaseOverview/BeerForm.tsx
+++ b/src/containers/DatabaseOverview/BeerForm.tsx
@@ -31,9 +31,9 @@ interface BeerFormProps {
     hops: Hop[];
     yeasts: Yeast[];
     additionalIngredients: AdditionalIngredient[];
-    isSubmitSuccessful: boolean;
-    messageType: string;
-    message: string;
+    isSubmitSuccessful?: boolean;
+    messageType?: string;
+    message?: string;
     beerFormState?: any;
     beers: Beer[];
     importBeer: (file: File) => void;
@@ -62,7 +62,7 @@ interface BeerFormState {
     hopsDTO: HopDTO[];
     yeastsDTO: YeastDTO[];
     additionalIngredientsDTO: AdditionalIngredientDTO[];
-    isSubmitSuccessful: boolean;
+    isSubmitSuccessful?: boolean;
     missingMalts?: string[];
     missingHops?: string[];
     missingYeasts?: string[];
@@ -103,7 +103,7 @@ export class BeerForm extends React.Component<BeerFormProps, BeerFormState> {
             hopsDTO: [{ id: '', name: '', quantity: undefined as any, time: 0, usage: HopUsage.BOIL, timeUnit: HopTimeUnit.MINUTES }],
             yeastsDTO: [{ id: '', name: '', quantity: undefined as any }],
             additionalIngredientsDTO: [],
-            isSubmitSuccessful: false,
+            isSubmitSuccessful: undefined,
             showValidationDialog: false,
             validationDialogMessage: '',
             validationErrors: {},
@@ -144,8 +144,8 @@ export class BeerForm extends React.Component<BeerFormProps, BeerFormState> {
 
     componentDidUpdate(prevProps: Readonly<BeerFormProps>, prevState: Readonly<BeerFormState>, snapshot?: any) {
         const {isSubmitSuccessful, importedBeer} = this.props;
-        if (!isEqual(this.state.isSubmitSuccessful,prevState.isSubmitSuccessful)) {
-            this.setState({isSubmitSuccessful:isSubmitSuccessful});
+        if (!isEqual(isSubmitSuccessful, prevProps.isSubmitSuccessful)) {
+            this.setState({isSubmitSuccessful});
         }
 
         // Wenn importedBeer gesetzt ist und sich geändert hat, Formular mit importierten Daten füllen
@@ -172,7 +172,7 @@ export class BeerForm extends React.Component<BeerFormProps, BeerFormState> {
                 yeastsDTO: importedBeer.fermentationMaturation && importedBeer.fermentationMaturation.yeast ? importedBeer.fermentationMaturation.yeast.map(y => ({ id: y.id, name: y.name, quantity: y.quantity })) : [],
                 // Alte Rezepte ohne additionalIngredients bleiben kompatibel und werden als leere Liste geführt.
                 additionalIngredientsDTO: importedBeer.additionalIngredients ? importedBeer.additionalIngredients.map(aIngredient => this.normalizeAdditionalIngredient(aIngredient)) : [],
-                isSubmitSuccessful: false,
+                isSubmitSuccessful: undefined,
             }, () => {
                 this.props.saveBeerFormState(this.state);
             });
@@ -378,9 +378,37 @@ export class BeerForm extends React.Component<BeerFormProps, BeerFormState> {
 
 
 
+    validateRequiredRecipeFields = () => {
+        const validationErrors: Record<string, string> = {};
+        const requiredTextError = 'Bitte ausfüllen.';
+        const requiredNumberError = 'Bitte einen gültigen Wert größer als 0 eingeben.';
+
+        if (!this.state.name.trim()) validationErrors.name = requiredTextError;
+        if (!this.state.type.trim()) validationErrors.type = requiredTextError;
+
+        ['bitterness', 'alcohol', 'originalwort', 'mashVolume', 'spargeVolume', 'cookingTime', 'cookingTemperatur'].forEach((field) => {
+            const value = this.state[field as keyof BeerFormState];
+            const parsed = Number(value);
+            if (!Number.isFinite(parsed) || parsed <= 0) {
+                validationErrors[field] = requiredNumberError;
+            }
+        });
+
+        const expandedSections = { ...this.state.expandedSections };
+        if (validationErrors.name || validationErrors.type) expandedSections.basic = true;
+        if (validationErrors.bitterness || validationErrors.alcohol || validationErrors.originalwort) expandedSections.basic = true;
+        if (validationErrors.mashVolume || validationErrors.spargeVolume || validationErrors.cookingTime || validationErrors.cookingTemperatur) expandedSections.brewing = true;
+
+        this.setState((prevState) => ({validationErrors: {...prevState.validationErrors, ...validationErrors}, expandedSections}));
+        return validationErrors;
+    };
+
+    renderInputError = (aKey: string) => this.renderFieldError(aKey);
+
     handleSubmit = (e: FormEvent) => {
-        const {malts,hops,yeasts} = this.props;
+        const {malts,hops,yeasts, isSavingBeer} = this.props;
         e.preventDefault();
+        if (isSavingBeer) return;
         const {
             id,
             name,
@@ -402,6 +430,11 @@ export class BeerForm extends React.Component<BeerFormProps, BeerFormState> {
             additionalIngredientsDTO,
         } = this.state;
         const quantityValidationErrors = this.validateIngredientQuantities();
+        const requiredValidationErrors = this.validateRequiredRecipeFields();
+        if (Object.keys(requiredValidationErrors).length > 0) {
+            this.openValidationDialog('Bitte korrigiere die markierten Pflichtfelder.');
+            return;
+        }
         if (Object.keys(quantityValidationErrors).length > 0) {
             this.openValidationDialog('Bitte korrigiere die markierten Mengenfelder. Mengen sind erforderlich und müssen größer als 0 sein.');
             return;
@@ -480,7 +513,6 @@ export class BeerForm extends React.Component<BeerFormProps, BeerFormState> {
                 .map((aIngredient) => ({...aIngredient, quantity: Number(aIngredient.quantity)}))
         };
 
-        console.log(beer);
         this.props.onSubmitBeer(beer);
     };
 
@@ -642,7 +674,7 @@ export class BeerForm extends React.Component<BeerFormProps, BeerFormState> {
                 yeastsDTO: selectedBeer.fermentationMaturation && selectedBeer.fermentationMaturation.yeast ? selectedBeer.fermentationMaturation.yeast.map(y => ({ id: y.id, name: y.name, quantity: y.quantity })) : [],
                 // Für alte DB-Einträge ohne Feld wird bewusst [] gesetzt.
                 additionalIngredientsDTO: selectedBeer.additionalIngredients ? selectedBeer.additionalIngredients.map(aIngredient => this.normalizeAdditionalIngredient(aIngredient)) : [],
-                isSubmitSuccessful: false,
+                isSubmitSuccessful: undefined,
             }, () => {
                 this.props.saveBeerFormState(this.state);
             });
@@ -712,19 +744,19 @@ export class BeerForm extends React.Component<BeerFormProps, BeerFormState> {
 
         let info: string = "";
         if (isEqual(isSubmitSuccessful, true)) {
-            info = "Beer created successfully";
+            info = this.props.message || "Beer saved successfully";
         } else if (isSubmitSuccessful === false) {
-            info = "Beer creation failed";
+            info = this.props.message || "Beer creation failed";
         }
 
         const basicContent = (
             <div className="beer-form-grid">
-                <label>Name:<input type="text" name="name" className="field-name" value={name} onChange={this.handleChange} required={true} maxLength={15} /></label>
-                <label>Typ:<input type="text" name="type" className="field-type" value={type} onChange={this.handleChange} required={true} maxLength={10} /></label>
+                <label>Name:<input type="text" name="name" className="field-name" value={name} onChange={this.handleChange} required={true} maxLength={15} />{this.renderInputError('name')}</label>
+                <label>Typ:<input type="text" name="type" className="field-type" value={type} onChange={this.handleChange} required={true} maxLength={10} />{this.renderInputError('type')}</label>
                 <label>Farbe:<input type="text" name="color" className="field-color" value={color} onChange={this.handleChange} maxLength={4} /></label>
-                <label>Bitterkeit:<input type="number" name="bitterness" className="field-number-small" value={bitterness} min={0} step={0.1} onChange={this.handleChange} required={true} max={99} /></label>
-                <label>Alkoholgehalt:<input type="number" name="alcohol" className="field-number-small" value={alcohol} min={0} step={0.1} onChange={this.handleChange} required={true} max={99} /></label>
-                <label>Stammwürze:<input type="number" name="originalwort" className="field-number-small" value={originalwort} min={0} step={0.1} onChange={this.handleChange} required={true} max={99} /></label>
+                <label>Bitterkeit:<input type="number" name="bitterness" className="field-number-small" value={bitterness} min={0} step={0.1} onChange={this.handleChange} required={true} max={99} />{this.renderInputError('bitterness')}</label>
+                <label>Alkoholgehalt:<input type="number" name="alcohol" className="field-number-small" value={alcohol} min={0} step={0.1} onChange={this.handleChange} required={true} max={99} />{this.renderInputError('alcohol')}</label>
+                <label>Stammwürze:<input type="number" name="originalwort" className="field-number-small" value={originalwort} min={0} step={0.1} onChange={this.handleChange} required={true} max={99} />{this.renderInputError('originalwort')}</label>
                 <label>Bewertung:<input type="number" name="rating" className="field-number-small" value={rating} min={0} max={5} onChange={this.handleChange} /></label>
                 <label className="full-width">Beschreibung:<textarea name="description" className="beer-description" value={description} onChange={this.handleChange} /></label>
             </div>
@@ -732,10 +764,10 @@ export class BeerForm extends React.Component<BeerFormProps, BeerFormState> {
 
         const brewingContent = (
             <div className="beer-form-grid brewing-data-grid">
-                <label>Hauptguss (l):<input type="number" name="mashVolume" className="field-number-small" min={0} value={mashVolume} step={0.1} onChange={this.handleChange} required={true} max={99} /></label>
-                <label>Nachguss (l):<input type="number" name="spargeVolume" className="field-number-small" min={0} step={0.1} value={spargeVolume} onChange={this.handleChange} required={true} max={99} /></label>
-                <label>Kochzeit (min):<input type="number" name="cookingTime" className="field-number-medium" min={0} value={cookingTime} onChange={this.handleChange} required={true} max={999} /></label>
-                <label>Kochtemperatur:<input type="number" name="cookingTemperatur" className="field-number-small" min={1} value={cookingTemperatur} onChange={this.handleChange} required={true} max={99} /></label>
+                <label>Hauptguss (l):<input type="number" name="mashVolume" className="field-number-small" min={0} value={mashVolume} step={0.1} onChange={this.handleChange} required={true} max={99} />{this.renderInputError('mashVolume')}</label>
+                <label>Nachguss (l):<input type="number" name="spargeVolume" className="field-number-small" min={0} step={0.1} value={spargeVolume} onChange={this.handleChange} required={true} max={99} />{this.renderInputError('spargeVolume')}</label>
+                <label>Kochzeit (min):<input type="number" name="cookingTime" className="field-number-medium" min={0} value={cookingTime} onChange={this.handleChange} required={true} max={999} />{this.renderInputError('cookingTime')}</label>
+                <label>Kochtemperatur:<input type="number" name="cookingTemperatur" className="field-number-small" min={1} value={cookingTemperatur} onChange={this.handleChange} required={true} max={99} />{this.renderInputError('cookingTemperatur')}</label>
             </div>
         );
 
@@ -795,7 +827,7 @@ export class BeerForm extends React.Component<BeerFormProps, BeerFormState> {
         );
 
         return (
-            <form id="beer-recipe-form" className="beer-form" onSubmit={this.handleSubmit}>
+            <form id="beer-recipe-form" className="beer-form" onSubmit={this.handleSubmit} noValidate>
                 <input type="file" accept="application/json" className="visually-hidden-file" ref={ref => this.fileInput = ref} onChange={this.handleImportBeerJson} />
                 <div className="beer-form-toolbar">
                     <div className="beer-form-toolbar-title">Rezept</div>
@@ -850,7 +882,7 @@ export class BeerForm extends React.Component<BeerFormProps, BeerFormState> {
                         <span>Bier</span>
                         <div className="beer-form-panel-actions">
                             <button type="button" className="add-button brauhaus-button brauhaus-button-secondary secondary-action" onClick={this.resetForm}>Abbrechen / Zurücksetzen</button>
-                            <button className="finish-btn brauhaus-button brauhaus-button-primary submit-button primary-action" type="submit" form="beer-recipe-form" disabled={this.props.isSavingBeer}>💾 Rezept speichern</button>
+                            <button className="finish-btn brauhaus-button brauhaus-button-primary submit-button primary-action" type="submit" form="beer-recipe-form" disabled={this.props.isSavingBeer}>{this.props.isSavingBeer ? '⏳ Speichern...' : '💾 Rezept speichern'}</button>
                         </div>
                     </div>
                     <div className="beer-form-scroll">{this.renderCreateBeerForm()}</div>


### PR DESCRIPTION
### Motivation
- Native browser form validation could block submit silently for hidden/accordion fields so the React `onSubmit` was never reached and no API request was sent.  
- The form needed visible, centralized validation, a guard against duplicate submits, and proper propagation of success/error messages from Redux.  
- Changes must preserve existing Redux/epic/repository flow (dispatch `SUBMIT_BEER`, epic calls repository which issues `POST`/`PUT`).

### Description
- Disable native browser validation and run explicit React validation by adding `noValidate` to the `<form>` and a new `validateRequiredRecipeFields` method in `src/containers/DatabaseOverview/BeerForm.tsx`.  
- Show per-field validation errors (`renderInputError` / `renderFieldError`) and automatically expand affected accordion sections so users see why submit was blocked.  
- Prevent duplicate submits by honoring `isSavingBeer` in `handleSubmit` and showing a loading label on the save button (`⏳ Speichern...`), and stop noisy `console.log(beer)`.  
- Update component lifecycle handling so `isSubmitSuccessful` and save messages from Redux are reflected in the form UI.  
- Add/extend unit tests in `src/containers/DatabaseOverview/BeerForm.test.tsx` to cover: invalid form (visible errors), new-beer create submit, existing-beer update submit, success/error message display, and duplicate-submit prevention.

### Testing
- Attempted `npm test -- --watchAll=false src/containers/DatabaseOverview/BeerForm.test.tsx src/repositorys/BeerRepository.test.ts` but automated test run failed in this environment because `react-scripts` / dependency installation failed (network/registry / peer-dep resolution), so Jest could not execute here.  
- Performed repository static checks such as `git diff --check` which passed and committed the changes (`Fix beer form submit validation flow`).  
- New and updated unit tests were added under `src/containers/DatabaseOverview/BeerForm.test.tsx` and `src/containers/DatabaseOverview/BeerForm.tsx` and must be executed in CI or a developer environment with project dependencies (`npm ci`) to validate behavior end-to-end; run command locally/CI: `CI=true npm test -- --watchAll=false src/containers/DatabaseOverview/BeerForm.test.tsx src/repositorys/BeerRepository.test.ts`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a623bbf4208832f83ea24e1166eab2a)