### PR TITLE
Fix recipe water fill state display and liter formatting

### DIFF
--- a/src/components/Controlls/WaterControll/WaterControl.tsx
+++ b/src/components/Controlls/WaterControll/WaterControl.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import './WaterControll.css';
 import { VesselContentType } from '../../../model/VesselContentType';
+import { formatLiters } from '../../../utils/format/liters';
 
 export interface WaterStatus {
     filledLiters: number;
@@ -240,11 +241,7 @@ class WaterControl extends React.Component<WaterControlProps> {
                     </span>
 
                     <strong>
-                        {numericLiters.toLocaleString('de-DE', {
-                            minimumFractionDigits: 1,
-                            maximumFractionDigits: 2,
-                        })}{' '}
-                        L
+                        {formatLiters(numericLiters)}
                     </strong>
                 </div>
             </div>

--- a/src/containers/Production/Production.test.tsx
+++ b/src/containers/Production/Production.test.tsx
@@ -221,7 +221,7 @@ describe('Production recipe water filling', () => {
         expect(getSpargeButton()).not.toBeDisabled();
         expect(getMashButton()).toBeDisabled();
         expect(screen.getByText('Aktueller Füllvorgang')).toBeInTheDocument();
-        expect(screen.getByText('0,0 L')).toBeInTheDocument();
+        expect(screen.getByText('0,0 l')).toBeInTheDocument();
     });
 
     it('does not allow Hauptguss before Nachguss completed', () => {
@@ -239,7 +239,7 @@ describe('Production recipe water filling', () => {
         expect(getSpargeButton()).toBeDisabled();
         expect(getMashButton()).toBeDisabled();
         expect(screen.getAllByText('Nachguss').length).toBeGreaterThan(0);
-        expect(screen.getByText('0,0 L')).toBeInTheDocument();
+        expect(screen.getByText('0,0 l')).toBeInTheDocument();
     });
 
     it('does not complete Nachguss from the initial openClose false status', () => {
@@ -255,12 +255,42 @@ describe('Production recipe water filling', () => {
         rerender(<Production {...props} waterStatus={{filledLiters: 2, targetLiters: 9, openClose: true}} />);
         expect(getSpargeButton()).toBeDisabled();
         expect(getMashButton()).toBeDisabled();
-        expect(screen.getByText('2,0 L')).toBeInTheDocument();
+        expect(screen.getByText('2,0 l')).toBeInTheDocument();
         rerender(<Production {...props} waterStatus={{filledLiters: 9, targetLiters: 9, openClose: false}} />);
         expect(screen.getByRole('button', {name: '✓ Nachguss fertig'})).toBeDisabled();
         expect(getMashButton()).not.toBeDisabled();
         expect(screen.getAllByText('Nachguss').length).toBeGreaterThan(0);
-        expect(screen.getByText('9,0 L')).toBeInTheDocument();
+        expect(screen.getByText('9,0 l')).toBeInTheDocument();
+    });
+
+
+    it('keeps completed Nachguss visible when polling later reports an idle zero status', () => {
+        const {rerender, props} = renderProduction({selectedBeer: createBeer(21, 16.6), waterStatus: {filledLiters: 0, targetLiters: 0, openClose: false}});
+        fireEvent.click(getSpargeButton());
+        rerender(<Production {...props} waterStatus={{filledLiters: 8.44, targetLiters: 16.6, openClose: true}} />);
+        expect(screen.getByText('8,4 l')).toBeInTheDocument();
+        rerender(<Production {...props} waterStatus={{filledLiters: 16.6, targetLiters: 16.6, openClose: false}} />);
+        expect(screen.getByRole('button', {name: '✓ Nachguss fertig'})).toBeDisabled();
+        expect(getMashButton()).not.toBeDisabled();
+        expect(screen.getByText('16,6 l')).toBeInTheDocument();
+
+        rerender(<Production {...props} waterStatus={{filledLiters: 0, targetLiters: 0, openClose: false}} />);
+
+        expect(screen.getByRole('button', {name: '✓ Nachguss fertig'})).toBeDisabled();
+        expect(getMashButton()).not.toBeDisabled();
+        expect(screen.getByText('16,6 l')).toBeInTheDocument();
+        expect(screen.queryByText('0,0 l')).not.toBeInTheDocument();
+    });
+
+    it('uses the last running filled liters when the terminal polling update already reports zero', () => {
+        const {rerender, props} = renderProduction({selectedBeer: createBeer(21, 16.6), waterStatus: {filledLiters: 0, targetLiters: 0, openClose: false}});
+        fireEvent.click(getSpargeButton());
+        rerender(<Production {...props} waterStatus={{filledLiters: 16.6, targetLiters: 16.6, openClose: true}} />);
+        rerender(<Production {...props} waterStatus={{filledLiters: 0, targetLiters: 0, openClose: false}} />);
+
+        expect(screen.getByRole('button', {name: '✓ Nachguss fertig'})).toBeDisabled();
+        expect(getMashButton()).not.toBeDisabled();
+        expect(screen.getByText('16,6 l')).toBeInTheDocument();
     });
 
     it('starts Hauptguss only after completed Nachguss and visibly resets the fill display to 0', () => {
@@ -271,8 +301,8 @@ describe('Production recipe water filling', () => {
         fireEvent.click(getMashButton());
         expect(props.startWaterFilling).toHaveBeenLastCalledWith(21);
         expect(screen.getAllByText('Hauptguss').length).toBeGreaterThan(0);
-        expect(screen.getByText('0,0 L')).toBeInTheDocument();
-        expect(screen.queryByText('9,0 L')).not.toBeInTheDocument();
+        expect(screen.getByText('0,0 l')).toBeInTheDocument();
+        expect(screen.queryByText('9,0 l')).not.toBeInTheDocument();
     });
 
     it('shows only Hauptguss during and after Hauptguss until Abmaischen is confirmed', () => {
@@ -282,13 +312,13 @@ describe('Production recipe water filling', () => {
         rerender(<Production {...props} waterStatus={{filledLiters: 9, targetLiters: 9, openClose: false}} />);
         fireEvent.click(getMashButton());
         rerender(<Production {...props} waterStatus={{filledLiters: 12, targetLiters: 21, openClose: true}} />);
-        expect(screen.getByText('12,0 L')).toBeInTheDocument();
+        expect(screen.getByText('12,0 l')).toBeInTheDocument();
         rerender(<Production {...props} waterStatus={{filledLiters: 21, targetLiters: 21, openClose: false}} />);
         expect(screen.getByRole('button', {name: '✓ Nachguss fertig'})).toBeDisabled();
         expect(screen.getByRole('button', {name: '✓ Hauptguss fertig'})).toBeDisabled();
         expect(screen.getAllByText('Hauptguss').length).toBeGreaterThan(0);
-        expect(screen.getByText('21,0 L')).toBeInTheDocument();
-        expect(screen.queryByText('30,0 L')).not.toBeInTheDocument();
+        expect(screen.getByText('21,0 l')).toBeInTheDocument();
+        expect(screen.queryByText('30,0 l')).not.toBeInTheDocument();
     });
 
     it('adds Nachguss exactly once after the process leaves MASHING_OUT_CONFIRMATION for a later phase', () => {
@@ -306,13 +336,13 @@ describe('Production recipe water filling', () => {
         fireEvent.click(getMashButton());
         rerender(<Production {...props} brewingStatus={waitingForMashingOut} waterStatus={{filledLiters: 21, targetLiters: 21, openClose: true}} />);
         rerender(<Production {...props} brewingStatus={waitingForMashingOut} waterStatus={{filledLiters: 21, targetLiters: 21, openClose: false}} />);
-        expect(screen.queryByText('30,0 L')).not.toBeInTheDocument();
+        expect(screen.queryByText('30,0 l')).not.toBeInTheDocument();
         rerender(<Production {...props} brewingStatus={cooking} waterStatus={{filledLiters: 21, targetLiters: 21, openClose: false}} />);
         expect(screen.getByText('Brauwasser gesamt')).toBeInTheDocument();
-        expect(screen.getByText('30,0 L')).toBeInTheDocument();
+        expect(screen.getByText('30,0 l')).toBeInTheDocument();
         rerender(<Production {...props} brewingStatus={cooking} waterStatus={{filledLiters: 21, targetLiters: 21, openClose: false}} />);
-        expect(screen.getByText('30,0 L')).toBeInTheDocument();
-        expect(screen.queryByText('39,0 L')).not.toBeInTheDocument();
+        expect(screen.getByText('30,0 l')).toBeInTheDocument();
+        expect(screen.queryByText('39,0 l')).not.toBeInTheDocument();
     });
 
     it('disables recipe water buttons with missing or invalid volumes', () => {
@@ -348,8 +378,8 @@ describe('Production recipe water filling', () => {
         rerender(<Production {...props} waterStatus={{filledLiters: 9, targetLiters: 9, openClose: false}} />);
         expect(screen.getByRole('button', {name: '✓ Nachguss fertig'})).toBeDisabled();
         rerender(<Production {...props} selectedBeer={createBeer(22, 10, '2')} waterStatus={{filledLiters: 0, targetLiters: 0, openClose: false}} />);
-        expect(screen.getByRole('button', {name: 'Nachguss'})).not.toBeDisabled();
-        expect(screen.getByRole('button', {name: 'Hauptguss'})).toBeDisabled();
+        expect(screen.getByRole('button', {name: 'Nachguss einfüllen'})).not.toBeDisabled();
+        expect(screen.getByRole('button', {name: 'Hauptguss einfüllen'})).toBeDisabled();
     });
 
     it('resets completed recipe water filling when a new brew starts', () => {
@@ -359,8 +389,8 @@ describe('Production recipe water filling', () => {
         rerender(<Production {...props} waterStatus={{filledLiters: 9, targetLiters: 9, openClose: false}} />);
         expect(screen.getByRole('button', {name: '✓ Nachguss fertig'})).toBeDisabled();
         fireEvent.click(screen.getByRole('button', {name: 'Start'}));
-        expect(screen.getByRole('button', {name: 'Nachguss'})).not.toBeDisabled();
-        expect(screen.getByRole('button', {name: 'Hauptguss'})).toBeDisabled();
+        expect(screen.getByRole('button', {name: 'Nachguss einfüllen'})).not.toBeDisabled();
+        expect(screen.getByRole('button', {name: 'Hauptguss einfüllen'})).toBeDisabled();
     });
 
     it('keeps the existing manual water filling control unchanged', () => {

--- a/src/containers/Production/Production.tsx
+++ b/src/containers/Production/Production.tsx
@@ -196,7 +196,7 @@ export class Production extends React.Component<ProductionProps, ProductionState
         }
 
         if (prevProps.waterStatus?.openClose === true && waterStatus?.openClose === false) {
-            this.completePendingRecipeWaterFill();
+            this.completePendingRecipeWaterFill(prevProps.waterStatus?.filledLiters);
         }
 
         if (!this.state.isSpargeIncluded && this.shouldIncludeSpargeAfterMashingOut(prevProps.brewingStatus, brewingStatus)) {
@@ -413,13 +413,17 @@ export class Production extends React.Component<ProductionProps, ProductionState
         this.setState(aAdditionalState === undefined ? resetState : {...resetState, ...aAdditionalState});
     }
 
-    completePendingRecipeWaterFill = (): void => {
+    completePendingRecipeWaterFill = (aPreviousFilledLiters?: number): void => {
         const {activeFillType, activeFillWasOpened} = this.state;
-        if (!activeFillWasOpened || activeFillType === undefined) {
+        if ((!activeFillWasOpened && aPreviousFilledLiters === undefined) || activeFillType === undefined) {
             this.setState({waterSwitchState: false, activeFillWasOpened: false});
             return;
         }
-        const completedLiters = this.getSafeWaterStatusFilledLiters();
+        const currentFilledLiters = this.getSafeWaterStatusFilledLiters();
+        const previousFilledLiters = Number(aPreviousFilledLiters);
+        const completedLiters = currentFilledLiters > 0 || !Number.isFinite(previousFilledLiters)
+            ? currentFilledLiters
+            : previousFilledLiters;
         this.setState({
             waterSwitchState: false,
             activeFillWasOpened: false,
@@ -564,7 +568,7 @@ export class Production extends React.Component<ProductionProps, ProductionState
         if (aRecipeWaterFill === 'mash' && this.state.mashState === 'COMPLETED') {
             return '✓ Hauptguss fertig';
         }
-        return aRecipeWaterFill === 'sparge' ? 'Nachguss' : 'Hauptguss';
+        return aRecipeWaterFill === 'sparge' ? 'Nachguss einfüllen' : 'Hauptguss einfüllen';
     }
 
     startMashWaterFilling = (): void => {

--- a/src/utils/format/liters.test.ts
+++ b/src/utils/format/liters.test.ts
@@ -1,0 +1,13 @@
+import { formatLiters } from './liters';
+
+describe('formatLiters', () => {
+    it.each([
+        [0, '0,0 l'],
+        [8, '8,0 l'],
+        [8.44, '8,4 l'],
+        [8.46, '8,5 l'],
+        [16.6, '16,6 l'],
+    ])('formats %p with one German decimal place', (aValue: number, aExpected: string) => {
+        expect(formatLiters(aValue)).toBe(aExpected);
+    });
+});

--- a/src/utils/format/liters.ts
+++ b/src/utils/format/liters.ts
@@ -1,0 +1,8 @@
+export const formatLiters = (aLiters: number): string => {
+    const safeLiters = Number.isFinite(aLiters) ? aLiters : 0;
+
+    return `${safeLiters.toLocaleString('de-DE', {
+        minimumFractionDigits: 1,
+        maximumFractionDigits: 1,
+    })} l`;
+};


### PR DESCRIPTION
### Motivation
- Terminal `WaterStatus` polling could report `filledLiters: 0` immediately after a completed fill, which made the UI reset visible fill levels and re-enable finished buttons incorrectly.  
- The UI displayed liters with inconsistent formatting and uppercase `L`, and formatting logic was duplicated in components.  
- Button labels were ambiguous about the action (start fill vs finished) and the recipe water-fill state transitions needed to be deterministic and driven by explicit fill states.

### Description
- Preserve the last meaningful running `filledLiters` when completing a recipe fill by passing the previous poll value into `completePendingRecipeWaterFill` and using it if the terminal poll already reports `0`; change implemented in `src/containers/Production/Production.tsx`.  
- Keep recipe water button and step state driven by `spargeState` / `mashState` (values `IDLE|FILLING|COMPLETED|ERROR`) so completed steps remain disabled and the main/given transitions are deterministic; logic updated in `src/containers/Production/Production.tsx`.  
- Introduce a shared formatter `formatLiters` in `src/utils/format/liters.ts` and use it in `WaterControl` to always render German-style liters with exactly one decimal and a lowercase `l` (e.g. `16,6 l`), replacing inline formatting in `src/components/Controlls/WaterControll/WaterControl.tsx`.  
- Make recipe water button labels explicit (`Nachguss einfüllen` / `Hauptguss einfüllen`) while preserving `✓ ... fertig` finished labels; text updated in `src/containers/Production/Production.tsx`.  
- Add/extend tests to cover the corrected behaviors and formatting in `src/containers/Production/Production.test.tsx` and `src/utils/format/liters.test.ts`.

### Testing
- Ran `git diff --check` which succeeded.  
- Added unit tests `src/utils/format/liters.test.ts` and extended `src/containers/Production/Production.test.tsx`, but running the test suite with `npm test` could not be completed because `npm install` failed due to a registry `403 Forbidden` for `@types/react`, so the new tests were not executed in this environment.  
- Existing CI/local test expectations were updated in the modified test file to reflect the new liter formatting and button labels (tests are present and ready to run once dependencies are available).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a625bc77bac832fb29db0ff55157b2c)