### PR TITLE
Align water gauge fill with 0–70 L scale (usable area + tests)

### DIFF
--- a/src/components/Controlls/WaterControll/WaterControl.test.tsx
+++ b/src/components/Controlls/WaterControll/WaterControl.test.tsx
@@ -31,10 +31,14 @@ describe('WaterControl vessel content display', () => {
     it('keeps scale, liter value, agitator, and fill height in all states', () => {
         [VesselContentType.WATER, VesselContentType.MASH, VesselContentType.WORT].forEach((contentType) => {
             const {container, unmount} = renderWaterControl(contentType);
+            const usableArea = container.querySelector('.water-gauge__usable-area');
+            const fill = container.querySelector('.water-gauge__fill');
             expect(container.querySelector('.water-gauge__scale')).not.toBeNull();
             expect(container.querySelector('.water-gauge__agitator')).not.toBeNull();
             expect(screen.getByText('35,0 L')).toBeInTheDocument();
-            expect(container.querySelector('.water-gauge__fill')).toHaveStyle({height: '50%'});
+            expect(usableArea).not.toBeNull();
+            expect(usableArea?.contains(fill)).toBe(true);
+            expect(fill).toHaveStyle({height: '50%'});
             unmount();
         });
     });
@@ -49,6 +53,8 @@ describe('WaterControl fill level', () => {
 
     it('uses filledLiters for tank height and caps only the visual level at vessel capacity', () => {
         expect(getFillHeight(0)).toBe('0%');
+        expect(getFillHeight(2)).toBe(`${(2 / 70) * 100}%`);
+        expect(getFillHeight(10)).toBe(`${(10 / 70) * 100}%`);
         expect(getFillHeight(0.0286)).toBe(`${(0.0286 / 70) * 100}%`);
         expect(getFillHeight(16.6)).toBe(`${(16.6 / 70) * 100}%`);
         expect(getFillHeight(80)).toBe('100%');

--- a/src/components/Controlls/WaterControll/WaterControl.tsx
+++ b/src/components/Controlls/WaterControll/WaterControl.tsx
@@ -187,21 +187,23 @@ class WaterControl extends React.Component<WaterControlProps> {
         return (
             <div className={waterGaugeClassName}>
                 <div className="water-gauge__tank">
-                    <div
-                        className="water-gauge__fill"
-                        style={{
-                            height: `${waterLevel}%`,
-                        }}
-                    >
+                    <div className="water-gauge__usable-area">
                         <div
-                            className="water-gauge__particles"
-                            aria-hidden="true"
-                        />
+                            className="water-gauge__fill"
+                            style={{
+                                height: `${waterLevel}%`,
+                            }}
+                        >
+                            <div
+                                className="water-gauge__particles"
+                                aria-hidden="true"
+                            />
 
-                        <div
-                            className="water-gauge__surface"
-                            aria-hidden="true"
-                        />
+                            <div
+                                className="water-gauge__surface"
+                                aria-hidden="true"
+                            />
+                        </div>
                     </div>
 
                     <div

--- a/src/components/Controlls/WaterControll/WaterControll.css
+++ b/src/components/Controlls/WaterControll/WaterControll.css
@@ -11,6 +11,8 @@
 }
 
 .water-gauge__tank {
+    --water-gauge-vertical-inset: 0.85rem;
+
     position: relative;
     width: clamp(8rem, 76%, 11rem);
     height: min(100%, 34rem);
@@ -76,6 +78,14 @@
             inset 3px 0 0 rgb(255 255 255 / 38%),
             inset -3px 0 0 rgb(0 0 0 / 10%),
             inset 0 0 0 1px rgb(255 255 255 / 22%);
+}
+
+.water-gauge__usable-area {
+    position: absolute;
+    inset: var(--water-gauge-vertical-inset) 0;
+    z-index: 1;
+    overflow: hidden;
+    pointer-events: none;
 }
 
 .water-gauge__fill {
@@ -178,7 +188,7 @@
 
 .water-gauge__scale {
     position: absolute;
-    inset: 0.85rem 0.7rem 0.85rem 0.55rem;
+    inset: var(--water-gauge-vertical-inset) 0.7rem var(--water-gauge-vertical-inset) 0.55rem;
     z-index: 5;
     pointer-events: none;
 }


### PR DESCRIPTION
### Motivation
- Fix a visual mismatch where the numeric liter display, the visible water surface and the 0–70 L scale were not aligned and the water surface did not reflect proportional fill height. 
- Render the water surface proportionally within the usable tank area while keeping the existing 70 L normalization.

### Description
- Introduce a `.water-gauge__usable-area` wrapper and a `--water-gauge-vertical-inset` CSS variable and adjust `.water-gauge__fill` and scale in `src/components/Controlls/WaterControll/WaterControll.css` so the visual fill is constrained to the usable tank height. 
- Update `WaterControl` markup in `src/components/Controlls/WaterControll/WaterControl.tsx` to nest the fill inside the usable area while preserving the existing `MAX_WATER_LITERS` percentage calculation. 
- Extend `src/components/Controlls/WaterControll/WaterControl.test.tsx` to assert that the fill element is contained within the usable area and to check proportional heights for `2 L` and `10 L` in addition to the existing cases.

### Testing
- Ran `git diff --check` which reported no whitespace/conflict issues and completed successfully. 
- Attempted to run the updated Jest test via `npm test -- --runTestsByPath src/components/Controlls/WaterControll/WaterControl.test.tsx` but execution failed because `react-scripts` is not installed in `node_modules` in the current environment (test run failed). 
- Attempted `npm ci` to install dependencies for the test run but it failed due to the npm registry returning `403 Forbidden` for `@types/react` (dependency install failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6267977708832fb518e3917782843e)