### PR TITLE
Refactor Production: extract water-fill, countdown, hop-schedule and dialogs

### DIFF
--- a/src/containers/Production/Production.tsx
+++ b/src/containers/Production/Production.tsx
@@ -1,12 +1,13 @@
 import React from 'react';
-import _, {isUndefined} from 'lodash';
+import {isUndefined} from 'lodash';
 import {Beer} from "../../model/Beer";
 import {connect} from "react-redux";
+import {Dispatch} from "redux";
 import 'bootstrap/dist/css/bootstrap.min.css';
 import {v4 as uuidv4} from 'uuid';
 import '@fortawesome/fontawesome-free/css/all.css'; // Stile
 import './Production.css'
-import Timeline, {TimelineData} from "./Timeline/Timeline";
+
 import WaterControl, {WaterStatus} from "../../components/Controlls/WaterControll/WaterControl";
 import Flame from "../../components/Flame/Flame";
 import {BeerActions, ProductionActions} from "../../actions/actions";
@@ -16,12 +17,11 @@ import {MashAgitatorStates} from "../../model/MashAgitator";
 import QuantityPicker from '../../components/Controlls/QuantityPicker/QuantityPicker';
 import {BrewingData} from "../../model/BrewingData";
 import {mapBeerToBrewingData} from "../../utils/productionRecipe";
-import {HeatingStates} from "../../model/BrewingStatus";
-import {BrewingStatus, ProcessMode, ProcessPhase, ProcessState, WaitingFor} from "../../model/brewingStatus.types";
+
+import {BrewingStatus, ProcessMode, ProcessPhase, ProcessState} from "../../model/brewingStatus.types";
 import {TimeFormatter} from "../../utils/TimeFormatter";
-import ModalDialog, {DialogType} from "../../components/ModalDialog/ModalDialog";
-import {ProgressBar} from "react-bootstrap";
-import {MashingType} from "../../enums/eMashingType";
+
+
 import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
 import {faRepeat} from '@fortawesome/free-solid-svg-icons';
 import Switch from "react-switch";
@@ -29,10 +29,18 @@ import {IconProp} from "@fortawesome/fontawesome-svg-core";
 import {FinishedBrew} from "../../model/FinishedBrew";
 import {eBrewState} from "../../enums/eBrewState";
 import {BackendAvailable} from "../../reducers/productionReducer";
-import {ProcessList, createProcessSteps} from "./ProcessList/ProcessList";
+import {RootState} from "../../reducers/rootReducer";
+import {ProcessList} from "./ProcessList/ProcessList";
 import { dataCollector } from '../../utils/DataCollector/dataCollector';
-import {getBrewingStatusLabel, isBrewingProcessActive, isProcessActive} from "../../utils/brewingStatus/selectors";
+import {isBrewingProcessActive, isProcessActive} from "../../utils/brewingStatus/selectors";
 import {getVesselContentType} from "../../utils/brewingStatus/vesselContent";
+import {calculateHopSchedule, getDueHopAddition, HopAddition} from "./utils/hopSchedule";
+import {getRemainingSecondsFromStatus, shouldCountdownLocally, tickRemainingSeconds} from "./utils/productionCountdown";
+import {isAgitatorActive, isControllerAvailable as getIsControllerAvailable, isHeaterActive} from "./utils/productionStatus";
+import {RecipeWaterFill, RecipeWaterFillStatus} from "./waterFill/recipeWaterFill.types";
+import {completeWaterFill, createInitialRecipeWaterFillStatus, failWaterFill, markValveOpened, resetWaterFill, startWaterFill} from "./waterFill/recipeWaterFillState";
+import {ProductionDialogs} from "./components/ProductionDialogs";
+import {getDisplayedWaterLiters as selectDisplayedWaterLiters, getWaterLabel, getWaterTargetLiters, isRecipeWaterButtonDisabled as selectRecipeWaterButtonDisabled, isWaterFillingActive as selectWaterFillingActive, shouldIncludeSpargeAfterMashingOut as selectShouldIncludeSpargeAfterMashingOut, sanitizeLiters} from "./waterFill/recipeWaterFillSelectors";
 
 export interface ProductionProps {
     selectedBeer: Beer;
@@ -58,11 +66,6 @@ export interface ProductionProps {
     isPollingRunning: boolean;
 }
 
-type RecipeWaterFill = 'mash' | 'sparge';
-type WaterFillType = 'SPARGE' | 'MASH';
-type WaterFillState = 'IDLE' | 'FILLING' | 'COMPLETED' | 'ERROR';
-type RecipeWaterFillResetState = Pick<ProductionState, 'activeFillType' | 'spargeState' | 'mashState' | 'completedSpargeLiters' | 'completedMashLiters' | 'currentFillLiters' | 'activeFillWasOpened' | 'isSpargeIncluded'>;
-
 interface ProductionState {
     agitatorState: ToggleState;
     agitatorSpeed: number;
@@ -77,7 +80,7 @@ interface ProductionState {
     mainAgitatorError: boolean
     isWaterSwitchBlinking: boolean
     isMainSwitchBlinking: boolean
-    hopsTimes: Record<number, string>
+    hopSchedule: HopAddition[]
     hopName: string
     showHopsDialog: boolean
     showErrorDialog: boolean
@@ -87,29 +90,19 @@ interface ProductionState {
     indexOfCurrentStep: number;
     brewingIsRunning: boolean;
     announcedHopTimes: number[];
-    activeFillType: WaterFillType | undefined;
-    spargeState: WaterFillState;
-    mashState: WaterFillState;
-    completedSpargeLiters: number;
-    completedMashLiters: number;
-    currentFillLiters: number;
-    activeFillWasOpened: boolean;
-    isSpargeIncluded: boolean;
+    recipeWaterFill: RecipeWaterFillStatus;
     displayedRemainingSeconds: number | undefined;
 }
 
 export class Production extends React.Component<ProductionProps, ProductionState> {
-    private blinkIntervalMainSwitch: NodeJS.Timeout | null = null;
-    private blinkIntervalWaterSwitch: NodeJS.Timeout | null = null;
-    private timelineData: TimelineData[] = [];
     private isBrewingStartRequestPending = false;
     private readonly MAX_AGITATOR_SPEED = 40;
     private readonly MAX_WATER_LEVEL = 70;
-    private readonly MAX_INTERVAL_TIME = 10;
-    private readonly MIN_INTERVAL_TIME = 10;
     private readonly MAX_BREAK_TIME = 10;
     private readonly MAX_RUNNING_TIME = 10;
     private remainingTimeInterval: NodeJS.Timeout | null = null;
+    private errorTimeouts: NodeJS.Timeout[] = [];
+    private isMountedComponent = false;
 
     constructor(props: ProductionProps) {
         super(props);
@@ -127,7 +120,7 @@ export class Production extends React.Component<ProductionProps, ProductionState
             mainAgitatorError: false,
             isWaterSwitchBlinking: false,
             isMainSwitchBlinking: false,
-            hopsTimes: {},
+            hopSchedule: [],
             hopName: '',
             showHopsDialog: false,
             showErrorDialog: false,
@@ -137,19 +130,13 @@ export class Production extends React.Component<ProductionProps, ProductionState
             indexOfCurrentStep: 0,
             brewingIsRunning: false,
             announcedHopTimes: [],
-            activeFillType: undefined,
-            spargeState: 'IDLE',
-            mashState: 'IDLE',
-            completedSpargeLiters: 0,
-            completedMashLiters: 0,
-            currentFillLiters: 0,
-            activeFillWasOpened: false,
-            isSpargeIncluded: false,
+            recipeWaterFill: createInitialRecipeWaterFillStatus(),
             displayedRemainingSeconds: undefined
         }
     }
 
     componentDidMount() {
+        this.isMountedComponent = true;
         const {getTemperatures, selectedBeer} = this.props;
         if (!isUndefined(selectedBeer)) {
             this.calculateTheHopTimes();
@@ -160,10 +147,13 @@ export class Production extends React.Component<ProductionProps, ProductionState
     }
 
     componentWillUnmount() {
+        this.isMountedComponent = false;
         if (this.remainingTimeInterval !== null) {
             clearInterval(this.remainingTimeInterval);
             this.remainingTimeInterval = null;
         }
+        this.errorTimeouts.forEach(clearTimeout);
+        this.errorTimeouts = [];
     }
 
 
@@ -191,55 +181,43 @@ export class Production extends React.Component<ProductionProps, ProductionState
             this.setState({brewingIsRunning: false});
         }
 
-        if (this.state.activeFillType !== undefined && waterStatus?.openClose === true && !prevProps.waterStatus?.openClose) {
-            this.setState({activeFillWasOpened: true});
+        if (this.state.recipeWaterFill.activeFillType !== undefined && waterStatus?.openClose === true && !prevProps.waterStatus?.openClose) {
+            this.setState((prevState) => ({recipeWaterFill: markValveOpened(prevState.recipeWaterFill)}));
         }
 
         if (prevProps.waterStatus?.openClose === true && waterStatus?.openClose === false) {
             this.completePendingRecipeWaterFill(prevProps.waterStatus?.filledLiters);
         }
 
-        if (!this.state.isSpargeIncluded && this.shouldIncludeSpargeAfterMashingOut(prevProps.brewingStatus, brewingStatus)) {
-            this.setState({isSpargeIncluded: true});
+        if (!this.state.recipeWaterFill.isSpargeIncluded && this.shouldIncludeSpargeAfterMashingOut(prevProps.brewingStatus, brewingStatus)) {
+            this.setState((prevState) => ({recipeWaterFill: {...prevState.recipeWaterFill, isSpargeIncluded: true}}));
         }
 
 
         if (!isToggleAgitatorSuccess && mainSwitchState) {
-            const delay = 300;
-            setTimeout(() => {
-                this.setState({mainSwitchState: false, mainAgitatorError: true});
-            }, delay);
+            const timeoutId = setTimeout(() => {
+                if (this.isMountedComponent) {
+                    this.setState({mainSwitchState: false, mainAgitatorError: true});
+                }
+            }, 300);
+            this.errorTimeouts.push(timeoutId);
         }
 
-        if (prevState.intervalSwitchState == !intervalSwitchState && mainSwitchState) {
+        if (prevState.intervalSwitchState !== intervalSwitchState && mainSwitchState) {
             toggleAgitator(this.setAgitatorStates(mainSwitchState));
         }
 
-        if (prevState.heatingAndStirringSwitchState == !heatingAndStirringSwitchState && mainSwitchState) {
+        if (prevState.heatingAndStirringSwitchState !== heatingAndStirringSwitchState && mainSwitchState) {
             toggleAgitator(this.setAgitatorStates(mainSwitchState));
         }
 
         if (!isWaterFillingSuccessful && waterSwitchState) {
-            const delay = 300;
-            setTimeout(() => {
-                this.failActiveRecipeWaterFill();
-            }, delay);
-        }
-        if (brewingStatus && brewingStatus.currentStep?.mode !== prevProps?.brewingStatus?.currentStep?.mode) {
-            let timelineData: TimelineData | undefined;
-            if (brewingStatus.currentStep.mode === ProcessMode.HEATING) {
-                timelineData = {
-                    type: 'heating', elapsed: brewingStatus.elapsedTime
+            const timeoutId = setTimeout(() => {
+                if (this.isMountedComponent) {
+                    this.failActiveRecipeWaterFill();
                 }
-            } else {
-                timelineData = {
-                    type: 'rast', elapsed: brewingStatus.elapsedTime
-                }
-            }
-            if (timelineData !== undefined) {
-                this.timelineData.push(timelineData);
-            }
-
+            }, 300);
+            this.errorTimeouts.push(timeoutId);
         }
         if (typeof brewingStatus?.currentStep?.index === "number" && brewingStatus.currentStep.index !== prevProps?.brewingStatus?.currentStep?.index) {
             this.setState({indexOfCurrentStep: brewingStatus.currentStep.index});
@@ -249,7 +227,7 @@ export class Production extends React.Component<ProductionProps, ProductionState
         if (brewingStatus?.currentStep?.phase === ProcessPhase.COOKING && !showHopsDialog) {
             this.checkForHopAddition()
         }
-        if(brewingStatus?.process?.state === ProcessState.FINISHED && ! showFinishDialog ! && !this.state.brewingFinished)
+        if (brewingStatus?.process?.state === ProcessState.FINISHED && !showFinishDialog && !this.state.brewingFinished)
         {
             this.setState({showFinishDialog: true})
         }
@@ -273,69 +251,33 @@ export class Production extends React.Component<ProductionProps, ProductionState
             if (typeof prevState.displayedRemainingSeconds !== 'number') {
                 return null;
             }
-            return {displayedRemainingSeconds: Math.max(0, prevState.displayedRemainingSeconds - 1)};
+            return {displayedRemainingSeconds: tickRemainingSeconds(prevState.displayedRemainingSeconds)};
         });
     }
 
     shouldCountdownLocally = (aBrewingStatus?: BrewingStatus): boolean => {
-        return aBrewingStatus?.process?.state === ProcessState.ACTIVE
-            && aBrewingStatus.currentStep?.mode === ProcessMode.TIMER_RUNNING
-            && typeof aBrewingStatus.currentStep?.duration === 'number'
-            && aBrewingStatus.currentStep.duration > 0;
+        return shouldCountdownLocally(aBrewingStatus);
     }
 
     getRemainingSecondsFromStatus = (): number | undefined => {
-        const {brewingStatus} = this.props;
-        if (brewingStatus?.process?.state === ProcessState.FINISHED) {
-            return 0;
-        }
-        if (!this.shouldCountdownLocally(brewingStatus)) {
-            return undefined;
-        }
-        const statusRemainingTime = Number(brewingStatus?.currentStep?.remainingTime);
-        if (Number.isFinite(statusRemainingTime) && statusRemainingTime >= 0) {
-            return Math.max(0, Math.floor(statusRemainingTime));
-        }
-        const duration = Number(brewingStatus?.currentStep?.duration);
-        const elapsed = Number(brewingStatus?.currentStep?.elapsedTime);
-        if (Number.isFinite(duration) && Number.isFinite(elapsed)) {
-            return Math.max(0, Math.floor(duration - elapsed));
-        }
-        return undefined;
+        return getRemainingSecondsFromStatus(this.props.brewingStatus);
     }
     checkForHopAddition() {
-        const {hopsTimes, announcedHopTimes} = this.state;
-        const {brewingStatus} = this.props;
-
-        // Hop additions must be calculated relative to the cooking phase,
-        // nicht relativ zur gesamten Sudlaufzeit.
-        const aCookingElapsed = Math.floor(brewingStatus?.currentStep?.elapsedTime ?? 0);
-        if (!hopsTimes.hasOwnProperty(aCookingElapsed)) {
+        const {hopSchedule, announcedHopTimes} = this.state;
+        const aCookingElapsed = Math.floor(this.props.brewingStatus?.currentStep?.elapsedTime ?? 0);
+        const dueAddition = getDueHopAddition(hopSchedule, aCookingElapsed, announcedHopTimes);
+        if (dueAddition === undefined) {
             return;
         }
-        if (announcedHopTimes.includes(aCookingElapsed)) {
-            return;
-        }
-
-        const aHopName = hopsTimes[aCookingElapsed];
         this.setState((aPrevState) => ({
             showHopsDialog: true,
-            hopName: aHopName,
-            announcedHopTimes: [...aPrevState.announcedHopTimes, aCookingElapsed]
+            hopName: dueAddition.names.join(', '),
+            announcedHopTimes: [...aPrevState.announcedHopTimes, dueAddition.timeSeconds]
         }));
     }
 
     calculateTheHopTimes() {
-        let hopsDict: Record<number, string> = {};
-        const {selectedBeer} = this.props
-        const totalCookingTime = selectedBeer.cookingTime
-        selectedBeer.wortBoiling.hops.forEach((item) => {
-            const time = totalCookingTime - item.time;
-            const secTime = time * 60;
-            hopsDict[secTime] = item.name;
-
-        })
-        this.setState({hopsTimes: hopsDict, announcedHopTimes: []});
+        this.setState({hopSchedule: calculateHopSchedule(this.props.selectedBeer), announcedHopTimes: []});
     }
 
     setAgitatorStates(mainSwitchState: boolean) {
@@ -400,53 +342,31 @@ export class Production extends React.Component<ProductionProps, ProductionState
     }
 
     resetRecipeWaterFillState = (aAdditionalState?: Pick<ProductionState, 'indexOfCurrentStep'>): void => {
-        const resetState: RecipeWaterFillResetState = {
-            activeFillType: undefined,
-            spargeState: 'IDLE',
-            mashState: 'IDLE',
-            completedSpargeLiters: 0,
-            completedMashLiters: 0,
-            currentFillLiters: 0,
-            activeFillWasOpened: false,
-            isSpargeIncluded: false
-        };
+        const resetState = {recipeWaterFill: resetWaterFill()};
         this.setState(aAdditionalState === undefined ? resetState : {...resetState, ...aAdditionalState});
     }
 
     completePendingRecipeWaterFill = (aPreviousFilledLiters?: number): void => {
-        const {activeFillType, activeFillWasOpened} = this.state;
-        if ((!activeFillWasOpened && aPreviousFilledLiters === undefined) || activeFillType === undefined) {
-            this.setState({waterSwitchState: false, activeFillWasOpened: false});
+        const {recipeWaterFill} = this.state;
+        if ((!recipeWaterFill.activeFillWasOpened && aPreviousFilledLiters === undefined) || recipeWaterFill.activeFillType === undefined) {
+            this.setState((prevState) => ({waterSwitchState: false, recipeWaterFill: {...prevState.recipeWaterFill, activeFillWasOpened: false}}));
             return;
         }
         const currentFilledLiters = this.getSafeWaterStatusFilledLiters();
         const previousFilledLiters = Number(aPreviousFilledLiters);
-        const completedLiters = currentFilledLiters > 0 || !Number.isFinite(previousFilledLiters)
-            ? currentFilledLiters
-            : previousFilledLiters;
-        this.setState({
+        const completedLiters = currentFilledLiters > 0 || !Number.isFinite(previousFilledLiters) ? currentFilledLiters : previousFilledLiters;
+        this.setState((prevState) => ({
             waterSwitchState: false,
-            activeFillWasOpened: false,
-            activeFillType: undefined,
-            currentFillLiters: completedLiters,
-            completedMashLiters: activeFillType === 'MASH' ? completedLiters : this.state.completedMashLiters,
-            completedSpargeLiters: activeFillType === 'SPARGE' ? completedLiters : this.state.completedSpargeLiters,
-            mashState: activeFillType === 'MASH' ? 'COMPLETED' : this.state.mashState,
-            spargeState: activeFillType === 'SPARGE' ? 'COMPLETED' : this.state.spargeState
-        });
+            recipeWaterFill: completeWaterFill(prevState.recipeWaterFill, completedLiters)
+        }));
     }
 
     failActiveRecipeWaterFill = (): void => {
-        const {activeFillType} = this.state;
-        this.setState({
+        this.setState((prevState) => ({
             waterSwitchState: false,
             waterFillingError: true,
-            activeFillType: undefined,
-            activeFillWasOpened: false,
-            currentFillLiters: 0,
-            spargeState: activeFillType === 'SPARGE' ? 'ERROR' : this.state.spargeState,
-            mashState: activeFillType === 'MASH' ? 'ERROR' : this.state.mashState
-        });
+            recipeWaterFill: failWaterFill(prevState.recipeWaterFill)
+        }));
     }
 
     getRecipeWaterVolume = (aRecipeWaterFill: RecipeWaterFill): number | undefined => {
@@ -459,15 +379,11 @@ export class Production extends React.Component<ProductionProps, ProductionState
     }
 
     isWaterFillingActive = (): boolean => {
-        return this.state.waterSwitchState || this.state.activeFillType !== undefined || this.props.waterStatus?.openClose === true;
+        return selectWaterFillingActive(this.state.recipeWaterFill, this.state.waterSwitchState, this.props.waterStatus);
     }
 
     isControllerAvailable = (): boolean => {
-        const {isBackenAvailable} = this.props;
-        if (typeof isBackenAvailable === 'boolean') {
-            return isBackenAvailable;
-        }
-        return isBackenAvailable?.isBackenAvailable === true;
+        return getIsControllerAvailable(this.props.isBackenAvailable);
     }
 
     startRecipeWaterFilling = (aRecipeWaterFill: RecipeWaterFill): void => {
@@ -475,97 +391,45 @@ export class Production extends React.Component<ProductionProps, ProductionState
         if (volume === undefined || this.isRecipeWaterButtonDisabled(aRecipeWaterFill)) {
             return;
         }
-        const activeFillType: WaterFillType = aRecipeWaterFill === 'mash' ? 'MASH' : 'SPARGE';
-        this.setState({
+        this.setState((prevState) => ({
             waterSwitchState: true,
             liters: volume,
-            activeFillType,
-            currentFillLiters: 0,
-            activeFillWasOpened: false,
             waterFillingError: false,
-            mashState: activeFillType === 'MASH' ? 'FILLING' : this.state.mashState,
-            spargeState: activeFillType === 'SPARGE' ? 'FILLING' : this.state.spargeState
-        });
+            recipeWaterFill: startWaterFill(prevState.recipeWaterFill, aRecipeWaterFill)
+        }));
         this.props.startWaterFilling(volume);
     }
 
     getSafeWaterStatusFilledLiters = (): number => {
-        const waterStatusFilledLiters = Number(this.props.waterStatus?.filledLiters);
-        return Number.isFinite(waterStatusFilledLiters) ? waterStatusFilledLiters : 0;
+        return sanitizeLiters(this.props.waterStatus?.filledLiters);
     }
-
-    getCurrentWaterFillLiters = (): number => {
-        if (this.state.activeFillType !== undefined && !this.state.activeFillWasOpened) {
-            return this.state.currentFillLiters;
-        }
-        if (this.state.activeFillType !== undefined || this.props.waterStatus?.openClose === true) {
-            return this.getSafeWaterStatusFilledLiters();
-        }
-        if (this.state.mashState === 'COMPLETED') {
-            return this.state.completedMashLiters;
-        }
-        return this.state.currentFillLiters;
-    }
-
 
     getCurrentWaterFillTargetLiters = (): number => {
-        if (this.state.activeFillType !== undefined || this.props.waterStatus?.openClose === true) {
-            const rawTargetLiters = Number(this.props.waterStatus?.targetLiters);
-            if (Number.isFinite(rawTargetLiters) && rawTargetLiters > 0) {
-                return rawTargetLiters;
-            }
-        }
-        const rawRecipeLiters = Number(this.state.liters);
-        return Number.isFinite(rawRecipeLiters) ? Math.max(0, rawRecipeLiters) : 0;
+        return getWaterTargetLiters(this.state.recipeWaterFill, this.state.liters, this.props.waterStatus);
     }
 
     getDisplayedWaterLiters = (): number => {
-        return this.state.isSpargeIncluded
-            ? this.state.completedMashLiters + this.state.completedSpargeLiters
-            : this.getCurrentWaterFillLiters();
+        return selectDisplayedWaterLiters(this.state.recipeWaterFill, this.props.waterStatus);
     }
 
     getDisplayedWaterLabel = (): string => {
-        if (this.state.isSpargeIncluded) {
-            return 'Brauwasser gesamt';
-        }
-        if (this.state.activeFillType === 'SPARGE' || (this.state.spargeState === 'COMPLETED' && this.state.mashState === 'IDLE')) {
-            return 'Nachguss';
-        }
-        if (this.state.activeFillType === 'MASH' || this.state.mashState === 'COMPLETED') {
-            return 'Hauptguss';
-        }
-        return 'Aktueller Füllvorgang';
+        return getWaterLabel(this.state.recipeWaterFill);
     }
 
     shouldIncludeSpargeAfterMashingOut = (aPreviousStatus?: BrewingStatus, aCurrentStatus?: BrewingStatus): boolean => {
-        if (this.state.spargeState !== 'COMPLETED' || this.state.mashState !== 'COMPLETED') {
-            return false;
-        }
-        const previousWaitingFor = aPreviousStatus?.waiting?.waitingFor;
-        const currentPhase = aCurrentStatus?.currentStep?.phase;
-        const currentProcessState = aCurrentStatus?.process?.state;
-        const wasWaitingForMashingOut = previousWaitingFor === WaitingFor.MASHING_OUT_CONFIRMATION;
-        const isAfterMashingOutPhase = currentPhase === ProcessPhase.COOKING || currentPhase === ProcessPhase.COOLING || currentPhase === ProcessPhase.FINISHED || currentProcessState === ProcessState.FINISHED;
-        return wasWaitingForMashingOut && isAfterMashingOutPhase;
+        return selectShouldIncludeSpargeAfterMashingOut(this.state.recipeWaterFill, aPreviousStatus, aCurrentStatus);
     }
 
     isRecipeWaterButtonDisabled = (aRecipeWaterFill: RecipeWaterFill): boolean => {
         const volume = this.getRecipeWaterVolume(aRecipeWaterFill);
-        if (volume === undefined || !this.isControllerAvailable() || this.isWaterFillingActive()) {
-            return true;
-        }
-        if (aRecipeWaterFill === 'sparge') {
-            return this.state.spargeState === 'COMPLETED' || this.state.mashState !== 'IDLE';
-        }
-        return this.state.spargeState !== 'COMPLETED' || this.state.mashState === 'COMPLETED';
+        return selectRecipeWaterButtonDisabled(aRecipeWaterFill, this.state.recipeWaterFill, volume, this.isControllerAvailable(), this.isWaterFillingActive());
     }
 
     getRecipeWaterButtonLabel = (aRecipeWaterFill: RecipeWaterFill): string => {
-        if (aRecipeWaterFill === 'sparge' && this.state.spargeState === 'COMPLETED') {
+        if (aRecipeWaterFill === 'sparge' && this.state.recipeWaterFill.spargeState === 'COMPLETED') {
             return '✓ Nachguss fertig';
         }
-        if (aRecipeWaterFill === 'mash' && this.state.mashState === 'COMPLETED') {
+        if (aRecipeWaterFill === 'mash' && this.state.recipeWaterFill.mashState === 'COMPLETED') {
             return '✓ Hauptguss fertig';
         }
         return aRecipeWaterFill === 'sparge' ? 'Nachguss einfüllen' : 'Hauptguss einfüllen';
@@ -607,9 +471,7 @@ export class Production extends React.Component<ProductionProps, ProductionState
         this.resetRecipeWaterFillState();
         this.isBrewingStartRequestPending = true;
         dataCollector.reset();
-        console.log('Starting brewing with data:', sendBrewingData);
         const result = mapBeerToBrewingData(selectedBeer);
-        console.log('Starting brewing with data:', result);
         if (!result.ok || !result.brewingData) {
             this.isBrewingStartRequestPending = false;
             this.setState({
@@ -619,7 +481,6 @@ export class Production extends React.Component<ProductionProps, ProductionState
             return;
         }
         this.setState({brewingIsRunning: true});
-        console.log('Starting brewing with data:', result.brewingData);
         sendBrewingData(result.brewingData);
     }
 
@@ -643,23 +504,12 @@ export class Production extends React.Component<ProductionProps, ProductionState
         return TimeFormatter.formatSecondsToHMS(time);
     }
 
-    createTimelineData() {
-        const {brewingStatus} = this.props;
-
-        if (this.timelineData.length > 0) {
-            const lastObject = _.last(this.timelineData);
-            if (lastObject) {
-                lastObject.elapsed = brewingStatus?.elapsedTime ?? 0;
-            }
-        }
-    }
-
     renderFlames() {
         const {brewingStatus} = this.props;
 
         return (
             <div className='Flame'>
-              {(brewingStatus?.hardware?.heater === HeatingStates.ON || brewingStatus?.currentStep?.mode === ProcessMode.HEATING) && (
+              {isHeaterActive(brewingStatus) && (
                     <div className="flame-strip" aria-label="Heizung aktiv">
                         <Flame/>
                         <Flame/>
@@ -695,8 +545,7 @@ export class Production extends React.Component<ProductionProps, ProductionState
             mainSwitchState,
             intervalSwitchState,
             heatingAndStirringSwitchState,
-            waterSwitchState,
-            liters
+            waterSwitchState
         } = this.state;
         const mashWaterDisabled = this.isRecipeWaterButtonDisabled('mash');
         const spargeWaterDisabled = this.isRecipeWaterButtonDisabled('sparge');
@@ -793,47 +642,10 @@ export class Production extends React.Component<ProductionProps, ProductionState
 
             <div className="Water">
                 <WaterControl filledLiters={displayedWaterLiters} label={this.getDisplayedWaterLabel()} agitatorSpeed={currentAgitatorSpeed}
-                              agitatorState={brewingStatus?.hardware?.agitator === "ON"}
+                              agitatorState={isAgitatorActive(brewingStatus)}
                               contentType={getVesselContentType(brewingStatus)}></WaterControl>
 
             </div>);
-    }
-
-    renderProgressBar() {
-        const {brewingStatus} = this.props;
-        let statusText = '';
-        if (!isUndefined(brewingStatus)) {
-                statusText = getBrewingStatusLabel(brewingStatus);
-
-                if(brewingStatus?.currentStep?.mode === ProcessMode.HEATING){
-                    return (
-                        <div className="container mt-4">
-                            <h3 className='progressLabel'>{brewingStatus.currentStep?.name ?? "-"}</h3>
-                            <p className='progressLabel'>{statusText}</p>
-                        </div>
-                    );
-                }
-                const stepDuration = Number(brewingStatus?.currentStep?.duration);
-                const finishedInPercent = stepDuration > 0 ? Math.min(100, Math.max(0, Math.round((brewingStatus?.elapsedTime ?? 0) * 100 / stepDuration))) : 0;
-
-
-                const progressBarStyle = {
-                    width: '100%',
-                    maxWidth: '43rem',
-                    height: '3rem',
-                    marginLeft: '1rem'
-                };
-                return (
-                    <div className="container mt-4">
-                        <h3 className='progressLabel'>{brewingStatus.currentStep?.name ?? "-"}</h3>
-                        <p className='progressLabel'>{statusText}</p>
-                            <ProgressBar animated striped now={finishedInPercent} label={`${finishedInPercent}%`}
-                                         style={progressBarStyle}/>
-
-                    </div>
-                );
-
-        }
     }
 
     renderHeader() {
@@ -879,33 +691,13 @@ export class Production extends React.Component<ProductionProps, ProductionState
             addFinishedBrew(finishedBrew);
         }
     };
-    renderHopDialog() {
-        const {showHopsDialog,hopName} = this.state;
-        return (<div>
-            <ModalDialog onConfirm={this.confirmHopDialog} type={DialogType.CONFIRM} open={showHopsDialog}
-                         content={'Bitte den ' + hopName + ' Hopfen zufügen!'} header={"Hopfen Zufügen"}></ModalDialog>
-        </div>);
-
-    }
-
-    renderErrorDialog() {
-        const {showErrorDialog, errorDialogContent} = this.state
-        const {isBackenAvailable} = this.props
+    getErrorDialogContent = (): string => {
+        const {errorDialogContent} = this.state;
+        const {isBackenAvailable} = this.props;
         const statusText = typeof isBackenAvailable === 'boolean' ? '' : isBackenAvailable.statusText;
-        const contentText = errorDialogContent || ('Die Brau-Steuerung ist nicht erreichbar\n\n' + statusText)
-        return (<div>
-            <ModalDialog onConfirm={this.confirmErrorDialog} type={DialogType.ERROR} open={showErrorDialog}
-                         content={contentText} header={"Fehler!"}></ModalDialog>
-        </div>);
+        return errorDialogContent || ('Die Brau-Steuerung ist nicht erreichbar\n\n' + statusText);
     }
 
-    renderFinishDialog() {
-        const {showFinishDialog} = this.state
-        return (<div>
-            <ModalDialog onConfirm={this.confirmFinishDialog} type={DialogType.INFO} open={showFinishDialog}
-                         content={'Das Bier ist fertig!'} header={"Fertig!"}></ModalDialog>
-        </div>);
-    }
 
     renderProcessList() {
         const { selectedBeer, brewingStatus } = this.props;
@@ -916,23 +708,19 @@ export class Production extends React.Component<ProductionProps, ProductionState
 
 
     render() {
-        const {isBackenAvailable} = this.props;
-        const {showHopsDialog,showFinishDialog} = this.state;
-        this.createTimelineData();
+        const {showHopsDialog, showFinishDialog} = this.state;
         return (
             <div className="containerProduction ">
-                {
-                    showHopsDialog &&
-                    (this.renderHopDialog())
-                }
-                {
-                    isBackenAvailable &&
-                    (this.renderErrorDialog())
-                }
-                {
-                    showFinishDialog &&
-                    (this.renderFinishDialog())
-                }
+                <ProductionDialogs
+                    showHopsDialog={showHopsDialog}
+                    hopName={this.state.hopName}
+                    showErrorDialog={this.state.showErrorDialog || !this.isControllerAvailable()}
+                    errorContent={this.getErrorDialogContent()}
+                    showFinishDialog={showFinishDialog}
+                    onConfirmHop={this.confirmHopDialog}
+                    onConfirmError={this.confirmErrorDialog}
+                    onConfirmFinish={this.confirmFinishDialog}
+                />
 
                 {this.renderHeader()}
                 <div className="Left">
@@ -957,7 +745,7 @@ export class Production extends React.Component<ProductionProps, ProductionState
 
 }
 
-const mapDispatchToProps = (dispatch: any) => ({
+const mapDispatchToProps = (dispatch: Dispatch) => ({
     getTemperatures: () => {
         dispatch(ProductionActions.getTemperatures())
     },
@@ -987,12 +775,12 @@ const mapDispatchToProps = (dispatch: any) => ({
         dispatch(ProductionActions.nextProcedureStep())
     }
 });
-const mapStateToProps = (state: any) => (
+const mapStateToProps = (state: RootState) => (
     {
         selectedBeer: state.beerDataReducer.beerToBrew,
         temperature: state.productionReducer.temperature,
-        currentAgitatorState: state.productionReducer.setedAgitatorState,
-        currentAgitatorSpeed: state.productionReducer.setedAgitatorSpeed,
+        currentAgitatorState: state.productionReducer.currentAgitatorState,
+        currentAgitatorSpeed: state.productionReducer.currentAgitatorSpeed,
         agitatorIsRunning: state.productionReducer.agitatorIsRunning,
         agitatorSpeed: state.productionReducer.agitatorSpeed,
         isWaterFillingSuccessful: state.productionReducer.isWaterFillingSuccessful,

--- a/src/containers/Production/components/ProductionDialogs.tsx
+++ b/src/containers/Production/components/ProductionDialogs.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import ModalDialog, {DialogType} from '../../../components/ModalDialog/ModalDialog';
+
+export interface ProductionDialogsProps {
+    showHopsDialog: boolean;
+    hopName: string;
+    showErrorDialog: boolean;
+    errorContent: string;
+    showFinishDialog: boolean;
+    onConfirmHop: () => void;
+    onConfirmError: () => void;
+    onConfirmFinish: () => void;
+}
+
+export class ProductionDialogs extends React.Component<ProductionDialogsProps> {
+    render(): React.ReactNode {
+        const {showHopsDialog, hopName, showErrorDialog, errorContent, showFinishDialog, onConfirmHop, onConfirmError, onConfirmFinish} = this.props;
+        return (
+            <>
+                <ModalDialog onConfirm={onConfirmHop} type={DialogType.CONFIRM} open={showHopsDialog} content={'Bitte den ' + hopName + ' Hopfen zufügen!'} header="Hopfen Zufügen" />
+                <ModalDialog onConfirm={onConfirmError} type={DialogType.ERROR} open={showErrorDialog} content={errorContent} header="Fehler!" />
+                <ModalDialog onConfirm={onConfirmFinish} type={DialogType.INFO} open={showFinishDialog} content="Das Bier ist fertig!" header="Fertig!" />
+            </>
+        );
+    }
+}

--- a/src/containers/Production/utils/hopSchedule.test.ts
+++ b/src/containers/Production/utils/hopSchedule.test.ts
@@ -1,0 +1,23 @@
+import {Beer} from '../../../model/Beer';
+import {calculateHopSchedule, getDueHopAddition} from './hopSchedule';
+
+const beer = {
+    cookingTime: 60,
+    wortBoiling: {
+        hops: [
+            {name: 'A', time: 10},
+            {name: 'B', time: 10},
+            {name: 'C', time: 5}
+        ]
+    }
+} as unknown as Beer;
+
+describe('hop schedule', () => {
+    it('keeps multiple hops for the same time and triggers once when reached or skipped', () => {
+        const schedule = calculateHopSchedule(beer);
+        expect(schedule[0].names).toEqual(['A', 'B']);
+        const due = getDueHopAddition(schedule, 3001, []);
+        expect(due?.names).toEqual(['A', 'B']);
+        expect(getDueHopAddition(schedule, 3001, [3000])?.names).toEqual(['C']);
+    });
+});

--- a/src/containers/Production/utils/hopSchedule.ts
+++ b/src/containers/Production/utils/hopSchedule.ts
@@ -1,0 +1,18 @@
+import {Beer} from '../../../model/Beer';
+
+export interface HopAddition { timeSeconds: number; names: string[]; }
+
+export const calculateHopSchedule = (aBeer: Beer): HopAddition[] => {
+    const schedule = new Map<number, string[]>();
+    const totalCookingTime = Number(aBeer.cookingTime);
+    if (!Number.isFinite(totalCookingTime) || !aBeer.wortBoiling?.hops) return [];
+    aBeer.wortBoiling.hops.forEach((hop) => {
+        const timeSeconds = Math.max(0, Math.floor((totalCookingTime - Number(hop.time)) * 60));
+        const names = schedule.get(timeSeconds) ?? [];
+        schedule.set(timeSeconds, [...names, hop.name]);
+    });
+    return Array.from(schedule.entries()).map(([timeSeconds, names]) => ({timeSeconds, names})).sort((a, b) => a.timeSeconds - b.timeSeconds);
+};
+
+export const getDueHopAddition = (aSchedule: HopAddition[], aElapsedSeconds: number, aAnnouncedTimes: number[]): HopAddition | undefined =>
+    aSchedule.find((addition) => addition.timeSeconds <= aElapsedSeconds && !aAnnouncedTimes.includes(addition.timeSeconds));

--- a/src/containers/Production/utils/productionCountdown.test.ts
+++ b/src/containers/Production/utils/productionCountdown.test.ts
@@ -1,0 +1,26 @@
+import {BrewingStatus, ProcessMode, ProcessState, WaitingFor} from '../../../model/brewingStatus.types';
+import {getRemainingSecondsFromStatus, shouldCountdownLocally, tickRemainingSeconds} from './productionCountdown';
+
+const status = (mode: ProcessMode, remainingTime: number): BrewingStatus => ({
+    elapsedTime: 0,
+    currentTime: 0,
+    process: {state: ProcessState.ACTIVE},
+    currentStep: {mode, duration: 10, elapsedTime: 10 - remainingTime, remainingTime},
+    temperature: {},
+    hardware: {},
+    waiting: {waitingFor: WaitingFor.NONE, canConfirm: false},
+    error: {}
+});
+
+describe('production countdown', () => {
+    it('runs only during TIMER_RUNNING and not during HEATING', () => {
+        expect(shouldCountdownLocally(status(ProcessMode.TIMER_RUNNING, 5))).toBe(true);
+        expect(shouldCountdownLocally(status(ProcessMode.HEATING, 5))).toBe(false);
+    });
+
+    it('does not drop below zero and synchronizes new backend values', () => {
+        expect(tickRemainingSeconds(0)).toBe(0);
+        expect(getRemainingSecondsFromStatus(status(ProcessMode.TIMER_RUNNING, 7))).toBe(7);
+        expect(getRemainingSecondsFromStatus({...status(ProcessMode.TIMER_RUNNING, 7), process: {state: ProcessState.FINISHED}})).toBe(0);
+    });
+});

--- a/src/containers/Production/utils/productionCountdown.ts
+++ b/src/containers/Production/utils/productionCountdown.ts
@@ -1,0 +1,19 @@
+import {BrewingStatus, ProcessMode, ProcessState} from '../../../model/brewingStatus.types';
+
+export const shouldCountdownLocally = (aBrewingStatus?: BrewingStatus): boolean =>
+    aBrewingStatus?.process?.state === ProcessState.ACTIVE
+    && aBrewingStatus.currentStep?.mode === ProcessMode.TIMER_RUNNING
+    && Number(aBrewingStatus.currentStep?.duration) > 0;
+
+export const getRemainingSecondsFromStatus = (aBrewingStatus?: BrewingStatus): number | undefined => {
+    if (aBrewingStatus?.process?.state === ProcessState.FINISHED) return 0;
+    if (!shouldCountdownLocally(aBrewingStatus)) return undefined;
+    const remaining = Number(aBrewingStatus.currentStep?.remainingTime);
+    if (Number.isFinite(remaining) && remaining >= 0) return Math.floor(remaining);
+    const duration = Number(aBrewingStatus.currentStep?.duration);
+    const elapsed = Number(aBrewingStatus.currentStep?.elapsedTime);
+    return Number.isFinite(duration) && Number.isFinite(elapsed) ? Math.max(0, Math.floor(duration - elapsed)) : undefined;
+};
+
+export const tickRemainingSeconds = (aCurrent: number | undefined): number | undefined =>
+    typeof aCurrent === 'number' ? Math.max(0, aCurrent - 1) : undefined;

--- a/src/containers/Production/utils/productionStatus.ts
+++ b/src/containers/Production/utils/productionStatus.ts
@@ -1,0 +1,10 @@
+import {BackendAvailable} from '../../../reducers/productionReducer';
+import {BrewingStatus, ProcessMode} from '../../../model/brewingStatus.types';
+
+export const isControllerAvailable = (aBackendAvailable: BackendAvailable | boolean): boolean =>
+    typeof aBackendAvailable === 'boolean' ? aBackendAvailable : aBackendAvailable?.isBackenAvailable === true;
+
+export const isHeaterActive = (aBrewingStatus?: BrewingStatus): boolean =>
+    aBrewingStatus?.hardware?.heater === 'ON' || aBrewingStatus?.currentStep?.mode === ProcessMode.HEATING;
+
+export const isAgitatorActive = (aBrewingStatus?: BrewingStatus): boolean => aBrewingStatus?.hardware?.agitator === 'ON';

--- a/src/containers/Production/waterFill/recipeWaterFill.test.ts
+++ b/src/containers/Production/waterFill/recipeWaterFill.test.ts
@@ -1,0 +1,46 @@
+import {ProcessPhase, ProcessState, WaitingFor} from '../../../model/brewingStatus.types';
+import {completeWaterFill, createInitialRecipeWaterFillStatus, failWaterFill, markValveOpened, resetWaterFill, startWaterFill} from './recipeWaterFillState';
+import {getDisplayedWaterLiters, isRecipeWaterButtonDisabled, sanitizeLiters, shouldIncludeSpargeAfterMashingOut} from './recipeWaterFillSelectors';
+
+describe('recipe water fill state', () => {
+    it('starts sparge from IDLE and marks the valve opened', () => {
+        const filling = startWaterFill(createInitialRecipeWaterFillStatus(), 'sparge');
+        expect(filling.spargeState).toBe('FILLING');
+        expect(markValveOpened(filling).activeFillWasOpened).toBe(true);
+    });
+
+    it('completes sparge, keeps its water level and disables the sparge button', () => {
+        const completed = completeWaterFill(markValveOpened(startWaterFill(createInitialRecipeWaterFillStatus(), 'sparge')), 12.4);
+        expect(completed.spargeState).toBe('COMPLETED');
+        expect(completed.completedSpargeLiters).toBe(12.4);
+        expect(isRecipeWaterButtonDisabled('sparge', completed, 12, true, false)).toBe(true);
+        expect(getDisplayedWaterLiters(completed, {filledLiters: 0, targetLiters: 0, openClose: false})).toBe(12.4);
+    });
+
+    it('enables mash only after sparge and disables mash after completion', () => {
+        const initial = createInitialRecipeWaterFillStatus();
+        expect(isRecipeWaterButtonDisabled('mash', initial, 20, true, false)).toBe(true);
+        const spargeCompleted = completeWaterFill(markValveOpened(startWaterFill(initial, 'sparge')), 10);
+        expect(isRecipeWaterButtonDisabled('mash', spargeCompleted, 20, true, false)).toBe(false);
+        const mashCompleted = completeWaterFill(markValveOpened(startWaterFill(spargeCompleted, 'mash')), 20);
+        expect(isRecipeWaterButtonDisabled('mash', mashCompleted, 20, true, false)).toBe(true);
+    });
+
+    it('sets only the active fill to ERROR and resets for a new brew', () => {
+        const failed = failWaterFill(startWaterFill(createInitialRecipeWaterFillStatus(), 'mash'));
+        expect(failed.mashState).toBe('ERROR');
+        expect(failed.spargeState).toBe('IDLE');
+        expect(resetWaterFill()).toEqual(createInitialRecipeWaterFillStatus());
+    });
+
+    it('adds mash and sparge after mashing out and sanitizes invalid backend values', () => {
+        const mashCompleted = completeWaterFill(markValveOpened(startWaterFill(completeWaterFill(markValveOpened(startWaterFill(createInitialRecipeWaterFillStatus(), 'sparge')), 8), 'mash')), 22);
+        const previousStatus = {waiting: {waitingFor: WaitingFor.MASHING_OUT_CONFIRMATION, canConfirm: true}};
+        const currentStatus = {process: {state: ProcessState.ACTIVE}, currentStep: {phase: ProcessPhase.COOKING}};
+        expect(shouldIncludeSpargeAfterMashingOut(mashCompleted, previousStatus, currentStatus)).toBe(true);
+        expect(getDisplayedWaterLiters({...mashCompleted, isSpargeIncluded: true})).toBe(30);
+        expect(sanitizeLiters(Number.NaN)).toBe(0);
+        expect(sanitizeLiters(undefined)).toBe(0);
+        expect(sanitizeLiters(-1)).toBe(0);
+    });
+});

--- a/src/containers/Production/waterFill/recipeWaterFill.types.ts
+++ b/src/containers/Production/waterFill/recipeWaterFill.types.ts
@@ -1,0 +1,20 @@
+export type RecipeWaterFill = 'mash' | 'sparge';
+export type WaterFillType = 'SPARGE' | 'MASH';
+export type WaterFillState = 'IDLE' | 'FILLING' | 'COMPLETED' | 'ERROR';
+
+export interface RecipeWaterFillStatus {
+    activeFillType?: WaterFillType;
+    spargeState: WaterFillState;
+    mashState: WaterFillState;
+    completedSpargeLiters: number;
+    completedMashLiters: number;
+    currentFillLiters: number;
+    activeFillWasOpened: boolean;
+    isSpargeIncluded: boolean;
+}
+
+export interface WaterStatusSnapshot {
+    filledLiters?: number;
+    targetLiters?: number;
+    openClose?: boolean;
+}

--- a/src/containers/Production/waterFill/recipeWaterFillSelectors.ts
+++ b/src/containers/Production/waterFill/recipeWaterFillSelectors.ts
@@ -1,0 +1,53 @@
+import {BrewingStatus, ProcessPhase, ProcessState, WaitingFor} from '../../../model/brewingStatus.types';
+import {RecipeWaterFill, RecipeWaterFillStatus, WaterStatusSnapshot} from './recipeWaterFill.types';
+
+export const sanitizeLiters = (aValue: unknown): number => {
+    const numericValue = Number(aValue);
+    return Number.isFinite(numericValue) && numericValue > 0 ? numericValue : 0;
+};
+
+export const getDisplayedWaterLiters = (aStatus: RecipeWaterFillStatus, aWaterStatus?: WaterStatusSnapshot): number => {
+    if (aStatus.isSpargeIncluded) {
+        return aStatus.completedMashLiters + aStatus.completedSpargeLiters;
+    }
+    if (aStatus.activeFillType !== undefined || aWaterStatus?.openClose === true) {
+        return sanitizeLiters(aWaterStatus?.filledLiters);
+    }
+    if (aStatus.mashState === 'COMPLETED') {
+        return aStatus.completedMashLiters;
+    }
+    return sanitizeLiters(aStatus.currentFillLiters);
+};
+
+export const getWaterTargetLiters = (aStatus: RecipeWaterFillStatus, aRecipeLiters: number, aWaterStatus?: WaterStatusSnapshot): number => {
+    if (aStatus.activeFillType !== undefined || aWaterStatus?.openClose === true) {
+        const target = sanitizeLiters(aWaterStatus?.targetLiters);
+        if (target > 0) {
+            return target;
+        }
+    }
+    return sanitizeLiters(aRecipeLiters);
+};
+
+export const getWaterLabel = (aStatus: RecipeWaterFillStatus): string => {
+    if (aStatus.isSpargeIncluded) return 'Brauwasser gesamt';
+    if (aStatus.activeFillType === 'SPARGE' || (aStatus.spargeState === 'COMPLETED' && aStatus.mashState === 'IDLE')) return 'Nachguss';
+    if (aStatus.activeFillType === 'MASH' || aStatus.mashState === 'COMPLETED') return 'Hauptguss';
+    return 'Aktueller Füllvorgang';
+};
+
+export const isWaterFillingActive = (aStatus: RecipeWaterFillStatus, aWaterSwitchState: boolean, aWaterStatus?: WaterStatusSnapshot): boolean =>
+    aWaterSwitchState || aStatus.activeFillType !== undefined || aWaterStatus?.openClose === true;
+
+export const isRecipeWaterButtonDisabled = (aFill: RecipeWaterFill, aStatus: RecipeWaterFillStatus, aVolume: number | undefined, aControllerAvailable: boolean, aIsActive: boolean): boolean => {
+    if (aVolume === undefined || !aControllerAvailable || aIsActive) return true;
+    if (aFill === 'sparge') return aStatus.spargeState === 'COMPLETED' || aStatus.mashState !== 'IDLE';
+    return aStatus.spargeState !== 'COMPLETED' || aStatus.mashState === 'COMPLETED';
+};
+
+export const shouldIncludeSpargeAfterMashingOut = (aStatus: RecipeWaterFillStatus, aPreviousStatus?: BrewingStatus, aCurrentStatus?: BrewingStatus): boolean => {
+    if (aStatus.isSpargeIncluded || aStatus.spargeState !== 'COMPLETED' || aStatus.mashState !== 'COMPLETED') return false;
+    const currentPhase = aCurrentStatus?.currentStep?.phase;
+    return aPreviousStatus?.waiting?.waitingFor === WaitingFor.MASHING_OUT_CONFIRMATION
+        && (currentPhase === ProcessPhase.COOKING || currentPhase === ProcessPhase.COOLING || currentPhase === ProcessPhase.FINISHED || aCurrentStatus?.process?.state === ProcessState.FINISHED);
+};

--- a/src/containers/Production/waterFill/recipeWaterFillState.ts
+++ b/src/containers/Production/waterFill/recipeWaterFillState.ts
@@ -1,0 +1,57 @@
+import {RecipeWaterFill, RecipeWaterFillStatus, WaterFillType} from './recipeWaterFill.types';
+
+export const createInitialRecipeWaterFillStatus = (): RecipeWaterFillStatus => ({
+    activeFillType: undefined,
+    spargeState: 'IDLE',
+    mashState: 'IDLE',
+    completedSpargeLiters: 0,
+    completedMashLiters: 0,
+    currentFillLiters: 0,
+    activeFillWasOpened: false,
+    isSpargeIncluded: false
+});
+
+export const getWaterFillType = (aFill: RecipeWaterFill): WaterFillType => aFill === 'mash' ? 'MASH' : 'SPARGE';
+
+export const startWaterFill = (aStatus: RecipeWaterFillStatus, aFill: RecipeWaterFill): RecipeWaterFillStatus => {
+    const activeFillType = getWaterFillType(aFill);
+    return {
+        ...aStatus,
+        activeFillType,
+        currentFillLiters: 0,
+        activeFillWasOpened: false,
+        mashState: activeFillType === 'MASH' ? 'FILLING' : aStatus.mashState,
+        spargeState: activeFillType === 'SPARGE' ? 'FILLING' : aStatus.spargeState
+    };
+};
+
+export const markValveOpened = (aStatus: RecipeWaterFillStatus): RecipeWaterFillStatus => ({...aStatus, activeFillWasOpened: true});
+
+export const completeWaterFill = (aStatus: RecipeWaterFillStatus, aCompletedLiters: number): RecipeWaterFillStatus => {
+    const completedLiters = Math.max(0, Number.isFinite(aCompletedLiters) ? aCompletedLiters : 0);
+    const activeFillType = aStatus.activeFillType;
+    if (activeFillType === undefined) {
+        return {...aStatus, activeFillWasOpened: false};
+    }
+    return {
+        ...aStatus,
+        activeFillType: undefined,
+        activeFillWasOpened: false,
+        currentFillLiters: completedLiters,
+        completedMashLiters: activeFillType === 'MASH' ? completedLiters : aStatus.completedMashLiters,
+        completedSpargeLiters: activeFillType === 'SPARGE' ? completedLiters : aStatus.completedSpargeLiters,
+        mashState: activeFillType === 'MASH' ? 'COMPLETED' : aStatus.mashState,
+        spargeState: activeFillType === 'SPARGE' ? 'COMPLETED' : aStatus.spargeState
+    };
+};
+
+export const failWaterFill = (aStatus: RecipeWaterFillStatus): RecipeWaterFillStatus => ({
+    ...aStatus,
+    activeFillType: undefined,
+    activeFillWasOpened: false,
+    currentFillLiters: 0,
+    spargeState: aStatus.activeFillType === 'SPARGE' ? 'ERROR' : aStatus.spargeState,
+    mashState: aStatus.activeFillType === 'MASH' ? 'ERROR' : aStatus.mashState
+});
+
+export const resetWaterFill = (): RecipeWaterFillStatus => createInitialRecipeWaterFillStatus();

--- a/src/reducers/rootReducer.ts
+++ b/src/reducers/rootReducer.ts
@@ -18,5 +18,6 @@ export const rootReducer = combineReducers({
 
 });
 
+export type RootState = ReturnType<typeof rootReducer>;
 export type { ApplicationReducerState, BeerDataReducerState, ProductionReducerState, HopsReducerState, MaltsReducerState, YeastReducerState, AdditionalIngredientsReducerState };
 export { initialApplicationState, initialBeerState, initialProductionState ,initialHopsState, initialMaltsState, initialYeastState, initialAdditionalIngredientsState};


### PR DESCRIPTION
### Motivation
- The original `Production` component had grown too large and mixed UI, lifecycle, polling, water-fill state machine, countdown and hop-schedule logic in one file, making it hard to maintain and test. 
- Water-fill and controller-status logic was duplicated and caused display/behaviour bugs (displayed liters not used, agitator state hard-coded, finish-dialog gating error). 
- Countdown and hop-schedule behaviors require pure, testable functions that must not depend on render-time side effects. 
- Timers and delayed timeouts were created but not reliably cleaned up on unmount, risking `setState()` after unmount. 

### Description
- Extracted recipe water-fill types, pure state transitions and selectors into `src/containers/Production/waterFill/recipeWaterFill.types.ts`, `recipeWaterFillState.ts` and `recipeWaterFillSelectors.ts` and updated `Production` to use a single `recipeWaterFill` state object. 
- Moved countdown, hop-schedule and controller-status helpers into `src/containers/Production/utils/productionCountdown.ts`, `hopSchedule.ts` and `productionStatus.ts` and changed `Production` to consume these pure helpers (`tickRemainingSeconds`, `getRemainingSecondsFromStatus`, `calculateHopSchedule`, `getDueHopAddition`, `isHeaterActive`, `isAgitatorActive`). 
- Introduced `ProductionDialogs` class component (`src/containers/Production/components/ProductionDialogs.tsx`) and replaced inline dialog rendering with a single typed dialog component; fixed finish-dialog gating so it opens only once per brew. 
- Reworked `Production` to use the extracted helpers: pass the calculated `filledLiters` and real agitator status to `WaterControl`, normalize controller availability via `isControllerAvailable`, remove render-time timeline side-effects, track and clear all timeouts/intervals on unmount, and reduce inline state fields. 
- Improved typing by adding `RootState` in `src/reducers/rootReducer.ts`, replacing `mapStateToProps`'s `any` with `RootState`, and using `Dispatch` in `mapDispatchToProps`. 

### Testing
- Added unit tests for water-fill behavior, countdown and hop scheduling in `src/containers/Production/waterFill/recipeWaterFill.test.ts`, `src/containers/Production/utils/productionCountdown.test.ts` and `src/containers/Production/utils/hopSchedule.test.ts` but execution was not possible in this environment. 
- `git diff --check` and local source checks passed in this environment. 
- Attempts to run the TypeScript check and the project test/build commands (`tsc --noEmit`, `npm run build`, `CI=true npm test -- --runTestsByPath ...`) failed because `npm install` / dependency installation was blocked by environment registry access (`403 Forbidden`), so automated test execution and full `tsc` build could not be completed here. 
- The new pure helpers and state transitions are unit-testable and the added test files exercise the required water-fill, countdown and hop-schedule cases (tests added but not executed due to environment constraints).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a63059a41d8832fa8dc65d5c1339fa8)