### PR TITLE
Fix production TypeScript errors and tighten water-fill selector types

### DIFF
--- a/src/containers/Production/utils/productionCountdown.test.ts
+++ b/src/containers/Production/utils/productionCountdown.test.ts
@@ -1,11 +1,11 @@
-import {BrewingStatus, ProcessMode, ProcessState, WaitingFor} from '../../../model/brewingStatus.types';
+import {BrewingStatus, ProcessMode, ProcessPhase, ProcessState, WaitingFor} from '../../../model/brewingStatus.types';
 import {getRemainingSecondsFromStatus, shouldCountdownLocally, tickRemainingSeconds} from './productionCountdown';
 
 const status = (mode: ProcessMode, remainingTime: number): BrewingStatus => ({
     elapsedTime: 0,
     currentTime: 0,
     process: {state: ProcessState.ACTIVE},
-    currentStep: {mode, duration: 10, elapsedTime: 10 - remainingTime, remainingTime},
+    currentStep: {phase: ProcessPhase.RAST, mode, duration: 10, elapsedTime: 10 - remainingTime, remainingTime},
     temperature: {},
     hardware: {},
     waiting: {waitingFor: WaitingFor.NONE, canConfirm: false},

--- a/src/containers/Production/utils/productionCountdown.ts
+++ b/src/containers/Production/utils/productionCountdown.ts
@@ -7,7 +7,7 @@ export const shouldCountdownLocally = (aBrewingStatus?: BrewingStatus): boolean 
 
 export const getRemainingSecondsFromStatus = (aBrewingStatus?: BrewingStatus): number | undefined => {
     if (aBrewingStatus?.process?.state === ProcessState.FINISHED) return 0;
-    if (!shouldCountdownLocally(aBrewingStatus)) return undefined;
+    if (aBrewingStatus === undefined || !shouldCountdownLocally(aBrewingStatus)) return undefined;
     const remaining = Number(aBrewingStatus.currentStep?.remainingTime);
     if (Number.isFinite(remaining) && remaining >= 0) return Math.floor(remaining);
     const duration = Number(aBrewingStatus.currentStep?.duration);

--- a/src/containers/Production/waterFill/recipeWaterFillSelectors.ts
+++ b/src/containers/Production/waterFill/recipeWaterFillSelectors.ts
@@ -1,6 +1,12 @@
 import {BrewingStatus, ProcessPhase, ProcessState, WaitingFor} from '../../../model/brewingStatus.types';
 import {RecipeWaterFill, RecipeWaterFillStatus, WaterStatusSnapshot} from './recipeWaterFill.types';
 
+type BrewingStatusTransitionSnapshot = {
+    process?: Partial<BrewingStatus['process']>;
+    currentStep?: Partial<BrewingStatus['currentStep']>;
+    waiting?: Partial<BrewingStatus['waiting']>;
+};
+
 export const sanitizeLiters = (aValue: unknown): number => {
     const numericValue = Number(aValue);
     return Number.isFinite(numericValue) && numericValue > 0 ? numericValue : 0;
@@ -45,7 +51,7 @@ export const isRecipeWaterButtonDisabled = (aFill: RecipeWaterFill, aStatus: Rec
     return aStatus.spargeState !== 'COMPLETED' || aStatus.mashState === 'COMPLETED';
 };
 
-export const shouldIncludeSpargeAfterMashingOut = (aStatus: RecipeWaterFillStatus, aPreviousStatus?: BrewingStatus, aCurrentStatus?: BrewingStatus): boolean => {
+export const shouldIncludeSpargeAfterMashingOut = (aStatus: RecipeWaterFillStatus, aPreviousStatus?: BrewingStatusTransitionSnapshot, aCurrentStatus?: BrewingStatusTransitionSnapshot): boolean => {
     if (aStatus.isSpargeIncluded || aStatus.spargeState !== 'COMPLETED' || aStatus.mashState !== 'COMPLETED') return false;
     const currentPhase = aCurrentStatus?.currentStep?.phase;
     return aPreviousStatus?.waiting?.waitingFor === WaitingFor.MASHING_OUT_CONFIRMATION

--- a/src/reducers/rootReducer.ts
+++ b/src/reducers/rootReducer.ts
@@ -18,6 +18,14 @@ export const rootReducer = combineReducers({
 
 });
 
-export type RootState = ReturnType<typeof rootReducer>;
+export interface RootState {
+    applicationReducer: ApplicationReducerState;
+    beerDataReducer: BeerDataReducerState;
+    productionReducer: ProductionReducerState;
+    hopsReducer: HopsReducerState;
+    maltsReducer: MaltsReducerState;
+    yeastReducer: YeastReducerState;
+    additionalIngredientsReducer: AdditionalIngredientsReducerState;
+}
 export type { ApplicationReducerState, BeerDataReducerState, ProductionReducerState, HopsReducerState, MaltsReducerState, YeastReducerState, AdditionalIngredientsReducerState };
 export { initialApplicationState, initialBeerState, initialProductionState ,initialHopsState, initialMaltsState, initialYeastState, initialAdditionalIngredientsState};


### PR DESCRIPTION
### Motivation

- Remove TypeScript errors that prevented the production container and its utilities from compiling and from using typed reducer slices. 
- Ensure the countdown logic and its tests handle optional/missing `BrewingStatus` fields safely. 
- Align the water-fill selector input types with how the selector is actually used during status transitions and in tests.

### Description

- Define an explicit `RootState` interface in `src/reducers/rootReducer.ts` so `mapStateToProps` consumers (e.g. Production) no longer see reducer slices as `never`.
- Add an explicit `undefined` guard in `src/containers/Production/utils/productionCountdown.ts` before reading `currentStep` fields to avoid unsafe access on an optional `BrewingStatus`.
- Update `src/containers/Production/utils/productionCountdown.test.ts` to include the required `currentStep.phase` field in the test fixture so the test types match the model.
- Relax the water-fill transition selector signature in `src/containers/Production/waterFill/recipeWaterFillSelectors.ts` to accept a lightweight `BrewingStatusTransitionSnapshot` (partial of `process`, `currentStep`, `waiting`) instead of the full `BrewingStatus`.

### Testing

- `git diff --check` was run and showed no whitespace/patch problems. 
- Type-check attempts with `tsc --noEmit` and targeted `tsc` runs were executed, and the modified files type-check with the added guards and type adjustments, but a full project type-check surfaced unrelated missing dependency/type-definition errors due to the environment.
- `npm test` and `npm run build` were attempted but could not complete because `node_modules/.bin/react-scripts` was not available in the execution environment, and `npm install` failed due to registry access (`403 Forbidden`) when trying to fetch type packages.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6309cb9fd8832f9386b5ee79157b8d)