### PR TITLE
Handle optional selectedBeer, harden countdown & water-fill logic, and export explicit RootState

### DIFF
--- a/src/containers/Production/Production.tsx
+++ b/src/containers/Production/Production.tsx
@@ -43,7 +43,7 @@ import {ProductionDialogs} from "./components/ProductionDialogs";
 import {getDisplayedWaterLiters as selectDisplayedWaterLiters, getWaterLabel, getWaterTargetLiters, isRecipeWaterButtonDisabled as selectRecipeWaterButtonDisabled, isWaterFillingActive as selectWaterFillingActive, shouldIncludeSpargeAfterMashingOut as selectShouldIncludeSpargeAfterMashingOut, sanitizeLiters} from "./waterFill/recipeWaterFillSelectors";
 
 export interface ProductionProps {
-    selectedBeer: Beer;
+    selectedBeer?: Beer;
     temperature: number;
     currentAgitatorState: ToggleState;
     currentAgitatorSpeed: number;
@@ -277,7 +277,8 @@ export class Production extends React.Component<ProductionProps, ProductionState
     }
 
     calculateTheHopTimes() {
-        this.setState({hopSchedule: calculateHopSchedule(this.props.selectedBeer), announcedHopTimes: []});
+        const {selectedBeer} = this.props;
+        this.setState({hopSchedule: selectedBeer ? calculateHopSchedule(selectedBeer) : [], announcedHopTimes: []});
     }
 
     setAgitatorStates(mainSwitchState: boolean) {
@@ -465,7 +466,7 @@ export class Production extends React.Component<ProductionProps, ProductionState
 
     startBrewing = (): void => {
         const {selectedBeer, sendBrewingData} = this.props;
-        if (this.isStartButtonDisabled()) {
+        if (selectedBeer === undefined || this.isStartButtonDisabled()) {
             return;
         }
         this.resetRecipeWaterFillState();
@@ -701,6 +702,9 @@ export class Production extends React.Component<ProductionProps, ProductionState
 
     renderProcessList() {
         const { selectedBeer, brewingStatus } = this.props;
+        if (selectedBeer === undefined) {
+            return null;
+        }
         return (
             <ProcessList selectedBeer={selectedBeer} currentStepIndex={brewingStatus?.currentStep?.index ?? 0} currentStep={brewingStatus?.currentStep} brewingStatus={brewingStatus} remainingSeconds={this.state.displayedRemainingSeconds} onNextStep={this.handleNextProcedureStep} isNextStepDisabled={!this.isNextProcedureStepAvailable()} />
         );

--- a/src/containers/Production/utils/productionCountdown.test.ts
+++ b/src/containers/Production/utils/productionCountdown.test.ts
@@ -1,11 +1,11 @@
-import {BrewingStatus, ProcessMode, ProcessState, WaitingFor} from '../../../model/brewingStatus.types';
+import {BrewingStatus, ProcessMode, ProcessPhase, ProcessState, WaitingFor} from '../../../model/brewingStatus.types';
 import {getRemainingSecondsFromStatus, shouldCountdownLocally, tickRemainingSeconds} from './productionCountdown';
 
 const status = (mode: ProcessMode, remainingTime: number): BrewingStatus => ({
     elapsedTime: 0,
     currentTime: 0,
     process: {state: ProcessState.ACTIVE},
-    currentStep: {mode, duration: 10, elapsedTime: 10 - remainingTime, remainingTime},
+    currentStep: {phase: ProcessPhase.RAST, mode, duration: 10, elapsedTime: 10 - remainingTime, remainingTime},
     temperature: {},
     hardware: {},
     waiting: {waitingFor: WaitingFor.NONE, canConfirm: false},

--- a/src/containers/Production/utils/productionCountdown.ts
+++ b/src/containers/Production/utils/productionCountdown.ts
@@ -7,7 +7,7 @@ export const shouldCountdownLocally = (aBrewingStatus?: BrewingStatus): boolean 
 
 export const getRemainingSecondsFromStatus = (aBrewingStatus?: BrewingStatus): number | undefined => {
     if (aBrewingStatus?.process?.state === ProcessState.FINISHED) return 0;
-    if (!shouldCountdownLocally(aBrewingStatus)) return undefined;
+    if (aBrewingStatus === undefined || !shouldCountdownLocally(aBrewingStatus)) return undefined;
     const remaining = Number(aBrewingStatus.currentStep?.remainingTime);
     if (Number.isFinite(remaining) && remaining >= 0) return Math.floor(remaining);
     const duration = Number(aBrewingStatus.currentStep?.duration);

--- a/src/containers/Production/waterFill/recipeWaterFillSelectors.ts
+++ b/src/containers/Production/waterFill/recipeWaterFillSelectors.ts
@@ -1,6 +1,12 @@
 import {BrewingStatus, ProcessPhase, ProcessState, WaitingFor} from '../../../model/brewingStatus.types';
 import {RecipeWaterFill, RecipeWaterFillStatus, WaterStatusSnapshot} from './recipeWaterFill.types';
 
+type BrewingStatusTransitionSnapshot = {
+    process?: Partial<BrewingStatus['process']>;
+    currentStep?: Partial<BrewingStatus['currentStep']>;
+    waiting?: Partial<BrewingStatus['waiting']>;
+};
+
 export const sanitizeLiters = (aValue: unknown): number => {
     const numericValue = Number(aValue);
     return Number.isFinite(numericValue) && numericValue > 0 ? numericValue : 0;
@@ -45,7 +51,7 @@ export const isRecipeWaterButtonDisabled = (aFill: RecipeWaterFill, aStatus: Rec
     return aStatus.spargeState !== 'COMPLETED' || aStatus.mashState === 'COMPLETED';
 };
 
-export const shouldIncludeSpargeAfterMashingOut = (aStatus: RecipeWaterFillStatus, aPreviousStatus?: BrewingStatus, aCurrentStatus?: BrewingStatus): boolean => {
+export const shouldIncludeSpargeAfterMashingOut = (aStatus: RecipeWaterFillStatus, aPreviousStatus?: BrewingStatusTransitionSnapshot, aCurrentStatus?: BrewingStatusTransitionSnapshot): boolean => {
     if (aStatus.isSpargeIncluded || aStatus.spargeState !== 'COMPLETED' || aStatus.mashState !== 'COMPLETED') return false;
     const currentPhase = aCurrentStatus?.currentStep?.phase;
     return aPreviousStatus?.waiting?.waitingFor === WaitingFor.MASHING_OUT_CONFIRMATION

--- a/src/reducers/rootReducer.ts
+++ b/src/reducers/rootReducer.ts
@@ -18,6 +18,14 @@ export const rootReducer = combineReducers({
 
 });
 
-export type RootState = ReturnType<typeof rootReducer>;
+export interface RootState {
+    applicationReducer: ApplicationReducerState;
+    beerDataReducer: BeerDataReducerState;
+    productionReducer: ProductionReducerState;
+    hopsReducer: HopsReducerState;
+    maltsReducer: MaltsReducerState;
+    yeastReducer: YeastReducerState;
+    additionalIngredientsReducer: AdditionalIngredientsReducerState;
+}
 export type { ApplicationReducerState, BeerDataReducerState, ProductionReducerState, HopsReducerState, MaltsReducerState, YeastReducerState, AdditionalIngredientsReducerState };
 export { initialApplicationState, initialBeerState, initialProductionState ,initialHopsState, initialMaltsState, initialYeastState, initialAdditionalIngredientsState};


### PR DESCRIPTION
### Motivation
- Prevent runtime errors when `selectedBeer` is not provided to the Production container.  
- Ensure countdown helpers are resilient to missing or finished brewing status data.  
- Make water-fill sparge-inclusion logic safer by using a narrower transition snapshot shape instead of full `BrewingStatus`.  
- Provide an explicit `RootState` interface for clearer typing instead of using `ReturnType` on the reducer.

### Description
- Made `ProductionProps.selectedBeer` optional and added guards in `calculateTheHopTimes`, `startBrewing`, and `renderProcessList` to avoid dereferencing `undefined`.  
- Hardened `getRemainingSecondsFromStatus` to return `undefined` when the status is missing and kept `tickRemainingSeconds` behavior, while importing `ProcessPhase` where needed.  
- Updated `productionCountdown.test.ts` to include `ProcessPhase` in the `currentStep` fixture and adjusted imports accordingly.  
- Introduced `BrewingStatusTransitionSnapshot` and changed `shouldIncludeSpargeAfterMashingOut` to accept partial transition snapshots to avoid relying on full `BrewingStatus` objects.  
- Replaced `ReturnType<typeof rootReducer>` with an explicit `RootState` interface in `rootReducer.ts` and preserved exported reducer state types.

### Testing
- Ran the updated unit test `productionCountdown.test.ts`, which passed.  
- Performed TypeScript type-checking after the changes, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6309cb9fd8832f9386b5ee79157b8d)