### PR TITLE
Extract Redux connectors to separate .connect files and convert components to pure exports

### DIFF
--- a/src/containers/App.tsx
+++ b/src/containers/App.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
-import Header from './MainView/Header/Header';
+import Header from './MainView/Header/Header.connect';
 import './App.css';
-import Index from "./index";
-import MobileProductionView from './Mobile/MobileStatusView/MobileProductionView';
+import Index from "./index.connect";
+import MobileProductionView from './Mobile/MobileStatusView/MobileProductionView.connect';
 
 const App: React.FC = () => {
     const isMobile = window.innerWidth < 768;

--- a/src/containers/Dashboard/DashboardPage.connect.ts
+++ b/src/containers/Dashboard/DashboardPage.connect.ts
@@ -1,0 +1,25 @@
+import { connect } from 'react-redux';
+import { BeerActions } from '../../actions/actions';
+import { BeerDataReducerState, ProductionReducerState } from '../../reducers/rootReducer';
+import {DashboardPage} from './DashboardPage';
+
+interface DashboardRootState {
+  beerDataReducer: BeerDataReducerState;
+  productionReducer: ProductionReducerState;
+}
+
+const mapStateToProps = (state: DashboardRootState) => ({
+  beers: state.beerDataReducer.beers,
+  finishedBrews: state.beerDataReducer.finishedBrews,
+  isFetching: state.beerDataReducer.isFetching,
+  beerToBrew: state.beerDataReducer.beerToBrew,
+  brewingStatus: state.productionReducer.brewingStatus,
+  isBackendAvailable: state.productionReducer.isBackenAvailable,
+});
+
+const mapDispatchToProps = (dispatch: (action: BeerActions.AllBeerActions) => void) => ({
+  getBeers: (isFetching: boolean) => dispatch(BeerActions.getBeers(isFetching)),
+  getFinishedBrews: (isFetching: boolean) => dispatch(BeerActions.getFinishedBeers(isFetching)),
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(DashboardPage);

--- a/src/containers/Dashboard/DashboardPage.tsx
+++ b/src/containers/Dashboard/DashboardPage.tsx
@@ -1,23 +1,16 @@
 import React from 'react';
-import { connect } from 'react-redux';
 import AssessmentIcon from '@mui/icons-material/Assessment';
 import LocalDrinkIcon from '@mui/icons-material/LocalDrink';
 import ScienceIcon from '@mui/icons-material/Science';
 import WarningAmberIcon from '@mui/icons-material/WarningAmber';
-import { BeerActions } from '../../actions/actions';
 import { Beer } from '../../model/Beer';
 import { FinishedBrew } from '../../model/FinishedBrew';
 import { BrewingStatus, ProcessMode, ProcessState } from '../../model/brewingStatus.types';
-import { BeerDataReducerState, ProductionReducerState } from '../../reducers/rootReducer';
 import { getBrewingStatusLabel, isProcessActive } from '../../utils/brewingStatus/selectors';
 import { buildActiveBrewRows, calculateCareHints, calculateDashboardKpis, calculateIngredientSummary, calculateMonthlyStats, formatDashboardQuantity, safeNumber } from '../../utils/Dashboard/dashboardCalculations';
 import { DashboardIngredientUsage, DashboardYeastUsage } from '../../utils/Dashboard/dashboardTypes';
 import './DashboardPage.css';
 
-interface DashboardRootState {
-  beerDataReducer: BeerDataReducerState;
-  productionReducer: ProductionReducerState;
-}
 
 interface DashboardPageProps {
   beers?: Beer[];
@@ -224,19 +217,3 @@ export class DashboardPage extends React.Component<DashboardPageProps> {
     );
   }
 }
-
-const mapStateToProps = (state: DashboardRootState) => ({
-  beers: state.beerDataReducer.beers,
-  finishedBrews: state.beerDataReducer.finishedBrews,
-  isFetching: state.beerDataReducer.isFetching,
-  beerToBrew: state.beerDataReducer.beerToBrew,
-  brewingStatus: state.productionReducer.brewingStatus,
-  isBackendAvailable: state.productionReducer.isBackenAvailable,
-});
-
-const mapDispatchToProps = (dispatch: (action: BeerActions.AllBeerActions) => void) => ({
-  getBeers: (isFetching: boolean) => dispatch(BeerActions.getBeers(isFetching)),
-  getFinishedBrews: (isFetching: boolean) => dispatch(BeerActions.getFinishedBeers(isFetching)),
-});
-
-export default connect(mapStateToProps, mapDispatchToProps)(DashboardPage);

--- a/src/containers/DatabaseOverview/BeerForm.connect.ts
+++ b/src/containers/DatabaseOverview/BeerForm.connect.ts
@@ -1,0 +1,36 @@
+import {connect} from "react-redux";
+import {Beer, Hop, Malt, Yeast} from "../../model/Beer";
+import {BeerDTO} from "../../model/BeerDTO";
+import {BeerActions} from "../../actions/actions";
+import {MaltsActions} from "../../actions/malt.actions";
+import {HopsActions} from "../../actions/hops.actions";
+import {YeastActions} from "../../actions/yeast.actions";
+import {AdditionalIngredientsActions} from "../../actions/additionalIngredients.actions";
+import {AdditionalIngredient} from "../../model/AdditionalIngredient";
+import {BeerForm} from './BeerForm';
+
+const mapStateToProps = (state: any) => ({
+    malts: state.maltsReducer.malts,
+    hops: state.hopsReducer.hops,
+    yeasts: state.yeastReducer.yeasts,
+    additionalIngredients: state.additionalIngredientsReducer.additionalIngredients || [],
+    isSubmitSuccessful: state.beerDataReducer.isSubmitSuccessful,
+    message: state.beerDataReducer.message,
+    messageType: state.beerDataReducer.type,
+    beerFormState: state.beerDataReducer.beerFormState,
+    beers: state.beerDataReducer.beers,
+    importedBeer: state.beerDataReducer.importedBeer,
+    isSavingBeer: state.beerDataReducer.isSavingBeer,
+});
+
+const mapDispatchToProps = (dispatch: any) => ({
+    onSubmitBeer: (beer: BeerDTO) => dispatch(BeerActions.submitBeer(beer)),
+    getMalt: (isFetching: boolean) => dispatch(MaltsActions.getMalts(isFetching)),
+    getHop: (isFetching: boolean) => dispatch(HopsActions.getHops(isFetching)),
+    getYeast: (isFetching: boolean) => dispatch(YeastActions.getYeasts(isFetching)),
+    getAdditionalIngredients: (isFetching: boolean) => dispatch(AdditionalIngredientsActions.getAdditionalIngredients(isFetching)),
+    saveBeerFormState: (formState: any) => dispatch(BeerActions.saveBeerFormState(formState)),
+    importBeer: (file: File) => dispatch(BeerActions.importBeer(file)),
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(BeerForm);

--- a/src/containers/DatabaseOverview/BeerForm.tsx
+++ b/src/containers/DatabaseOverview/BeerForm.tsx
@@ -5,17 +5,11 @@ import { HopUsage } from "../../enums/eHopUsage";
 import { HopTimeUnit } from "../../enums/eHopTimeUnit";
 import { normalizeHopDto, updateHopUsage, validateHopDto } from "./hopDefaults";
 import { isValidExecutionMode, normalizeFermentationStep } from "./fermentationDefaults";
-import {BeerActions} from "../../actions/actions";
-import {connect} from "react-redux";
 import {isEqual} from "lodash";
 
 import {MashingType} from "../../enums/eMashingType";
 import {RestExecutionMode} from "../../enums/eRestExecutionMode";
 import './BeerForm.css'
-import {MaltsActions} from "../../actions/malt.actions";
-import {HopsActions} from "../../actions/hops.actions";
-import {YeastActions} from "../../actions/yeast.actions";
-import {AdditionalIngredientsActions} from "../../actions/additionalIngredients.actions";
 import {AdditionalIngredient} from "../../model/AdditionalIngredient";
 import ModalDialog, {DialogType} from "../../components/ModalDialog/ModalDialog";
 import { isRequiredPositiveQuantity } from "../../utils/beerSubmission";
@@ -891,29 +885,3 @@ export class BeerForm extends React.Component<BeerFormProps, BeerFormState> {
         );
     }
 }
-
-const mapStateToProps = (state: any) => ({
-    malts: state.maltsReducer.malts,
-    hops: state.hopsReducer.hops,
-    yeasts: state.yeastReducer.yeasts,
-    additionalIngredients: state.additionalIngredientsReducer.additionalIngredients || [],
-    isSubmitSuccessful: state.beerDataReducer.isSubmitSuccessful,
-    message: state.beerDataReducer.message,
-    messageType: state.beerDataReducer.type,
-    beerFormState: state.beerDataReducer.beerFormState,
-    beers: state.beerDataReducer.beers,
-    importedBeer: state.beerDataReducer.importedBeer,
-    isSavingBeer: state.beerDataReducer.isSavingBeer,
-});
-
-const mapDispatchToProps = (dispatch: any) => ({
-    onSubmitBeer: (beer: BeerDTO) => dispatch(BeerActions.submitBeer(beer)),
-    getMalt: (isFetching: boolean) => dispatch(MaltsActions.getMalts(isFetching)),
-    getHop: (isFetching: boolean) => dispatch(HopsActions.getHops(isFetching)),
-    getYeast: (isFetching: boolean) => dispatch(YeastActions.getYeasts(isFetching)),
-    getAdditionalIngredients: (isFetching: boolean) => dispatch(AdditionalIngredientsActions.getAdditionalIngredients(isFetching)),
-    saveBeerFormState: (formState: any) => dispatch(BeerActions.saveBeerFormState(formState)),
-    importBeer: (file: File) => dispatch(BeerActions.importBeer(file)),
-});
-
-export default connect(mapStateToProps, mapDispatchToProps)(BeerForm);

--- a/src/containers/DatabaseOverview/IngredientsFormPage.connect.ts
+++ b/src/containers/DatabaseOverview/IngredientsFormPage.connect.ts
@@ -1,0 +1,33 @@
+import { connect } from 'react-redux';
+import { Malts } from '../../model/Malt';
+import { Hops } from '../../model/Hops';
+import { Yeasts } from '../../model/Yeasts';
+import { MaltsActions } from "../../actions/malt.actions";
+import { HopsActions } from "../../actions/hops.actions";
+import { YeastActions } from "../../actions/yeast.actions";
+import { AdditionalIngredientsActions } from "../../actions/additionalIngredients.actions";
+import {IngredientsFormPage} from './IngredientsFormPage';
+
+const mapStateToProps = (state: any) => ({
+    malts: state.maltsReducer.malts || [],
+    hops: state.hopsReducer.hops || [],
+    yeasts: state.yeastReducer.yeasts || [],
+    additionalIngredients: state.additionalIngredientsReducer.additionalIngredients || []
+});
+
+const mapDispatchToProps = (dispatch: any) => ({
+    getMalt: (isFetching: boolean) => dispatch(MaltsActions.getMalts(isFetching)),
+    getHop: (isFetching: boolean) => dispatch(HopsActions.getHops(isFetching)),
+    getYeast: (isFetching: boolean) => dispatch(YeastActions.getYeasts(isFetching)),
+    submitNewMalt: (malt: Malts) => dispatch(MaltsActions.submitNewMalt(malt)),
+    submitNewHop: (hop: Hops) => dispatch(HopsActions.submitNewHop(hop)),
+    submitNewYeast: (yeast: Yeasts) => dispatch(YeastActions.submitNewYeast(yeast)),
+    deleteMaltById: (aId: string) => dispatch(MaltsActions.deleteMaltsById(aId)),
+    deleteHopById: (aId: string) => dispatch(HopsActions.deleteHopById(aId)),
+    deleteYeastById: (aId: string) => dispatch(YeastActions.deleteYeastById(aId)),
+    getAdditionalIngredients: (isFetching: boolean) => dispatch(AdditionalIngredientsActions.getAdditionalIngredients(isFetching)),
+    submitNewAdditionalIngredient: (aIngredient: { name: string; description?: string }) => dispatch(AdditionalIngredientsActions.submitNewAdditionalIngredient(aIngredient)),
+    deleteAdditionalIngredientById: (aId: string) => dispatch(AdditionalIngredientsActions.deleteAdditionalIngredientById(aId))
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(IngredientsFormPage);

--- a/src/containers/DatabaseOverview/IngredientsFormPage.tsx
+++ b/src/containers/DatabaseOverview/IngredientsFormPage.tsx
@@ -12,7 +12,6 @@ import {
     TableRow
 } from "@mui/material";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
-import { connect } from 'react-redux';
 import SimpleBar from "simplebar-react";
 
 import { Malts } from '../../model/Malt';
@@ -21,14 +20,10 @@ import { Yeasts } from '../../model/Yeasts';
 
 import './IngredientsFormPage.css';
 
-import { MaltsActions } from "../../actions/malt.actions";
-import { HopsActions } from "../../actions/hops.actions";
-import { YeastActions } from "../../actions/yeast.actions";
-import { AdditionalIngredientsActions } from "../../actions/additionalIngredients.actions";
 import { AdditionalIngredient } from "../../model/AdditionalIngredient";
 
 
-class IngredientsFormPage extends React.Component<any, any> {
+export class IngredientsFormPage extends React.Component<any, any> {
 
     simpleBarRef: any = null;
 
@@ -382,27 +377,3 @@ class IngredientsFormPage extends React.Component<any, any> {
 }
 
 /* ====================== Redux Mapper ====================== */
-
-const mapStateToProps = (state: any) => ({
-    malts: state.maltsReducer.malts || [],
-    hops: state.hopsReducer.hops || [],
-    yeasts: state.yeastReducer.yeasts || [],
-    additionalIngredients: state.additionalIngredientsReducer.additionalIngredients || []
-});
-
-const mapDispatchToProps = (dispatch: any) => ({
-    getMalt: (isFetching: boolean) => dispatch(MaltsActions.getMalts(isFetching)),
-    getHop: (isFetching: boolean) => dispatch(HopsActions.getHops(isFetching)),
-    getYeast: (isFetching: boolean) => dispatch(YeastActions.getYeasts(isFetching)),
-    submitNewMalt: (malt: Malts) => dispatch(MaltsActions.submitNewMalt(malt)),
-    submitNewHop: (hop: Hops) => dispatch(HopsActions.submitNewHop(hop)),
-    submitNewYeast: (yeast: Yeasts) => dispatch(YeastActions.submitNewYeast(yeast)),
-    deleteMaltById: (aId: string) => dispatch(MaltsActions.deleteMaltsById(aId)),
-    deleteHopById: (aId: string) => dispatch(HopsActions.deleteHopById(aId)),
-    deleteYeastById: (aId: string) => dispatch(YeastActions.deleteYeastById(aId)),
-    getAdditionalIngredients: (isFetching: boolean) => dispatch(AdditionalIngredientsActions.getAdditionalIngredients(isFetching)),
-    submitNewAdditionalIngredient: (aIngredient: { name: string; description?: string }) => dispatch(AdditionalIngredientsActions.submitNewAdditionalIngredient(aIngredient)),
-    deleteAdditionalIngredientById: (aId: string) => dispatch(AdditionalIngredientsActions.deleteAdditionalIngredientById(aId))
-});
-
-export default connect(mapStateToProps, mapDispatchToProps)(IngredientsFormPage);

--- a/src/containers/DatabaseOverview/content/CreateHopForm.connect.ts
+++ b/src/containers/DatabaseOverview/content/CreateHopForm.connect.ts
@@ -1,0 +1,14 @@
+import {connect} from "react-redux";
+import {Hops} from "../../../model/Hops";
+import {HopsActions} from "../../../actions/hops.actions";
+import {HopForm} from './CreateHopForm';
+
+const mapStateToProps = (state: any) => ({
+    isSuccessful: state.hopsReducer.isSubmitHopSuccessful
+});
+
+const mapDispatchToProps = (dispatch: any) => ({
+    onSubmitHop: (hop: Hops) => dispatch(HopsActions.submitNewHop(hop))
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(HopForm);

--- a/src/containers/DatabaseOverview/content/CreateHopForm.tsx
+++ b/src/containers/DatabaseOverview/content/CreateHopForm.tsx
@@ -1,9 +1,6 @@
 import * as React from 'react';
 import {FormEvent} from "react";
 import {Hops} from "../../../model/Hops";
-import {BeerActions} from "../../../actions/actions";
-import {connect} from "react-redux";
-import {HopsActions} from "../../../actions/hops.actions";
 interface HopFormState {
   name: string;
   type: string;
@@ -14,7 +11,7 @@ interface HopFormState {
 interface HopFormProps {
     onSubmitHop: (hop: Hops) => void;
 }
-class HopForm extends React.Component<HopFormProps,HopFormState>
+export class HopForm extends React.Component<HopFormProps,HopFormState>
 {
 constructor(props: HopFormProps) {
     super(props);
@@ -74,12 +71,3 @@ render() {
   }
 
 }
-const mapStateToProps = (state: any) => ({
-    isSuccessful: state.hopsReducer.isSubmitHopSuccessful
-});
-
-const mapDispatchToProps = (dispatch: any) => ({
-    onSubmitHop: (hop: Hops) => dispatch(HopsActions.submitNewHop(hop))
-});
-
-export default connect(mapStateToProps, mapDispatchToProps)(HopForm);

--- a/src/containers/DatabaseOverview/content/CreateMaltForm.connect.ts
+++ b/src/containers/DatabaseOverview/content/CreateMaltForm.connect.ts
@@ -1,0 +1,13 @@
+import {connect} from "react-redux";
+import {Malts} from "../../../model/Malt";
+import {MaltsActions} from "../../../actions/malt.actions";
+import {MaltForm} from './CreateMaltForm';
+
+const mapStateToProps = (state: any) => ({
+    isSuccessful: state.beerDataReducer.isSubmitMaltSuccessful
+});
+const mapDispatchToProps = (dispatch: any) => ({
+    onSubmitMalt: (malt: Malts) => dispatch(MaltsActions.submitNewMalt(malt)),
+
+});
+export default connect(mapStateToProps,mapDispatchToProps)(MaltForm);

--- a/src/containers/DatabaseOverview/content/CreateMaltForm.tsx
+++ b/src/containers/DatabaseOverview/content/CreateMaltForm.tsx
@@ -1,10 +1,7 @@
 import * as React from 'react';
 import {ChangeEvent, FormEvent} from "react";
-import {BeerActions} from "../../../actions/actions";
-import {connect} from "react-redux";
 import {Malts} from "../../../model/Malt";
 import {isEqual} from "lodash";
-import {MaltsActions} from "../../../actions/malt.actions";
 
 interface MaltFormState {
     id: string;
@@ -18,7 +15,7 @@ interface MaltFormProps {
     isSuccessful: boolean;
 }
 
-class MaltForm extends React.Component<MaltFormProps,MaltFormState> {
+export class MaltForm extends React.Component<MaltFormProps,MaltFormState> {
     constructor(props: MaltFormProps) {
         super(props);
         this.state = {
@@ -110,13 +107,3 @@ class MaltForm extends React.Component<MaltFormProps,MaltFormState> {
 
 
 }
-
-
-const mapStateToProps = (state: any) => ({
-    isSuccessful: state.beerDataReducer.isSubmitMaltSuccessful
-});
-const mapDispatchToProps = (dispatch: any) => ({
-    onSubmitMalt: (malt: Malts) => dispatch(MaltsActions.submitNewMalt(malt)),
-
-});
-export default connect(mapStateToProps,mapDispatchToProps)(MaltForm);

--- a/src/containers/DatabaseOverview/content/CreateYeastForm.connect.ts
+++ b/src/containers/DatabaseOverview/content/CreateYeastForm.connect.ts
@@ -1,0 +1,13 @@
+import {connect} from "react-redux";
+import {Yeasts} from "../../../model/Yeasts";
+import {YeastActions} from "../../../actions/yeast.actions";
+import {YeastForm} from './CreateYeastForm';
+
+const mapStateToProps = (state: any) => ({
+    isSuccessful: state.yeastReducer.isSubmitYeastSuccessful
+});
+const mapDispatchToProps = (dispatch: any) => ({
+    onSubmitMalt: (yeast: Yeasts) => dispatch(YeastActions.submitNewYeast(yeast)),
+
+});
+export default connect(mapStateToProps,mapDispatchToProps)(YeastForm);

--- a/src/containers/DatabaseOverview/content/CreateYeastForm.tsx
+++ b/src/containers/DatabaseOverview/content/CreateYeastForm.tsx
@@ -1,13 +1,10 @@
 import * as React from 'react';
 import {ChangeEvent, FormEvent} from 'react';
-import {BeerActions} from "../../../actions/actions";
-import {connect} from "react-redux";
 import {isEqual} from "lodash";
 import {Yeasts} from "../../../model/Yeasts";
 import {YeastEVG, YeastType} from "../../../enums/eYeastType";
 import '../BeerForm.css'
 import ModalDialog, {DialogType} from "../../../components/ModalDialog/ModalDialog";
-import {YeastActions} from "../../../actions/yeast.actions";
 
 interface MaltFormState {
     id: string;
@@ -25,7 +22,7 @@ interface MaltFormProps {
     isSuccessful: boolean;
 }
 
-class YeastForm extends React.Component<MaltFormProps,MaltFormState> {
+export class YeastForm extends React.Component<MaltFormProps,MaltFormState> {
     constructor(props: MaltFormProps) {
         super(props);
         this.state = {
@@ -138,13 +135,3 @@ class YeastForm extends React.Component<MaltFormProps,MaltFormState> {
 
 
 }
-
-
-const mapStateToProps = (state: any) => ({
-    isSuccessful: state.yeastReducer.isSubmitYeastSuccessful
-});
-const mapDispatchToProps = (dispatch: any) => ({
-    onSubmitMalt: (yeast: Yeasts) => dispatch(YeastActions.submitNewYeast(yeast)),
-
-});
-export default connect(mapStateToProps,mapDispatchToProps)(YeastForm);

--- a/src/containers/MainView/BeerRecipes/Table.connect.ts
+++ b/src/containers/MainView/BeerRecipes/Table.connect.ts
@@ -1,0 +1,21 @@
+import {connect} from "react-redux";
+import {Beer} from "../../../model/Beer";
+import {BeerActions} from "../../../actions/actions";
+import setSelectedBeer = BeerActions.setSelectedBeer;
+import {BeerTableComponent} from './Table';
+
+const mapStateToProps = (state: any) => ({
+    beerToBrew: state.beerDataReducer.beerToBrew,
+    isPollingRunning: state.productionReducer.isPollingRunning,
+    beers: state.beerDataReducer.beers ?? [],
+    selectedBeer: state.beerDataReducer.selectedBeer
+});
+
+const mapDispatchToProps = (dispatch: any) => ({
+    setSelectedBeer: (beer: Beer) => dispatch(setSelectedBeer(beer)),
+    setBeerToBrew: (beer: Beer | undefined ) => dispatch(BeerActions.setBeerToBrew(beer)),
+    exportShoppingListPdf: (beer: Beer) => dispatch(BeerActions.generateShoppingListPdf(beer)),
+    deleteBeer: (aBeerId: string) => dispatch(BeerActions.deleteBeer(aBeerId)),
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(BeerTableComponent);

--- a/src/containers/MainView/BeerRecipes/Table.tsx
+++ b/src/containers/MainView/BeerRecipes/Table.tsx
@@ -2,12 +2,9 @@ import React from 'react';
 import {Paper, Table, TableBody, TableCell, TableContainer, TableHead, TableRow, TableSortLabel} from '@mui/material';
 import './Table.css';
 import {Beer} from "../../../model/Beer";
-import {connect} from "react-redux";
-import {BeerActions} from "../../../actions/actions";
 import {WaterHeatingTimeCalculator, cookingTimeOptions} from "../../../utils/WaterHeatingTimeCalculator";
 import {MashingType} from "../../../enums/eMashingType";
 import ModalDialog, {DialogType} from "../../../components/ModalDialog/ModalDialog";
-import setSelectedBeer = BeerActions.setSelectedBeer;
 
 export interface BeerTableProps {
     beers: Beer[];
@@ -260,20 +257,3 @@ export class BeerTableComponent extends React.Component<BeerTableProps, BeerTabl
         return <div className="Table">No data</div>;
     }
 }
-
-
-const mapStateToProps = (state: any) => ({
-    beerToBrew: state.beerDataReducer.beerToBrew,
-    isPollingRunning: state.productionReducer.isPollingRunning,
-    beers: state.beerDataReducer.beers ?? [],
-    selectedBeer: state.beerDataReducer.selectedBeer
-});
-
-const mapDispatchToProps = (dispatch: any) => ({
-    setSelectedBeer: (beer: Beer) => dispatch(setSelectedBeer(beer)),
-    setBeerToBrew: (beer: Beer | undefined ) => dispatch(BeerActions.setBeerToBrew(beer)),
-    exportShoppingListPdf: (beer: Beer) => dispatch(BeerActions.generateShoppingListPdf(beer)),
-    deleteBeer: (aBeerId: string) => dispatch(BeerActions.deleteBeer(aBeerId)),
-});
-
-export default connect(mapStateToProps, mapDispatchToProps)(BeerTableComponent);

--- a/src/containers/MainView/Details/Details.connect.ts
+++ b/src/containers/MainView/Details/Details.connect.ts
@@ -1,0 +1,16 @@
+import { connect } from 'react-redux';
+import { BeerActions } from "../../../actions/actions";
+import {scalingValues} from "../../../utils/BeerScaler/ScalingBeerRecipe";
+import {Details} from './Details';
+
+const mapStateToProps = (state: any) => ({
+    selectedBeer: state.beerDataReducer.selectedBeer,
+});
+
+const mapDispatchToProps = (dispatch: any) => ({
+    updateRecipeScaling: (aScalingValues: scalingValues) =>
+        dispatch(BeerActions.updateRecipeScaling(aScalingValues)),
+});
+
+
+export default connect(mapStateToProps, mapDispatchToProps)(Details);

--- a/src/containers/MainView/Details/Details.tsx
+++ b/src/containers/MainView/Details/Details.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { connect } from 'react-redux';
 import './Details.css';
 import { Beer } from "../../../model/Beer";
 import SimpleBar from 'simplebar-react';
@@ -18,7 +17,6 @@ import {
 } from "@mui/material";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import {scalingValues} from "../../../utils/BeerScaler/ScalingBeerRecipe";
-import {BeerActions} from "../../../actions/actions";
 import {COLOR_ACCENT, COLOR_BREW_BG} from "../../../colors";
 
 interface DetailsProps {
@@ -32,7 +30,7 @@ interface DetailsState {
     brewhouseEfficiency: number;
 }
 
-class Details extends React.Component<DetailsProps, DetailsState> {
+export class Details extends React.Component<DetailsProps, DetailsState> {
 
     constructor(props: DetailsProps) {
         super(props);
@@ -480,15 +478,3 @@ class Details extends React.Component<DetailsProps, DetailsState> {
         );
     }
 }
-
-const mapStateToProps = (state: any) => ({
-    selectedBeer: state.beerDataReducer.selectedBeer,
-});
-
-const mapDispatchToProps = (dispatch: any) => ({
-    updateRecipeScaling: (aScalingValues: scalingValues) =>
-        dispatch(BeerActions.updateRecipeScaling(aScalingValues)),
-});
-
-
-export default connect(mapStateToProps, mapDispatchToProps)(Details);

--- a/src/containers/MainView/FinishBrewsBeers/FinishedBrewsTable.connect.ts
+++ b/src/containers/MainView/FinishBrewsBeers/FinishedBrewsTable.connect.ts
@@ -1,0 +1,27 @@
+import {connect} from "react-redux";
+import {FinishedBrew} from "../../../model/FinishedBrew";
+import {finishedBrewsTestData} from "../../../model/finishedBrewsTestData";
+import {BeerActions} from "../../../actions/actions";
+import {FinishedBrewsTable} from './FinishedBrewsTable';
+
+const mapStateToProps = (state: any) => ({
+    brews: state.beerDataReducer.finishedBrews || finishedBrewsTestData,
+    beers: state.beerDataReducer.beers
+});
+
+const mapDispatchToProps = (dispatch: any) => ({
+    onSave: (brew: FinishedBrew) => {
+        dispatch(BeerActions.updateActiveBeer(brew));
+    },
+    exportPdf: (brews: FinishedBrew[]) => {
+        dispatch(BeerActions.generateFinishedBrewsPdf(brews));
+    },
+    getFinishedBrews: (isFetching: boolean) => {
+        dispatch(BeerActions.getFinishedBeers(isFetching));
+    },
+    onDelete: (id: string) => {
+        dispatch(BeerActions.deleteFinishedBeer(id));
+    }
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(FinishedBrewsTable);

--- a/src/containers/MainView/FinishBrewsBeers/FinishedBrewsTable.tsx
+++ b/src/containers/MainView/FinishBrewsBeers/FinishedBrewsTable.tsx
@@ -4,9 +4,6 @@ import SimpleBar from 'simplebar-react';
 import 'simplebar/dist/simplebar.min.css';
 import './FinishedBrewsTable.css';
 import {FinishedBrew} from "../../../model/FinishedBrew";
-import {connect} from "react-redux";
-import {finishedBrewsTestData} from "../../../model/finishedBrewsTestData";
-import {BeerActions} from "../../../actions/actions";
 import {isNil} from "lodash";
 import { v4 as uuidv4 } from 'uuid';
 import { eBrewState, BrewStateGerman } from '../../../enums/eBrewState';
@@ -40,7 +37,7 @@ const calcAlcohol = (w1: number, w2: number | null) => {
     return (((w1 - w2) * 0.5).toFixed(2) + ' %');
 };
 
-class FinishedBrewsTable extends React.Component<FinishedBrewsTableProps, FinishedBrewsTableState> {
+export class FinishedBrewsTable extends React.Component<FinishedBrewsTableProps, FinishedBrewsTableState> {
     constructor(props: FinishedBrewsTableProps) {
         super(props);
         this.state = { editRows: {}, filterYear: '', showOnlyActive: false, filterOutActive: false, clickedFinishBtn: {}, panelBrewId: null };
@@ -541,25 +538,3 @@ class FinishedBrewsTable extends React.Component<FinishedBrewsTableProps, Finish
         );
     }
 }
-
-const mapStateToProps = (state: any) => ({
-    brews: state.beerDataReducer.finishedBrews || finishedBrewsTestData,
-    beers: state.beerDataReducer.beers
-});
-
-const mapDispatchToProps = (dispatch: any) => ({
-    onSave: (brew: FinishedBrew) => {
-        dispatch(BeerActions.updateActiveBeer(brew));
-    },
-    exportPdf: (brews: FinishedBrew[]) => {
-        dispatch(BeerActions.generateFinishedBrewsPdf(brews));
-    },
-    getFinishedBrews: (isFetching: boolean) => {
-        dispatch(BeerActions.getFinishedBeers(isFetching));
-    },
-    onDelete: (id: string) => {
-        dispatch(BeerActions.deleteFinishedBeer(id));
-    }
-});
-
-export default connect(mapStateToProps, mapDispatchToProps)(FinishedBrewsTable);

--- a/src/containers/MainView/Header/Header.connect.ts
+++ b/src/containers/MainView/Header/Header.connect.ts
@@ -1,0 +1,18 @@
+import { connect } from 'react-redux';
+import {Views} from "../../../enums/eViews";
+import {ApplicationActions} from "../../../actions/actions";
+import setViewState = ApplicationActions.setViewState;
+import {Header} from './Header';
+
+const mapStateToProps = (state: any) => ({
+    currentView: state.applicationReducer.view,
+    messages: state.applicationReducer.message,
+    backendStatus: state.productionReducer.isBackenAvailable,
+});
+
+const mapDispatchToProps = (dispatch: any) => ({
+    setViewState: (viewState: Views) => dispatch(setViewState(viewState)),
+    removeAllMessages: () => dispatch(ApplicationActions.removeMessage()),
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(Header);

--- a/src/containers/MainView/Header/Header.tsx
+++ b/src/containers/MainView/Header/Header.tsx
@@ -1,9 +1,6 @@
 import React from 'react';
-import { connect } from 'react-redux';
 import './Header.css';
 import {Views} from "../../../enums/eViews";
-import {ApplicationActions} from "../../../actions/actions";
-import setViewState = ApplicationActions.setViewState;
 import StatusDisplay from './StatusDisplay';
 import DashboardIcon from '@mui/icons-material/Dashboard';
 
@@ -156,16 +153,3 @@ export class Header extends React.Component<HeaderProps, HeaderState> {
         );
     }
 }
-
-const mapStateToProps = (state: any) => ({
-    currentView: state.applicationReducer.view,
-    messages: state.applicationReducer.message,
-    backendStatus: state.productionReducer.isBackenAvailable,
-});
-
-const mapDispatchToProps = (dispatch: any) => ({
-    setViewState: (viewState: Views) => dispatch(setViewState(viewState)),
-    removeAllMessages: () => dispatch(ApplicationActions.removeMessage()),
-});
-
-export default connect(mapStateToProps, mapDispatchToProps)(Header);

--- a/src/containers/MainView/Main.connect.ts
+++ b/src/containers/MainView/Main.connect.ts
@@ -1,0 +1,14 @@
+import {connect} from "react-redux";
+import {BeerActions} from "../../actions/actions";
+import getBeers = BeerActions.getBeers;
+import {Main} from './Main';
+
+const mapStateToProps = (state: any) => ({beers: state.beerDataReducer.beers});
+const mapDispatchToProps =
+    (dispatch: any) => ({
+        getBeers: (isFetching: boolean) => dispatch(getBeers(isFetching))
+    });
+
+
+
+export default connect(mapStateToProps,mapDispatchToProps)(Main);

--- a/src/containers/MainView/Main.tsx
+++ b/src/containers/MainView/Main.tsx
@@ -1,13 +1,10 @@
 import React from 'react';
 
-import Details from "./Details/Details";
-import {connect} from "react-redux";
+import Details from "./Details/Details.connect";
 import SimpleBar from 'simplebar-react';
 import 'simplebar/dist/simplebar.min.css';
-import BeerTable from "./BeerRecipes/Table";
+import BeerTable from "./BeerRecipes/Table.connect";
 import {Beer} from "../../model/Beer";
-import {BeerActions} from "../../actions/actions";
-import getBeers = BeerActions.getBeers;
 
 interface MainProps {
 beers: Beer[]
@@ -18,7 +15,7 @@ interface MainState
 {
     maxHeight:number;
 }
-class Main extends React.Component<MainProps,MainState> {
+export class Main extends React.Component<MainProps,MainState> {
     constructor(props: MainProps) {
         super(props);
         this.state={
@@ -70,12 +67,3 @@ class Main extends React.Component<MainProps,MainState> {
         );
     }
 }
-const mapStateToProps = (state: any) => ({beers: state.beerDataReducer.beers});
-const mapDispatchToProps =
-    (dispatch: any) => ({
-        getBeers: (isFetching: boolean) => dispatch(getBeers(isFetching))
-    });
-
-
-
-export default connect(mapStateToProps,mapDispatchToProps)(Main);

--- a/src/containers/Mobile/MobileActiveFinishedBrewView/MobileActiveFinishedBrewView.connect.ts
+++ b/src/containers/Mobile/MobileActiveFinishedBrewView/MobileActiveFinishedBrewView.connect.ts
@@ -1,0 +1,20 @@
+import { connect } from 'react-redux';
+import { FinishedBrew } from '../../../model/FinishedBrew';
+import { finishedBrewsTestData } from '../../../model/finishedBrewsTestData';
+import { BeerActions } from '../../../actions/actions';
+import {MobileActiveFinishedBrewView} from './MobileActiveFinishedBrewView';
+
+const mapStateToProps = (state: any) => ({
+    finishedBrews: state.beerDataReducer?.finishedBrews?.filter((brew: FinishedBrew) => brew.active) || finishedBrewsTestData.filter((brew: FinishedBrew) => brew.active)
+});
+
+const mapDispatchToProps = (dispatch: any) => ({
+    getFinishedBrews: (isFetching: boolean) => {
+        dispatch(BeerActions.getFinishedBeers(isFetching));
+    },
+    saveFinishedBrew: (brew: FinishedBrew) => {
+        dispatch(BeerActions.updateActiveBeer(brew));
+    }
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(MobileActiveFinishedBrewView);

--- a/src/containers/Mobile/MobileActiveFinishedBrewView/MobileActiveFinishedBrewView.tsx
+++ b/src/containers/Mobile/MobileActiveFinishedBrewView/MobileActiveFinishedBrewView.tsx
@@ -1,9 +1,6 @@
 import React from 'react';
-import { connect } from 'react-redux';
 import { FinishedBrew } from '../../../model/FinishedBrew';
 import '../MobileStatusView/MobileProductionView.css';
-import { finishedBrewsTestData } from '../../../model/finishedBrewsTestData';
-import { BeerActions } from '../../../actions/actions';
 
 interface Props {
     finishedBrews?: FinishedBrew[];
@@ -17,7 +14,7 @@ interface State {
     editedBrew: FinishedBrew | undefined;
 }
 
-class MobileActiveFinishedBrewView extends React.Component<Props, State> {
+export class MobileActiveFinishedBrewView extends React.Component<Props, State> {
     constructor(props: Props) {
         super(props);
         this.state = {
@@ -234,19 +231,3 @@ class MobileActiveFinishedBrewView extends React.Component<Props, State> {
         );
     }
 }
-
-const mapStateToProps = (state: any) => ({
-    finishedBrews: state.beerDataReducer?.finishedBrews?.filter((brew: FinishedBrew) => brew.active) || finishedBrewsTestData.filter((brew: FinishedBrew) => brew.active)
-});
-
-const mapDispatchToProps = (dispatch: any) => ({
-    getFinishedBrews: (isFetching: boolean) => {
-        dispatch(BeerActions.getFinishedBeers(isFetching));
-    },
-    saveFinishedBrew: (brew: FinishedBrew) => {
-        dispatch(BeerActions.updateActiveBeer(brew));
-    }
-});
-
-export default connect(mapStateToProps, mapDispatchToProps)(MobileActiveFinishedBrewView);
-

--- a/src/containers/Mobile/MobileStatusView/MobileProductionView.connect.ts
+++ b/src/containers/Mobile/MobileStatusView/MobileProductionView.connect.ts
@@ -1,0 +1,16 @@
+import { connect } from 'react-redux';
+import { ProductionActions } from '../../../actions/actions';
+import {MobileProductionView} from './MobileProductionView';
+
+const mapStateToProps = (state: any) => ({
+    temperature: state.productionReducer.temperature,
+    brewingStatus: state.productionReducer.brewingStatus,
+    isPollingRunning: state.productionReducer.isPollingRunning
+});
+
+const mapDispatchToProps = (dispatch: any) => ({
+    startPolling: () => dispatch(ProductionActions.startPolling()),
+    stopPolling: () => dispatch(ProductionActions.stopPolling())
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(MobileProductionView);

--- a/src/containers/Mobile/MobileStatusView/MobileProductionView.tsx
+++ b/src/containers/Mobile/MobileStatusView/MobileProductionView.tsx
@@ -1,12 +1,10 @@
 import React from 'react';
-import { connect } from 'react-redux';
 import './MobileProductionView.css';
 import { BrewingStatus } from '../../../model/brewingStatus.types';
-import { ProductionActions } from '../../../actions/actions';
 import { TimeFormatter } from "../../../utils/TimeFormatter";
 import MobileBrewingCalculationsView from '../MobileBrewingCalculationsView/MobileBrewingCalculationsView';
 import {getBrewingStatusLabel, getStatusChangeKey, isStepWaiting} from '../../../utils/brewingStatus/selectors';
-import SettingsPage from '../../Settings/SettingsPage';
+import SettingsPage from '../../Settings/SettingsPage.connect';
 
 interface MobileProductionViewProps {
     temperature: number;
@@ -163,16 +161,3 @@ export class MobileProductionView extends React.Component<MobileProductionViewPr
 }
 
 const MobileActiveFinishedBrewViewLazy = React.lazy(() => import('../MobileActiveFinishedBrewView/MobileActiveFinishedBrewView'));
-
-const mapStateToProps = (state: any) => ({
-    temperature: state.productionReducer.temperature,
-    brewingStatus: state.productionReducer.brewingStatus,
-    isPollingRunning: state.productionReducer.isPollingRunning
-});
-
-const mapDispatchToProps = (dispatch: any) => ({
-    startPolling: () => dispatch(ProductionActions.startPolling()),
-    stopPolling: () => dispatch(ProductionActions.stopPolling())
-});
-
-export default connect(mapStateToProps, mapDispatchToProps)(MobileProductionView);

--- a/src/containers/Mobile/MobileStatusView/MobileProductionView.tsx
+++ b/src/containers/Mobile/MobileStatusView/MobileProductionView.tsx
@@ -160,4 +160,4 @@ export class MobileProductionView extends React.Component<MobileProductionViewPr
     }
 }
 
-const MobileActiveFinishedBrewViewLazy = React.lazy(() => import('../MobileActiveFinishedBrewView/MobileActiveFinishedBrewView'));
+const MobileActiveFinishedBrewViewLazy = React.lazy(() => import('../MobileActiveFinishedBrewView/MobileActiveFinishedBrewView.connect'));

--- a/src/containers/Production/Production.connect.ts
+++ b/src/containers/Production/Production.connect.ts
@@ -1,0 +1,56 @@
+import {connect} from "react-redux";
+import {Dispatch} from "redux";
+import {BeerActions, ProductionActions} from "../../actions/actions";
+import {MashAgitatorStates} from "../../model/MashAgitator";
+import {BrewingData} from "../../model/BrewingData";
+import {FinishedBrew} from "../../model/FinishedBrew";
+import {RootState} from "../../reducers/rootReducer";
+import {Production} from './Production';
+
+const mapDispatchToProps = (dispatch: Dispatch) => ({
+    getTemperatures: () => {
+        dispatch(ProductionActions.getTemperatures())
+    },
+    toggleAgitator: (agitatorState: MashAgitatorStates) => {
+        dispatch(ProductionActions.toggleAgitator(agitatorState))
+    },
+    startWaterFilling: (liters: number) => {
+        dispatch(ProductionActions.startWaterFilling(liters))
+    },
+    setAgitatorSpeed: (agitatorSpeed: number) => {
+        dispatch(ProductionActions.setAgitatorSpeed(agitatorSpeed))
+    },
+    sendBrewingData: (brewingData: BrewingData) => {
+        dispatch(ProductionActions.sendBrewingData(brewingData))
+    },
+    startPolling: () => {
+        dispatch(ProductionActions.startPolling())
+    },
+    stopPolling: () => {
+        dispatch(ProductionActions.stopPolling())
+    },
+
+    addFinishedBrew: (finishedBrew: FinishedBrew) => {
+        dispatch(BeerActions.addFinishedBrew(finishedBrew))
+    },
+    nextProcedureStep: () => {
+        dispatch(ProductionActions.nextProcedureStep())
+    }
+});
+const mapStateToProps = (state: RootState) => (
+    {
+        selectedBeer: state.beerDataReducer.beerToBrew,
+        temperature: state.productionReducer.temperature,
+        currentAgitatorState: state.productionReducer.currentAgitatorState,
+        currentAgitatorSpeed: state.productionReducer.currentAgitatorSpeed,
+        agitatorIsRunning: state.productionReducer.agitatorIsRunning,
+        agitatorSpeed: state.productionReducer.agitatorSpeed,
+        isWaterFillingSuccessful: state.productionReducer.isWaterFillingSuccessful,
+        isToggleAgitatorSuccess: state.productionReducer.isToggleAgitatorSuccess,
+        brewingStatus: state.productionReducer.brewingStatus,
+        isBackenAvailable: state.productionReducer.isBackenAvailable,
+        waterStatus: state.productionReducer.waterStatus,
+        isPollingRunning: state.productionReducer.isPollingRunning
+
+    });
+export default connect(mapStateToProps, mapDispatchToProps)(Production);

--- a/src/containers/Production/Production.tsx
+++ b/src/containers/Production/Production.tsx
@@ -1,8 +1,6 @@
 import React from 'react';
 import {isUndefined} from 'lodash';
 import {Beer} from "../../model/Beer";
-import {connect} from "react-redux";
-import {Dispatch} from "redux";
 import 'bootstrap/dist/css/bootstrap.min.css';
 import {v4 as uuidv4} from 'uuid';
 import '@fortawesome/fontawesome-free/css/all.css'; // Stile
@@ -10,7 +8,6 @@ import './Production.css'
 
 import WaterControl, {WaterStatus} from "../../components/Controlls/WaterControll/WaterControl";
 import Flame from "../../components/Flame/Flame";
-import {BeerActions, ProductionActions} from "../../actions/actions";
 import Gauge from "../../components/Controlls/Gauge/Gauge";
 import {ToggleState} from "../../enums/eToggleState";
 import {MashAgitatorStates} from "../../model/MashAgitator";
@@ -29,7 +26,6 @@ import {IconProp} from "@fortawesome/fontawesome-svg-core";
 import {FinishedBrew} from "../../model/FinishedBrew";
 import {eBrewState} from "../../enums/eBrewState";
 import {BackendAvailable} from "../../reducers/productionReducer";
-import {RootState} from "../../reducers/rootReducer";
 import {ProcessList} from "./ProcessList/ProcessList";
 import { dataCollector } from '../../utils/DataCollector/dataCollector';
 import {isBrewingProcessActive, isProcessActive} from "../../utils/brewingStatus/selectors";
@@ -725,51 +721,3 @@ export class Production extends React.Component<ProductionProps, ProductionState
 
 
 }
-
-const mapDispatchToProps = (dispatch: Dispatch) => ({
-    getTemperatures: () => {
-        dispatch(ProductionActions.getTemperatures())
-    },
-    toggleAgitator: (agitatorState: MashAgitatorStates) => {
-        dispatch(ProductionActions.toggleAgitator(agitatorState))
-    },
-    startWaterFilling: (liters: number) => {
-        dispatch(ProductionActions.startWaterFilling(liters))
-    },
-    setAgitatorSpeed: (agitatorSpeed: number) => {
-        dispatch(ProductionActions.setAgitatorSpeed(agitatorSpeed))
-    },
-    sendBrewingData: (brewingData: BrewingData) => {
-        dispatch(ProductionActions.sendBrewingData(brewingData))
-    },
-    startPolling: () => {
-        dispatch(ProductionActions.startPolling())
-    },
-    stopPolling: () => {
-        dispatch(ProductionActions.stopPolling())
-    },
-
-    addFinishedBrew: (finishedBrew: FinishedBrew) => {
-        dispatch(BeerActions.addFinishedBrew(finishedBrew))
-    },
-    nextProcedureStep: () => {
-        dispatch(ProductionActions.nextProcedureStep())
-    }
-});
-const mapStateToProps = (state: RootState) => (
-    {
-        selectedBeer: state.beerDataReducer.beerToBrew,
-        temperature: state.productionReducer.temperature,
-        currentAgitatorState: state.productionReducer.currentAgitatorState,
-        currentAgitatorSpeed: state.productionReducer.currentAgitatorSpeed,
-        agitatorIsRunning: state.productionReducer.agitatorIsRunning,
-        agitatorSpeed: state.productionReducer.agitatorSpeed,
-        isWaterFillingSuccessful: state.productionReducer.isWaterFillingSuccessful,
-        isToggleAgitatorSuccess: state.productionReducer.isToggleAgitatorSuccess,
-        brewingStatus: state.productionReducer.brewingStatus,
-        isBackenAvailable: state.productionReducer.isBackenAvailable,
-        waterStatus: state.productionReducer.waterStatus,
-        isPollingRunning: state.productionReducer.isPollingRunning
-
-    });
-export default connect(mapStateToProps, mapDispatchToProps)(Production);

--- a/src/containers/Settings/SettingsPage.connect.ts
+++ b/src/containers/Settings/SettingsPage.connect.ts
@@ -1,0 +1,14 @@
+import { connect } from 'react-redux';
+import { ThemeName } from '../../utils/theme';
+import { ApplicationActions } from '../../actions/actions';
+import {SettingsPage} from './SettingsPage';
+
+const mapStateToProps = (state: any) => ({
+    theme: state.applicationReducer.theme as ThemeName,
+});
+
+const mapDispatchToProps = (dispatch: any) => ({
+    setTheme: (theme: ThemeName) => dispatch(ApplicationActions.setTheme(theme)),
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(SettingsPage);

--- a/src/containers/Settings/SettingsPage.tsx
+++ b/src/containers/Settings/SettingsPage.tsx
@@ -1,8 +1,6 @@
 import React from 'react';
-import { connect } from 'react-redux';
 import './SettingsPage.css';
 import { ThemeName } from '../../utils/theme';
-import { ApplicationActions } from '../../actions/actions';
 import { PushService, getPermissionState, isPushSupported } from '../../utils/pushService';
 
 interface SettingsPageProps {
@@ -22,7 +20,7 @@ interface SettingsPageState {
     pushError: string | null;
 }
 
-class SettingsPage extends React.Component<SettingsPageProps, SettingsPageState> {
+export class SettingsPage extends React.Component<SettingsPageProps, SettingsPageState> {
     constructor(props: SettingsPageProps) {
         super(props);
 
@@ -317,13 +315,3 @@ class SettingsPage extends React.Component<SettingsPageProps, SettingsPageState>
         );
     }
 }
-
-const mapStateToProps = (state: any) => ({
-    theme: state.applicationReducer.theme as ThemeName,
-});
-
-const mapDispatchToProps = (dispatch: any) => ({
-    setTheme: (theme: ThemeName) => dispatch(ApplicationActions.setTheme(theme)),
-});
-
-export default connect(mapStateToProps, mapDispatchToProps)(SettingsPage);

--- a/src/containers/index.connect.ts
+++ b/src/containers/index.connect.ts
@@ -1,0 +1,31 @@
+import {connect} from "react-redux";
+import {Views} from '../enums/eViews';
+import {BrewingStatus} from "../model/brewingStatus.types";
+import {ProductionActions} from "../actions/actions";
+import {ConfirmStates} from "../enums/eConfirmStates";
+import {Index} from './index';
+
+const mapStateToProps = (state: any) => ({
+    viewState: state.applicationReducer.view as Views,
+    brewingStatus: state.productionReducer.brewingStatus,
+});
+
+const mapDispatchToProps = (dispatch: any) => ({
+    confirm: (confirmState: ConfirmStates) => {
+        dispatch(ProductionActions.confirm(confirmState))
+    },
+
+    checkIsBackenAvailable: () => {
+        dispatch(ProductionActions.checkIsBackenAvailable())
+    },
+
+    webSocketConnect: () => {
+        dispatch(ProductionActions.webSocketConnect());
+    }
+
+
+
+})
+
+
+export default connect(mapStateToProps, mapDispatchToProps)(Index);

--- a/src/containers/index.test.tsx
+++ b/src/containers/index.test.tsx
@@ -5,7 +5,7 @@ import {Views} from '../enums/eViews';
 import {BrewingStatus, ProcessMode, ProcessPhase, ProcessState, WaitingFor} from '../model/brewingStatus.types';
 import {ConfirmStates} from '../enums/eConfirmStates';
 
-jest.mock('./Dashboard/DashboardPage', () => () => <div><h1>Dashboard</h1></div>);
+jest.mock('./Dashboard/DashboardPage.connect', () => () => <div><h1>Dashboard</h1></div>);
 
 const makeStatus = (overrides: Partial<BrewingStatus> = {}): BrewingStatus => ({
     elapsedTime: 23,

--- a/src/containers/index.tsx
+++ b/src/containers/index.tsx
@@ -1,20 +1,18 @@
 import React from 'react';
-import {connect} from "react-redux";
 import {Views} from '../enums/eViews';
-import Main from "./MainView/Main";
-import Production from "./Production/Production";
-import DatabaseOverview from "./DatabaseOverview/BeerForm";
+import Main from "./MainView/Main.connect";
+import Production from "./Production/Production.connect";
+import DatabaseOverview from "./DatabaseOverview/BeerForm.connect";
 import SimpleBar from "simplebar-react";
 import ModalDialog, {DialogType} from "../components/ModalDialog/ModalDialog";
 import {BrewingStatus} from "../model/brewingStatus.types";
-import {ProductionActions} from "../actions/actions";
 import {ConfirmStates} from "../enums/eConfirmStates";
-import FinishedBrewsTable from "./MainView/FinishBrewsBeers/FinishedBrewsTable";
+import FinishedBrewsTable from "./MainView/FinishBrewsBeers/FinishedBrewsTable.connect";
 import BrewingCalculations from "./BrewingCalculations/BrewingCalculations";
-import IngredientsFormPage from "./DatabaseOverview/IngredientsFormPage";
-import SettingsPage from "./Settings/SettingsPage";
+import IngredientsFormPage from "./DatabaseOverview/IngredientsFormPage.connect";
+import SettingsPage from "./Settings/SettingsPage.connect";
 import VersionPage from "./Version/VersionPage";
-import DashboardPage from "./Dashboard/DashboardPage";
+import DashboardPage from "./Dashboard/DashboardPage.connect";
 import {getBrewingStatusLabel, getConfirmationType, shouldShowConfirmButton, shouldShowWaitingDialog} from "../utils/brewingStatus/selectors";
 
 interface indexMainProps {
@@ -103,28 +101,3 @@ export class Index extends React.Component<indexMainProps> {
         );
     }
 }
-
-const mapStateToProps = (state: any) => ({
-    viewState: state.applicationReducer.view as Views,
-    brewingStatus: state.productionReducer.brewingStatus,
-});
-
-const mapDispatchToProps = (dispatch: any) => ({
-    confirm: (confirmState: ConfirmStates) => {
-        dispatch(ProductionActions.confirm(confirmState))
-    },
-
-    checkIsBackenAvailable: () => {
-        dispatch(ProductionActions.checkIsBackenAvailable())
-    },
-
-    webSocketConnect: () => {
-        dispatch(ProductionActions.webSocketConnect());
-    }
-
-
-
-})
-
-
-export default connect(mapStateToProps, mapDispatchToProps)(Index);


### PR DESCRIPTION
### Motivation
- Separate Redux wiring from UI components to improve reusability, readability and testability by moving `connect` logic out of component files.
- Standardize imports across the app to use connected container entry points (e.g. `*.connect.ts`) so components can be imported either as connected containers or as pure components for testing.

### Description
- Introduced many new connector files (e.g. `*.connect.ts`) for components including `DashboardPage`, `BeerForm`, `IngredientsFormPage`, `CreateHopForm`, `CreateMaltForm`, `CreateYeastForm`, `Table`, `Details`, `FinishedBrewsTable`, `Header`, `Main`, multiple `Mobile` views, `MobileProductionView`, `Production`, `SettingsPage` and `index` and wired `mapStateToProps` / `mapDispatchToProps` there.
- Converted the corresponding component implementations to export named, unconnected components (e.g. `export class ...`) and removed inline `connect`/Redux imports and the `mapStateToProps`/`mapDispatchToProps` blocks from those files.
- Updated top-level imports across the app to consume the new connected entry points (for example `import Main from './MainView/Main.connect'` and `import DashboardPage from './Dashboard/DashboardPage.connect'`), and adjusted `App.tsx` and `index.tsx` accordingly.
- Updated unit test mocking to point at the new connector path (`index.test.tsx` now mocks `./Dashboard/DashboardPage.connect`).

### Testing
- Ran unit tests with `jest` and the test suite executed the modified `index.test.tsx` that now mocks `DashboardPage.connect`; the test passed.
- Ran the app build (`npm run build`) locally to verify imports and TypeScript compilation errors; the build completed successfully.
- Performed a quick smoke run of the development server (`npm start`) to ensure the connected components render without runtime import errors, and no runtime errors were observed.
- No automated UI/e2e tests were modified in this change set and none failed as part of the run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6312088734832fbf88ec5ce2ce3145)