### PR TITLE
Fix build/lint warnings: CSS autoprefixer, unused imports, equality checks, and heating-time return

### DIFF
--- a/src/components/Controlls/Gauge/Gauge.tsx
+++ b/src/components/Controlls/Gauge/Gauge.tsx
@@ -68,7 +68,7 @@ class Gauge extends React.Component<GaugeProps,GaugeState> {
     }
 
     calculateAreas() {
-        const { value, targetValue, offset, minValue, maxValue } = this.props;
+        const { targetValue, offset, minValue, maxValue } = this.props;
 
         let greenFrom = Math.max(targetValue - 1, 0);
         let greenTo = Math.min(targetValue + 1, maxValue);
@@ -99,9 +99,7 @@ class Gauge extends React.Component<GaugeProps,GaugeState> {
 
     render() {
         const { redFrom,redTo,yellowFrom,yellowTo,greenFrom,greenTo } = this.state
-        const {value,targetValue,label,minValue,maxValue,height,showAreas} = this.props;
-
-        let gaugeOptions: Gauge;
+        const {value,label,minValue,maxValue,height,showAreas} = this.props;
         const optionsWithArea ={
             greenFrom: greenFrom,
             greenTo: greenTo,

--- a/src/components/ModalDialog/ModalDialog.tsx
+++ b/src/components/ModalDialog/ModalDialog.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import {Button, Dialog, DialogTitle, DialogContent, DialogActions} from '@mui/material';
 import './ModalDialog.css';
-import {connect} from 'react-redux';
 
 export enum DialogType {
     CONFIRM = "confirm",

--- a/src/containers/Dashboard/DashboardPage.css
+++ b/src/containers/Dashboard/DashboardPage.css
@@ -225,7 +225,7 @@
 .dashboard-history-chart {
   min-height: 14rem;
   display: flex;
-  align-items: end;
+  align-items: flex-end;
   gap: var(--spacing-sm);
   padding-top: var(--spacing-md);
 }
@@ -241,7 +241,7 @@
 
 .dashboard-history-track {
   display: flex;
-  align-items: end;
+  align-items: flex-end;
   min-height: 10rem;
 }
 

--- a/src/containers/DatabaseOverview/BeerForm.connect.ts
+++ b/src/containers/DatabaseOverview/BeerForm.connect.ts
@@ -1,12 +1,10 @@
 import {connect} from "react-redux";
-import {Beer, Hop, Malt, Yeast} from "../../model/Beer";
 import {BeerDTO} from "../../model/BeerDTO";
 import {BeerActions} from "../../actions/actions";
 import {MaltsActions} from "../../actions/malt.actions";
 import {HopsActions} from "../../actions/hops.actions";
 import {YeastActions} from "../../actions/yeast.actions";
 import {AdditionalIngredientsActions} from "../../actions/additionalIngredients.actions";
-import {AdditionalIngredient} from "../../model/AdditionalIngredient";
 import {BeerForm} from './BeerForm';
 
 const mapStateToProps = (state: any) => ({

--- a/src/containers/DatabaseOverview/BeerForm.tsx
+++ b/src/containers/DatabaseOverview/BeerForm.tsx
@@ -1,5 +1,5 @@
 import React, { ChangeEvent, FormEvent } from 'react';
-import {AdditionalIngredientPhase, AdditionalIngredientTimeUnit, Beer, BeerAdditionalIngredient, FermentationSteps, Hop, Malt, Yeast} from "../../model/Beer";
+import {AdditionalIngredientPhase, AdditionalIngredientTimeUnit, Beer, FermentationSteps, Hop, Malt, Yeast} from "../../model/Beer";
 import {AdditionalIngredientDTO, BeerDTO, HopDTO, MaltDTO, YeastDTO} from "../../model/BeerDTO";
 import { HopUsage } from "../../enums/eHopUsage";
 import { HopTimeUnit } from "../../enums/eHopTimeUnit";

--- a/src/containers/MainView/Details/Details.tsx
+++ b/src/containers/MainView/Details/Details.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import './Details.css';
 import { Beer } from "../../../model/Beer";
-import SimpleBar from 'simplebar-react';
 import 'simplebar-react/dist/simplebar.min.css';
 
 import {

--- a/src/containers/MainView/FinishBrewsBeers/BrewProcessChart.tsx
+++ b/src/containers/MainView/FinishBrewsBeers/BrewProcessChart.tsx
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer, ReferenceLine, ReferenceArea, Brush } from 'recharts';
+import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer, ReferenceLine, ReferenceArea } from 'recharts';
 import './BrewProcessChart.css';
 import {
   COLOR_ACCENT,

--- a/src/containers/Production/Production.tsx
+++ b/src/containers/Production/Production.tsx
@@ -15,7 +15,7 @@ import QuantityPicker from '../../components/Controlls/QuantityPicker/QuantityPi
 import {BrewingData} from "../../model/BrewingData";
 import {mapBeerToBrewingData} from "../../utils/productionRecipe";
 
-import {BrewingStatus, ProcessMode, ProcessPhase, ProcessState} from "../../model/brewingStatus.types";
+import {BrewingStatus, ProcessPhase, ProcessState} from "../../model/brewingStatus.types";
 import {TimeFormatter} from "../../utils/TimeFormatter";
 
 
@@ -151,7 +151,7 @@ export class Production extends React.Component<ProductionProps, ProductionState
 
     componentDidUpdate(prevProps: Readonly<ProductionProps>, prevState: Readonly<ProductionState>) {
         const {toggleAgitator, brewingStatus,isToggleAgitatorSuccess,isWaterFillingSuccessful, waterStatus} = this.props;
-        const {intervalSwitchState, mainSwitchState, waterSwitchState,heatingAndStirringSwitchState,showHopsDialog,showFinishDialog, indexOfCurrentStep} = this.state;
+        const {intervalSwitchState, mainSwitchState, waterSwitchState,heatingAndStirringSwitchState,showHopsDialog,showFinishDialog} = this.state;
 
 
         if (prevProps.brewingStatus !== brewingStatus) {
@@ -299,7 +299,7 @@ export class Production extends React.Component<ProductionProps, ProductionState
     }
 
     toggleInterval = () => {
-        const {intervalSwitchState, mainSwitchState, agitatorSpeed} = this.state;
+        const {intervalSwitchState} = this.state;
 
         if (!intervalSwitchState) {
             this.setState({intervalSwitchState: true});

--- a/src/containers/index.connect.ts
+++ b/src/containers/index.connect.ts
@@ -1,6 +1,5 @@
 import {connect} from "react-redux";
 import {Views} from '../enums/eViews';
-import {BrewingStatus} from "../model/brewingStatus.types";
 import {ProductionActions} from "../actions/actions";
 import {ConfirmStates} from "../enums/eConfirmStates";
 import {Index} from './index';

--- a/src/containers/index.tsx
+++ b/src/containers/index.tsx
@@ -24,10 +24,6 @@ interface indexMainProps {
 }
 
 export class Index extends React.Component<indexMainProps> {
-    constructor(props: indexMainProps) {
-        super(props);
-    }
-
     componentDidMount() {
         const {checkIsBackenAvailable} = this.props;
         checkIsBackenAvailable();

--- a/src/epics/beerEpics.ts
+++ b/src/epics/beerEpics.ts
@@ -1,5 +1,5 @@
 import { ofType } from 'redux-observable';
-import {fromEvent, of, from} from 'rxjs';
+import {of, from} from 'rxjs';
 import { catchError, exhaustMap, map, mergeMap } from 'rxjs/operators';
 import {ApplicationActions, BeerActions} from '../actions/actions';
 import { BeerRepository } from '../repositorys/BeerRepository';

--- a/src/epics/hopsEpic.ts
+++ b/src/epics/hopsEpic.ts
@@ -1,8 +1,7 @@
 import {ofType} from "redux-observable";
-import {ApplicationActions, BeerActions} from "../actions/actions";
+import {ApplicationActions} from "../actions/actions";
 import {catchError, map, mergeMap} from "rxjs/operators";
-import {from, of} from "rxjs";
-import {BeerRepository} from "../repositorys/BeerRepository";
+import {from} from "rxjs";
 import {HopsActions} from "../actions/hops.actions";
 import {Hops} from "../model/Hops";
 import {HopRepository} from "../repositorys/HopRepository";

--- a/src/epics/maltsEpic.ts
+++ b/src/epics/maltsEpic.ts
@@ -1,7 +1,7 @@
 import {ofType} from "redux-observable";
-import {ApplicationActions, BeerActions} from "../actions/actions";
+import {ApplicationActions} from "../actions/actions";
 import {catchError, map, mergeMap} from "rxjs/operators";
-import {from, of} from "rxjs";
+import {from} from "rxjs";
 import {MaltsActions} from "../actions/malt.actions";
 import {Malts} from "../model/Malt";
 import {MaltRepository} from "../repositorys/MaltRepository";

--- a/src/epics/yeastEpic.ts
+++ b/src/epics/yeastEpic.ts
@@ -1,8 +1,7 @@
 import {ofType} from "redux-observable";
-import {ApplicationActions, BeerActions} from "../actions/actions";
+import {ApplicationActions} from "../actions/actions";
 import {catchError, map, mergeMap} from "rxjs/operators";
-import {from, of} from "rxjs";
-import {BeerRepository} from "../repositorys/BeerRepository";
+import {from} from "rxjs";
 import {YeastActions} from "../actions/yeast.actions";
 import {Yeasts} from "../model/Yeasts";
 import {YeastRepository} from "../repositorys/YeastRepository";

--- a/src/model/Beer.ts
+++ b/src/model/Beer.ts
@@ -1,4 +1,3 @@
-import { MashingType } from '../enums/eMashingType';
 import { RestExecutionMode } from '../enums/eRestExecutionMode';
 import { HopTimeUnit } from '../enums/eHopTimeUnit';
 import { HopUsage } from '../enums/eHopUsage';

--- a/src/reducers/beerReducer.ts
+++ b/src/reducers/beerReducer.ts
@@ -1,6 +1,6 @@
 import { BeerActions } from '../actions/actions';
 import AllBeerActions = BeerActions.AllBeerActions;
-import {Beer, Yeast} from "../model/Beer";
+import {Beer} from "../model/Beer";
 import {BeerDTO} from "../model/BeerDTO";
 import {FinishedBrew} from "../model/FinishedBrew";
 import {BeerRecipeScaler} from "../utils/BeerScaler/ScalingBeerRecipe";

--- a/src/reducers/hopsReducer.ts
+++ b/src/reducers/hopsReducer.ts
@@ -1,9 +1,6 @@
-import {Malts} from "../model/Malt";
-import {MaltsActions} from "../actions/malt.actions";
 import {Hops} from "../model/Hops";
 import {HopsActions} from "../actions/hops.actions";
 import AllHopsActions = HopsActions.AllHopsActions;
-import {BeerActions} from "../actions/actions";
 
 export interface HopsReducerState {
     hops: Hops[] | undefined

--- a/src/reducers/maltsReducer.ts
+++ b/src/reducers/maltsReducer.ts
@@ -1,7 +1,6 @@
 import {Malts} from "../model/Malt";
 import {MaltsActions} from "../actions/malt.actions";
 import AllMaltsActions = MaltsActions.AllMaltsActions;
-import {BeerActions} from "../actions/actions";
 
 export interface MaltsReducerState {
     malts: Malts[] | undefined

--- a/src/reducers/productionReducer.ts
+++ b/src/reducers/productionReducer.ts
@@ -1,5 +1,4 @@
 import { ProductionActions } from '../actions/actions';
-import { ProductionRepository } from '../repositorys/ProductionRepository';
 import AllProductionActions = ProductionActions.AllProductionActions;
 import { ToggleState } from '../enums/eToggleState';
 import { BrewingStatus } from '../model/BrewingStatus';

--- a/src/reducers/yeastReducer.ts
+++ b/src/reducers/yeastReducer.ts
@@ -1,7 +1,6 @@
 import {Yeast} from "../model/Beer";
 import {YeastActions} from "../actions/yeast.actions";
 import AllYeastActions = YeastActions.AllYeastActions;
-import {MaltsActions} from "../actions/malt.actions";
 
 export interface YeastReducerState {
     yeasts: Yeast[] | undefined

--- a/src/repositorys/BeerRepository.ts
+++ b/src/repositorys/BeerRepository.ts
@@ -1,7 +1,4 @@
 import {BeerDTO} from "../model/BeerDTO";
-import axios from "axios";
-import {DatabaseURL} from "../global";
-import {FinishedBrew} from "../model/FinishedBrew";
 import {Beer} from "../model/Beer";
 import {BaseRepository} from "./BaseRepository";
 import { BeerSubmissionResponse, hasPersistedBeerId, toBeerCreatePayload } from "../utils/beerSubmission";

--- a/src/repositorys/ProductionRepository.ts
+++ b/src/repositorys/ProductionRepository.ts
@@ -112,7 +112,7 @@ export class ProductionRepository {
     private static async _doConfirm(aConfirmState: ConfirmStates) {
         try {
             const response = await axios.post(ConfirmURL + aConfirmState);
-            if (response.status == 200) {
+            if (response.status === 200) {
                 console.log(response.data);
             } else {
                 console.log(response.data);
@@ -126,7 +126,7 @@ export class ProductionRepository {
     private static async _doGetTemperature(): Promise<number> {
         try {
             const response = await axios.get(`${BaseURL}/temperatur/0`);
-            if (response.status == 200) {
+            if (response.status === 200) {
                 return response.data;
             } else {
                 return 0;
@@ -142,7 +142,7 @@ export class ProductionRepository {
         const aConfig = createRequestConfig(aTimeoutMs);
         try {
             const response = await axios.get(`${BaseURL}/WaterStatus`, aConfig.config);
-            if (response.status == 200) {
+            if (response.status === 200) {
                 return normalizeWaterStatus(response.data);
 
             } else {
@@ -161,8 +161,8 @@ export class ProductionRepository {
 
     private static async _doStartBrewing() {
         try {
-            const response = await axios.post(CommandsURL + 'StartBrewing:\"\"');
-            return response.status == 200;
+            const response = await axios.post(CommandsURL + `StartBrewing:""`);
+            return response.status === 200;
         } catch (error) {
             console.error('Fehler beim API-Aufruf', error);
         }
@@ -172,7 +172,7 @@ export class ProductionRepository {
         const aConfig = createRequestConfig(aTimeoutMs);
         try {
             const response = await axios.get(`${BaseURL}/Status/`, aConfig.config);
-            if (response.status == 200) {
+            if (response.status === 200) {
                 const available: BackendAvailable = {
                     isBackenAvailable: true, statusText: response.statusText
                 };
@@ -210,7 +210,7 @@ export class ProductionRepository {
         try {
             const response = await axios.post(`${BaseURL}/Recipe/`, aBrewingData);
 
-            return response.status == 201;
+            return response.status === 201;
         } catch (error) {
             console.error('Fehler beim API-Aufruf', error);
             return false;
@@ -221,7 +221,7 @@ export class ProductionRepository {
     private static async _doFillWaterAutomatic(aLiters: number): Promise<boolean> {
         try {
             const response = await axios.post(CommandsURL + 'FillWaterAutomatic:' + aLiters.toString());
-            return response.status == 200;
+            return response.status === 200;
         } catch (error) {
             console.error('Fehler beim API-Aufruf', error);
             return false;
@@ -236,7 +236,7 @@ export class ProductionRepository {
             } else {
                 response = await axios.post(CommandsURL + 'TurnOff');
             }
-            if (response.status == 200) {
+            if (response.status === 200) {
                 store.dispatch(ProductionActions.toggleAgitatorSuccess(false));
             } else {
                 store.dispatch(ProductionActions.toggleAgitatorSuccess(false));
@@ -250,7 +250,7 @@ export class ProductionRepository {
     private static async _doSetAgitatorSpeed(speed: number): Promise<boolean> {
         try {
             const response = await axios.post(CommandsURL + 'Speed:' + speed.toString());
-            return response.status == 200;
+            return response.status === 200;
         } catch (error) {
             console.error('Fehler beim API-Aufruf', error);
             return false;
@@ -261,7 +261,7 @@ export class ProductionRepository {
         try {
             let response: AxiosResponse<any, any>;
 
-            response = await axios.post(CommandsURL + 'AgitatorInterval:\"\"', aMashAgitatorStates);
+            response = await axios.post(CommandsURL + `AgitatorInterval:""`, aMashAgitatorStates);
             return response.status === 200;
 
         } catch (error) {

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,4 +1,4 @@
-import { configureStore, Middleware, Dispatch } from '@reduxjs/toolkit';
+import { configureStore } from '@reduxjs/toolkit';
 import thunk, { ThunkMiddleware } from 'redux-thunk';
 import { createEpicMiddleware, combineEpics } from 'redux-observable';
 import { rootReducer } from './reducers/rootReducer';

--- a/src/utils/Calculations/calculationsUtils.ts
+++ b/src/utils/Calculations/calculationsUtils.ts
@@ -1,4 +1,3 @@
-import { brixToPlatoLookup } from './brixPlatoLookup';
 import { eSugarTypes } from "../../enums/eSugerTypes";
 import {BrixPlatoSgEntry, brixPlatoSgTable} from './brix_plato_sg_table';
 

--- a/src/utils/WaterHeatingTimeCalculator.tsx
+++ b/src/utils/WaterHeatingTimeCalculator.tsx
@@ -25,24 +25,22 @@ export class WaterHeatingTimeCalculator {
             case MashingType.RAST: {
                 const kJMalt = this.calculateWithMalt()
                 const kJWater = this.calculateOnlyWithWater()
-                const time = (((kJWater +kJMalt) * (this.options.targetTemperature - this.options.currentTemperature)) / DEFAULT_W)*60;
-                break;
+                return (((kJWater +kJMalt) * (this.options.targetTemperature - this.options.currentTemperature)) / DEFAULT_W)*60;
             }
             case MashingType.IN: {
                 const kJWater = this.calculateOnlyWithWater()
-                const time = ((kJWater * (this.options.targetTemperature - this.options.currentTemperature)) / DEFAULT_W)*60;
-                break;
+                return ((kJWater * (this.options.targetTemperature - this.options.currentTemperature)) / DEFAULT_W)*60;
             }
             case MashingType.DOWN: {
                 const kJMalt = this.calculateWithMalt()
                 const kJWater = this.calculateOnlyWithWater()
-                const time = (((kJWater +kJMalt) * (this.options.targetTemperature - this.options.currentTemperature)) / DEFAULT_W)*60;
-                break;
+                return (((kJWater +kJMalt) * (this.options.targetTemperature - this.options.currentTemperature)) / DEFAULT_W)*60;
             }
             default: {
             }
 
         }
+        return 0;
     }
 
 


### PR DESCRIPTION
### Motivation
- Address multiple build warnings reported by the toolchain: autoprefixer warnings for `end`, ESLint unused-import/unused-variable warnings, and some stylistic/bug-risk issues in API response checks and computed values.
- Reduce noise in builds so CI and developer workflows surface real issues instead of benign warnings.

### Description
- Replaced CSS `align-items: end` with `align-items: flex-end` in `src/containers/Dashboard/DashboardPage.css` to fix autoprefixer mixed-support warnings.
- Removed or simplified unused imports, removed unused destructured variables, and eliminated a redundant constructor across several files to resolve ESLint `no-unused-vars` and `no-useless-constructor` warnings (notable files: `Gauge.tsx`, `ModalDialog.tsx`, `BeerForm.connect.ts`, various epics and reducers, and `index.tsx`).
- Tightened HTTP status comparisons from loose `==` to strict `===` and removed unnecessary escaped quote sequences in `ProductionRepository` command strings to improve correctness and linting.
- Changed `WaterHeatingTimeCalculator.getTime()` to return the computed heating-time value instead of assigning to unused locals, and added safe default `return 0` for the fallback path.

### Testing
- Ran `git diff --check` which reported no whitespace or simple diff issues and passed successfully.
- Attempted `npm run build` but the build could not complete in this environment because `node_modules/.bin/react-scripts` is not installed, so the production build did not run to completion.
- Attempted dependency installation via `npm ci` which failed due to registry access returning `403 Forbidden` for `@types/react`, and `npm install --legacy-peer-deps` was started but the environment install process was interrupted, so a full install/test cycle could not be completed.
- Type-check/build helper commands (`tsc`, `eslint --fix`) were attempted but either not available or could not be executed to completion in the current environment, so only static code edits and local `git diff` checks were validated here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a631c671cbc832fb00ac13feab05030)