### PR TITLE
Disable Production settings and 'Nächster Schritt' when controller is offline

### DIFF
--- a/src/containers/Production/ProcessList/ProcessList.css
+++ b/src/containers/Production/ProcessList/ProcessList.css
@@ -298,6 +298,11 @@
     width: 100%;
 }
 
+.nextStepBtn:disabled {
+    cursor: not-allowed;
+    opacity: 0.55;
+}
+
 .process-list-scroll,
 .process-list-legacy {
     display: none;

--- a/src/containers/Production/ProcessList/ProcessList.tsx
+++ b/src/containers/Production/ProcessList/ProcessList.tsx
@@ -347,7 +347,8 @@ export class ProcessList extends React.Component<ProcessListProps, ProcessListSt
                                 className="nextStepBtn"
                                 onClick={onNextStep}
                                 disabled={isNextStepDisabled}
-                                title="Nächster Prozessschritt"
+                                aria-disabled={isNextStepDisabled}
+                                title={isNextStepDisabled ? "Nächster Prozessschritt ist nicht verfügbar" : "Nächster Prozessschritt"}
                             >
                                 Nächster Schritt
                             </button>

--- a/src/containers/Production/Production.css
+++ b/src/containers/Production/Production.css
@@ -146,6 +146,17 @@
     overflow: hidden;
 }
 
+
+.Settings--disabled {
+    opacity: 0.65;
+}
+
+.Settings--disabled button,
+.Settings--disabled input,
+.Settings--disabled select {
+    cursor: not-allowed;
+}
+
 .Settings h3 {
     margin: 0;
     font-size: 1.35rem;

--- a/src/containers/Production/Production.test.tsx
+++ b/src/containers/Production/Production.test.tsx
@@ -202,6 +202,18 @@ describe('Production next button', () => {
         expect(props.nextProcedureStep).toHaveBeenCalledTimes(1);
     });
 
+    it('disables the next button while the controller is offline and does not dispatch next', () => {
+        const {props} = renderProduction({
+            brewingStatus: createBrewingStatus(ProcessState.ACTIVE),
+            isBackenAvailable: {isBackenAvailable: false, statusText: 'Offline'}
+        });
+        const nextButton = getNextButton();
+
+        expect(nextButton).toBeDisabled();
+        fireEvent.click(nextButton);
+        expect(props.nextProcedureStep).not.toHaveBeenCalled();
+    });
+
     it('disables the next button again when the process is finished, aborted, or reset to idle', () => {
         const {rerender, props} = renderProduction({brewingStatus: createBrewingStatus(ProcessState.ACTIVE)});
         expect(getNextButton()).not.toBeDisabled();
@@ -408,6 +420,20 @@ describe('Production recipe water filling', () => {
         const manualWaterSwitch = container.querySelector('.settingsRowWater input') as HTMLInputElement;
         fireEvent.click(manualWaterSwitch);
         expect(props.startWaterFilling).toHaveBeenCalledWith(0);
+    });
+
+    it('disables production settings controls while the controller is offline', () => {
+        const {container} = renderProduction({
+            selectedBeer: createBeer(21, 9),
+            isBackenAvailable: {isBackenAvailable: false, statusText: 'Offline'}
+        });
+
+        expect(container.querySelector('.Settings')).toHaveClass('Settings--disabled');
+        expect(screen.getByRole('button', {name: 'Start'})).toBeDisabled();
+        expect(container.querySelector('.startPollingBtn')).toBeDisabled();
+        expect(screen.getByRole('button', {name: /Nachguss/})).toBeDisabled();
+        expect(screen.getByRole('button', {name: /Hauptguss/})).toBeDisabled();
+        expect(container.querySelectorAll('.Settings .quantity-picker-content button:not(:disabled)')).toHaveLength(0);
     });
 });
 

--- a/src/containers/Production/Production.tsx
+++ b/src/containers/Production/Production.tsx
@@ -706,8 +706,9 @@ export class Production extends React.Component<ProductionProps, ProductionState
         if (selectedBeer === undefined) {
             return null;
         }
+        const isNextStepDisabled = !this.isControllerAvailable() || !this.isNextProcedureStepAvailable();
         return (
-            <ProcessList selectedBeer={selectedBeer} currentStepIndex={brewingStatus?.currentStep?.index ?? 0} currentStep={brewingStatus?.currentStep} brewingStatus={brewingStatus} remainingSeconds={this.state.displayedRemainingSeconds} onNextStep={this.handleNextProcedureStep} isNextStepDisabled={!this.isNextProcedureStepAvailable()} />
+            <ProcessList selectedBeer={selectedBeer} currentStepIndex={brewingStatus?.currentStep?.index ?? 0} currentStep={brewingStatus?.currentStep} brewingStatus={brewingStatus} remainingSeconds={this.state.displayedRemainingSeconds} onNextStep={this.handleNextProcedureStep} isNextStepDisabled={isNextStepDisabled} />
         );
     }
 

--- a/src/containers/Production/Production.tsx
+++ b/src/containers/Production/Production.tsx
@@ -287,6 +287,9 @@ export class Production extends React.Component<ProductionProps, ProductionState
     }
 
     toggleAgitator = () => {
+        if (!this.isControllerAvailable()) {
+            return;
+        }
         const {toggleAgitator} = this.props;
         const {mainSwitchState} = this.state;
         if (!mainSwitchState) {
@@ -299,6 +302,9 @@ export class Production extends React.Component<ProductionProps, ProductionState
     }
 
     toggleInterval = () => {
+        if (!this.isControllerAvailable()) {
+            return;
+        }
         const {intervalSwitchState} = this.state;
 
         if (!intervalSwitchState) {
@@ -309,6 +315,9 @@ export class Production extends React.Component<ProductionProps, ProductionState
         }
     }
     toggleHeatingAndStirring = () => {
+        if (!this.isControllerAvailable()) {
+            return;
+        }
         const {heatingAndStirringSwitchState} = this.state;
         if (!heatingAndStirringSwitchState) {
             this.setState({heatingAndStirringSwitchState: true});
@@ -317,20 +326,32 @@ export class Production extends React.Component<ProductionProps, ProductionState
         }
     }
     onAgitatorSpeedChange = (value: number) => {
+        if (!this.isControllerAvailable()) {
+            return;
+        }
         const {setAgitatorSpeed} = this.props
         this.setState({agitatorSpeed: value});
         setAgitatorSpeed(value);
     }
 
     onIntervalChangeBreakTime = (value: number) => {
+        if (!this.isControllerAvailable()) {
+            return;
+        }
         this.setState({breakTime: value});
     }
 
     onIntervalChangeRunningTime = (value: number) => {
+        if (!this.isControllerAvailable()) {
+            return;
+        }
         this.setState({runningTime: value});
     }
 
     onSetWaterChangeQuantity = (value: number) => {
+        if (!this.isControllerAvailable()) {
+            return;
+        }
         this.setState({liters: value});
     }
 
@@ -437,6 +458,9 @@ export class Production extends React.Component<ProductionProps, ProductionState
     }
 
     toggleWaterSwitchState = () => {
+        if (!this.isControllerAvailable()) {
+            return;
+        }
         const {waterSwitchState, liters,} = this.state;
         const {startWaterFilling} = this.props;
         if (!waterSwitchState) {
@@ -453,7 +477,7 @@ export class Production extends React.Component<ProductionProps, ProductionState
 
     isStartButtonDisabled = (): boolean => {
         const {selectedBeer} = this.props;
-        return isUndefined(selectedBeer) || this.state.brewingIsRunning || this.isBrewingStartRequestPending || !this.isControlBrewingStartAvailable();
+        return isUndefined(selectedBeer) || !this.isControllerAvailable() || this.state.brewingIsRunning || this.isBrewingStartRequestPending || !this.isControlBrewingStartAvailable();
     }
 
     startBrewing = (): void => {
@@ -479,7 +503,7 @@ export class Production extends React.Component<ProductionProps, ProductionState
     }
 
     isNextProcedureStepAvailable = (): boolean => {
-        return isBrewingProcessActive(this.props.brewingStatus);
+        return this.isControllerAvailable() && isBrewingProcessActive(this.props.brewingStatus);
     }
 
     handleNextProcedureStep = (): void => {
@@ -536,39 +560,40 @@ export class Production extends React.Component<ProductionProps, ProductionState
             heatingAndStirringSwitchState,
             waterSwitchState
         } = this.state;
-        const mashWaterDisabled = this.isRecipeWaterButtonDisabled('mash');
-        const spargeWaterDisabled = this.isRecipeWaterButtonDisabled('sparge');
+        const settingsDisabled = !this.isControllerAvailable();
+        const mashWaterDisabled = settingsDisabled || this.isRecipeWaterButtonDisabled('mash');
+        const spargeWaterDisabled = settingsDisabled || this.isRecipeWaterButtonDisabled('sparge');
         return (
-            <div className="Settings">
+            <div className={`Settings${settingsDisabled ? ' Settings--disabled' : ''}`} aria-disabled={settingsDisabled}>
                 <h3>Settings</h3>
                 <div className="settingsRow">
                     <div className="leftAligned" id="formControl">
                       <label>
                         <span>Hauptschalter Rührwerk</span>
                         </label>
-                        <Switch onChange={this.toggleAgitator} checked={mainSwitchState} height={40} width={100} />
+                        <Switch onChange={this.toggleAgitator} checked={mainSwitchState} height={40} width={100} disabled={settingsDisabled} />
                         <label>
                         <span>Interval</span>
                         </label>
-                        <Switch onChange={this.toggleInterval} checked={intervalSwitchState} height={40} width={100}/>
+                        <Switch onChange={this.toggleInterval} checked={intervalSwitchState} height={40} width={100} disabled={settingsDisabled}/>
                         <label>
                         <span>Heizphase</span>
                         </label>
-                        <Switch onChange={this.toggleHeatingAndStirring} checked={heatingAndStirringSwitchState} height={40} width={100} />
+                        <Switch onChange={this.toggleHeatingAndStirring} checked={heatingAndStirringSwitchState} height={40} width={100} disabled={settingsDisabled} />
                     </div>
                     <div className="rightAligned" id="quantityPicker">
                         <QuantityPicker initialValue={1} min={1} max={this.MAX_AGITATOR_SPEED} onChange={this.onAgitatorSpeedChange}
-                                        isDisabled={false} label="Geschwindigkeit" labelPosition="above"/>
+                                        isDisabled={settingsDisabled} label="Geschwindigkeit" labelPosition="above"/>
                         <div className="quantityPickerItem">
 
                         </div>
                         <QuantityPicker initialValue={1} min={1} max={this.MAX_BREAK_TIME} onChange={this.onIntervalChangeBreakTime}
-                                        isDisabled={false} label="Pausenzeit" labelPosition="above"/>
+                                        isDisabled={settingsDisabled} label="Pausenzeit" labelPosition="above"/>
                         <div className="quantityPickerItem">
 
                         </div>
                         <QuantityPicker initialValue={1} min={1} max={this.MAX_RUNNING_TIME} onChange={this.onIntervalChangeRunningTime}
-                                        isDisabled={false} label="Laufzeit" labelPosition="above"/>
+                                        isDisabled={settingsDisabled} label="Laufzeit" labelPosition="above"/>
                     </div>
                 </div>
 
@@ -577,11 +602,11 @@ export class Production extends React.Component<ProductionProps, ProductionState
                     <label>
                         <span>Wasser</span>
                     </label>
-                    <Switch onChange={this.toggleWaterSwitchState} checked={waterSwitchState} height={40} width={100} />
+                    <Switch onChange={this.toggleWaterSwitchState} checked={waterSwitchState} height={40} width={100} disabled={settingsDisabled} />
                     </div>
                     <div className="rightAligned">
                         <QuantityPicker initialValue={1} min={1} max={this.MAX_WATER_LEVEL} onChange={this.onSetWaterChangeQuantity}
-                                        isDisabled={waterSwitchState} label="Liter" labelPosition="above"/>
+                                        isDisabled={settingsDisabled || waterSwitchState} label="Liter" labelPosition="above"/>
                     </div>
 
 
@@ -594,7 +619,7 @@ export class Production extends React.Component<ProductionProps, ProductionState
                     <button className="startBtn" disabled={this.isStartButtonDisabled()} onClick={this.startBrewing}>Start</button>
                 </div>
                 <div className="startPollingBtnDiv">
-                    <button className="startPollingBtn" disabled={this.props.isPollingRunning} onClick={this.startPolling}>
+                    <button className="startPollingBtn" disabled={settingsDisabled || this.props.isPollingRunning} onClick={this.startPolling}>
                         <FontAwesomeIcon icon={faRepeat as IconProp} />
                     </button>
                 </div>


### PR DESCRIPTION
### Motivation
- Prevent user interactions with production controls when the PI/controller is offline to avoid commands that will fail or be confusing. 
- Keep the UI consistent by reflecting backend availability in interactive controls and the next-step workflow. 

### Description
- Guarded interactive handlers in `src/containers/Production/Production.tsx` to no-op when the controller is offline by calling the existing `isControllerAvailable()` helper inside switch/quantity/water handlers and `toggleAgitator`, `toggleInterval`, `toggleHeatingAndStirring`, `onAgitatorSpeedChange`, `onIntervalChangeBreakTime`, `onIntervalChangeRunningTime`, `onSetWaterChangeQuantity`, and `toggleWaterSwitchState`.
- Disabled `Start`, recipe water buttons, polling/repeat button, and quantity pickers when controller is offline by adding a `settingsDisabled` flag and passing it to controls; also added a CSS class `Settings--disabled` and `aria-disabled` on the `Settings` panel to show a disabled visual state (`src/containers/Production/Production.css`).
- Prevented the `Nächster Schritt` action when the controller is offline by combining the existing active-process guard with `isControllerAvailable()` in `isNextProcedureStepAvailable()` and keeping the click handler guarded in `handleNextProcedureStep()`.
- Added unit tests in `src/containers/Production/Production.test.tsx` covering the offline `Nächster Schritt` behavior and that settings controls are disabled when the controller is offline.

### Testing
- Added two unit tests to `src/containers/Production/Production.test.tsx` that assert the next-step button is disabled when `isBackenAvailable` is false and that the Settings panel gets the `Settings--disabled` class and key controls are disabled; these tests are present in the repo.
- Ran repository checks (`git diff --check`) which passed locally.
- Attempted to run the test suite (`CI=true npm test -- --runInBand src/containers/Production/Production.test.tsx`) and to install dependencies (`npm ci`), but automated test execution is blocked in this environment because `node_modules` are not installed and `npm ci` failed due to registry access returning `403 Forbidden` for `@types/react`, so tests could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a632b3a249c832f8623f38153f49589)