### PR TITLE
Add production temperature timeline

### DIFF
--- a/src/containers/Production/Production.css
+++ b/src/containers/Production/Production.css
@@ -160,11 +160,19 @@
     margin-top: 0;
     display: flex;
     flex-wrap: nowrap;
-    align-items: center;
+    align-items: stretch;
     gap: 1rem;
+    width: 100%;
     min-height: 0;
     min-width: 0;
     overflow: hidden;
+}
+
+.production-temperature-timeline-card {
+    grid-area: info;
+    width: 100%;
+    min-width: 0;
+    min-height: 0;
 }
 
 /* Zeit- und Label-Anzeigen */
@@ -201,7 +209,7 @@
     color: var(--color-light-text);
 }
 
-.Info .container {
+.info .container {
     width: 100%;
     max-width: none;
     margin: 0 !important;

--- a/src/containers/Production/Production.css
+++ b/src/containers/Production/Production.css
@@ -12,7 +12,7 @@
         minmax(360px, 1.05fr)
         minmax(440px, 1.25fr)
         minmax(500px, 1.45fr);
-    grid-template-rows: minmax(0, 1fr) clamp(6rem, 9.5vh, 6.875rem);
+    grid-template-rows: minmax(0, 1fr) clamp(13rem, 24vh, 16rem);
     grid-template-areas:
         "left list meters settings"
         "info info info info";

--- a/src/containers/Production/Production.tsx
+++ b/src/containers/Production/Production.tsx
@@ -536,7 +536,7 @@ export class Production extends React.Component<ProductionProps, ProductionState
 
     renderInfo() {
         return (
-            <div className="Info" aria-label="Temperatur-Timeline Produktionsbereich">
+            <div className="info production-temperature-timeline-card" aria-label="Temperatur-Timeline Produktionsbereich">
                 <ProductionTemperatureTimeline
                     selectedBeer={this.props.selectedBeer}
                     brewingStatus={this.props.brewingStatus}

--- a/src/containers/Production/Production.tsx
+++ b/src/containers/Production/Production.tsx
@@ -36,6 +36,7 @@ import {isAgitatorActive, isControllerAvailable as getIsControllerAvailable, isH
 import {RecipeWaterFill, RecipeWaterFillStatus} from "./waterFill/recipeWaterFill.types";
 import {completeWaterFill, createInitialRecipeWaterFillStatus, failWaterFill, markValveOpened, resetWaterFill, startWaterFill} from "./waterFill/recipeWaterFillState";
 import {ProductionDialogs} from "./components/ProductionDialogs";
+import {ProductionTemperatureTimeline} from "./TemperatureTimeline/ProductionTemperatureTimeline";
 import {getDisplayedWaterLiters as selectDisplayedWaterLiters, getWaterLabel, getWaterTargetLiters, isRecipeWaterButtonDisabled as selectRecipeWaterButtonDisabled, isWaterFillingActive as selectWaterFillingActive, shouldIncludeSpargeAfterMashingOut as selectShouldIncludeSpargeAfterMashingOut, sanitizeLiters} from "./waterFill/recipeWaterFillSelectors";
 
 export interface ProductionProps {
@@ -534,7 +535,16 @@ export class Production extends React.Component<ProductionProps, ProductionState
     }
 
     renderInfo() {
-        return <div className="Info Info--empty" aria-label="Freier Produktionsbereich" />;
+        return (
+            <div className="Info" aria-label="Temperatur-Timeline Produktionsbereich">
+                <ProductionTemperatureTimeline
+                    selectedBeer={this.props.selectedBeer}
+                    brewingStatus={this.props.brewingStatus}
+                    measurements={dataCollector.getTimelineMeasurements()}
+                    fallbackTemperature={this.props.temperature}
+                />
+            </div>
+        );
     }
 
     renderTemperature() {

--- a/src/containers/Production/TemperatureTimeline/ProductionTemperatureTimeline.css
+++ b/src/containers/Production/TemperatureTimeline/ProductionTemperatureTimeline.css
@@ -5,7 +5,7 @@
     min-height: 0;
     display: flex;
     flex-direction: column;
-    gap: 0.45rem;
+    gap: 0.65rem;
     color: var(--color-light-text);
 }
 
@@ -13,30 +13,46 @@
     display: flex;
     align-items: flex-start;
     justify-content: space-between;
-    gap: 1rem;
+    gap: 2rem;
+    flex: 0 0 auto;
+    min-width: 0;
 }
 
-.temperatureTimeline__header h3 {
+.temperatureTimeline__titleArea {
+    min-width: 0;
+    flex: 1 1 auto;
+}
+
+.temperatureTimeline__title {
     margin: 0;
-    font-size: 1rem;
-    line-height: 1.1;
+    font-size: 1.05rem;
+    line-height: 1.15;
+    white-space: nowrap;
+    overflow-wrap: normal;
+    word-break: normal;
 }
 
-.temperatureTimeline__header p {
-    margin: 0.2rem 0 0;
-    font-size: 0.78rem;
+.temperatureTimeline__description {
+    margin: 0.25rem 0 0;
+    font-size: 0.82rem;
+    line-height: 1.25;
     opacity: 0.78;
+    white-space: normal;
+    overflow-wrap: normal;
+    word-break: normal;
 }
 
 .temperatureTimeline__progress {
-    min-width: 10rem;
+    flex: 0 0 clamp(12rem, 18vw, 20rem);
+    min-width: 12rem;
     text-align: right;
     font-weight: bold;
+    white-space: nowrap;
 }
 
 .temperatureTimeline__progressTrack {
     height: 0.5rem;
-    margin-top: 0.25rem;
+    margin-top: 0.3rem;
     overflow: hidden;
     border-radius: 999px;
     background: rgba(255, 255, 255, 0.16);
@@ -50,8 +66,11 @@
 }
 
 .temperatureTimeline__chart {
+    width: 100%;
+    height: clamp(9rem, 15vh, 12rem);
+    min-width: 0;
+    min-height: 9rem;
     flex: 1 1 auto;
-    min-height: 0;
 }
 
 .temperatureTimeline__empty {
@@ -59,8 +78,26 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    min-height: 0;
+    min-height: 9rem;
+    width: 100%;
     color: var(--color-light-text);
     opacity: 0.75;
     text-align: center;
+}
+
+@media (max-width: 900px) {
+    .temperatureTimeline__header {
+        flex-direction: column;
+        gap: 0.75rem;
+    }
+
+    .temperatureTimeline__progress {
+        width: 100%;
+        flex-basis: auto;
+        text-align: left;
+    }
+
+    .temperatureTimeline__title {
+        white-space: normal;
+    }
 }

--- a/src/containers/Production/TemperatureTimeline/ProductionTemperatureTimeline.css
+++ b/src/containers/Production/TemperatureTimeline/ProductionTemperatureTimeline.css
@@ -1,0 +1,66 @@
+.temperatureTimeline {
+    width: 100%;
+    height: 100%;
+    min-width: 0;
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.45rem;
+    color: var(--color-light-text);
+}
+
+.temperatureTimeline__header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 1rem;
+}
+
+.temperatureTimeline__header h3 {
+    margin: 0;
+    font-size: 1rem;
+    line-height: 1.1;
+}
+
+.temperatureTimeline__header p {
+    margin: 0.2rem 0 0;
+    font-size: 0.78rem;
+    opacity: 0.78;
+}
+
+.temperatureTimeline__progress {
+    min-width: 10rem;
+    text-align: right;
+    font-weight: bold;
+}
+
+.temperatureTimeline__progressTrack {
+    height: 0.5rem;
+    margin-top: 0.25rem;
+    overflow: hidden;
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.16);
+}
+
+.temperatureTimeline__progressBar {
+    height: 100%;
+    border-radius: inherit;
+    background: var(--color-accent);
+    transition: width 0.2s ease;
+}
+
+.temperatureTimeline__chart {
+    flex: 1 1 auto;
+    min-height: 0;
+}
+
+.temperatureTimeline__empty {
+    flex: 1 1 auto;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 0;
+    color: var(--color-light-text);
+    opacity: 0.75;
+    text-align: center;
+}

--- a/src/containers/Production/TemperatureTimeline/ProductionTemperatureTimeline.tsx
+++ b/src/containers/Production/TemperatureTimeline/ProductionTemperatureTimeline.tsx
@@ -1,0 +1,185 @@
+import React from 'react';
+import {
+    CartesianGrid,
+    Line,
+    LineChart,
+    ReferenceArea,
+    ReferenceLine,
+    ResponsiveContainer,
+    Tooltip,
+    XAxis,
+    YAxis
+} from 'recharts';
+import {Beer, FermentationSteps} from '../../../model/Beer';
+import {BrewingStatus} from '../../../model/brewingStatus.types';
+import {TimeFormatter} from '../../../utils/TimeFormatter';
+import {TimelineMeasurement} from '../../../utils/DataCollector/dataCollector';
+import './ProductionTemperatureTimeline.css';
+
+interface ProductionTemperatureTimelineProps {
+    selectedBeer?: Beer;
+    brewingStatus?: BrewingStatus;
+    measurements: TimelineMeasurement[];
+    fallbackTemperature: number;
+}
+
+interface TimelinePoint {
+    elapsedSeconds: number;
+    actualTemperature?: number;
+    targetTemperature?: number;
+}
+
+interface PlannedStep {
+    name: string;
+    startSeconds: number;
+    endSeconds: number;
+    targetTemperature?: number;
+}
+
+const COOKING_STEP_NAME = 'Kochen';
+const DEFAULT_STEP_SECONDS = 60;
+
+export class ProductionTemperatureTimeline extends React.Component<ProductionTemperatureTimelineProps> {
+    getSafeNumber = (aValue: unknown): number | undefined => {
+        const value = Number(aValue);
+        return Number.isFinite(value) ? value : undefined;
+    }
+
+    getCurrentElapsedSeconds = (): number => {
+        const elapsed = this.getSafeNumber(this.props.brewingStatus?.elapsedTime);
+        return elapsed !== undefined && elapsed > 0 ? elapsed : 0;
+    }
+
+    getCurrentActualTemperature = (): number | undefined => {
+        const statusTemperature = this.getSafeNumber(this.props.brewingStatus?.temperature?.current);
+        if (statusTemperature !== undefined && statusTemperature > 0) {
+            return statusTemperature;
+        }
+        const fallback = this.getSafeNumber(this.props.fallbackTemperature);
+        return fallback !== undefined && fallback > 0 ? fallback : undefined;
+    }
+
+    getCurrentTargetTemperature = (): number | undefined => {
+        const target = this.getSafeNumber(this.props.brewingStatus?.temperature?.target);
+        return target !== undefined && target > 0 ? target : undefined;
+    }
+
+    buildPlannedSteps = (): PlannedStep[] => {
+        const {selectedBeer} = this.props;
+        if (selectedBeer === undefined) {
+            return [];
+        }
+        const fermentationSteps = Array.isArray(selectedBeer.fermentation) ? selectedBeer.fermentation : [];
+        const plannedFermentationSteps = fermentationSteps.map((step: FermentationSteps) => ({
+            name: step.type || 'Prozessschritt',
+            durationSeconds: Math.max((this.getSafeNumber(step.time) ?? 0) * 60, DEFAULT_STEP_SECONDS),
+            targetTemperature: this.getSafeNumber(step.temperature)
+        }));
+        const cookingMinutes = this.getSafeNumber(selectedBeer.cookingTime) ?? this.getSafeNumber(selectedBeer.wortBoiling?.totalTime);
+        const cookingTemperature = this.getSafeNumber(selectedBeer.cookingTemperatur);
+        const allSteps = [
+            ...plannedFermentationSteps,
+            ...(cookingMinutes !== undefined && cookingMinutes > 0 ? [{
+                name: COOKING_STEP_NAME,
+                durationSeconds: cookingMinutes * 60,
+                targetTemperature: cookingTemperature
+            }] : [])
+        ];
+        let cursor = 0;
+        return allSteps.map((step) => {
+            const plannedStep: PlannedStep = {
+                name: step.name,
+                startSeconds: cursor,
+                endSeconds: cursor + step.durationSeconds,
+                targetTemperature: step.targetTemperature
+            };
+            cursor = plannedStep.endSeconds;
+            return plannedStep;
+        });
+    }
+
+    buildTimelinePoints = (): TimelinePoint[] => {
+        const pointsBySecond = new Map<number, TimelinePoint>();
+        this.props.measurements.forEach((measurement) => {
+            const elapsed = this.getSafeNumber(measurement.elapsedTime);
+            if (elapsed === undefined || elapsed < 0) {
+                return;
+            }
+            const elapsedSeconds = Math.floor(elapsed);
+            pointsBySecond.set(elapsedSeconds, {
+                elapsedSeconds,
+                actualTemperature: this.getSafeNumber(measurement.Temperature),
+                targetTemperature: this.getSafeNumber(measurement.TargetTemperature)
+            });
+        });
+        const currentElapsedSeconds = Math.floor(this.getCurrentElapsedSeconds());
+        const currentPoint = pointsBySecond.get(currentElapsedSeconds) ?? {elapsedSeconds: currentElapsedSeconds};
+        pointsBySecond.set(currentElapsedSeconds, {
+            ...currentPoint,
+            actualTemperature: currentPoint.actualTemperature ?? this.getCurrentActualTemperature(),
+            targetTemperature: currentPoint.targetTemperature ?? this.getCurrentTargetTemperature()
+        });
+        return Array.from(pointsBySecond.values()).sort((a, b) => a.elapsedSeconds - b.elapsedSeconds);
+    }
+
+    getChartEndSeconds = (plannedSteps: PlannedStep[], points: TimelinePoint[]): number => {
+        const plannedEnd = plannedSteps.length > 0 ? plannedSteps[plannedSteps.length - 1].endSeconds : 0;
+        const lastPoint = points.length > 0 ? points[points.length - 1].elapsedSeconds : 0;
+        return Math.max(plannedEnd, lastPoint, DEFAULT_STEP_SECONDS);
+    }
+
+    formatAxisTime = (elapsedSeconds: number): string => {
+        return TimeFormatter.formatSecondsToHMS(Math.max(0, elapsedSeconds));
+    }
+
+    renderEmptyState = (): React.ReactNode => {
+        return <div className="temperatureTimeline__empty">Noch keine Rezept- oder Temperaturdaten für die Timeline vorhanden.</div>;
+    }
+
+    render() {
+        const plannedSteps = this.buildPlannedSteps();
+        const points = this.buildTimelinePoints();
+        const currentElapsedSeconds = this.getCurrentElapsedSeconds();
+        const chartEndSeconds = this.getChartEndSeconds(plannedSteps, points);
+        const progressPercent = Math.min(100, Math.max(0, (currentElapsedSeconds / chartEndSeconds) * 100));
+        const hasChartData = plannedSteps.length > 0 || points.some((point) => point.actualTemperature !== undefined || point.targetTemperature !== undefined);
+
+        return (
+            <section className="temperatureTimeline" aria-label="Temperatur-Timeline">
+                <div className="temperatureTimeline__header">
+                    <div>
+                        <h3>Temperatur-Timeline</h3>
+                        <p>Isttemperatur, Zieltemperatur und Prozessschritte über den gesamten Brautag.</p>
+                    </div>
+                    <div className="temperatureTimeline__progress" aria-label={`Braufortschritt ${Math.round(progressPercent)} Prozent`}>
+                        <span>{Math.round(progressPercent)}%</span>
+                        <div className="temperatureTimeline__progressTrack">
+                            <div className="temperatureTimeline__progressBar" style={{width: `${progressPercent}%`}} />
+                        </div>
+                    </div>
+                </div>
+                {!hasChartData ? this.renderEmptyState() : (
+                    <div className="temperatureTimeline__chart">
+                        <ResponsiveContainer width="100%" height="100%">
+                            <LineChart data={points} margin={{top: 10, right: 28, bottom: 10, left: 0}}>
+                                <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.18)" />
+                                <XAxis dataKey="elapsedSeconds" type="number" domain={[0, chartEndSeconds]} tickFormatter={this.formatAxisTime} stroke="var(--color-light-text)" />
+                                <YAxis domain={[0, 105]} unit="°C" stroke="var(--color-light-text)" />
+                                <Tooltip labelFormatter={(value) => `Zeit: ${this.formatAxisTime(Number(value))}`} formatter={(value, name) => [`${Number(value).toFixed(1)} °C`, name === 'actualTemperature' ? 'Isttemperatur' : 'Zieltemperatur']} />
+                                {plannedSteps.map((step, index) => (
+                                    <ReferenceArea key={`${step.name}-${step.startSeconds}`} x1={step.startSeconds} x2={step.endSeconds} fill={index % 2 === 0 ? 'rgba(76, 175, 80, 0.10)' : 'rgba(33, 150, 243, 0.10)'} stroke="rgba(255,255,255,0.18)" label={{value: step.name, position: 'insideTop', fill: 'var(--color-light-text)', fontSize: 12}} />
+                                ))}
+                                {plannedSteps.map((step) => (
+                                    <ReferenceLine key={`${step.name}-end`} x={step.endSeconds} stroke="rgba(255,255,255,0.35)" strokeDasharray="4 4" />
+                                ))}
+                                <ReferenceLine x={currentElapsedSeconds} stroke="var(--color-accent)" strokeWidth={2} label={{value: 'Jetzt', position: 'top', fill: 'var(--color-accent)', fontSize: 12}} />
+                                <Line type="monotone" dataKey="actualTemperature" name="Isttemperatur" stroke="var(--color-warning)" strokeWidth={3} dot={{r: 2}} isAnimationActive={false} connectNulls />
+                                <Line type="stepAfter" dataKey="targetTemperature" name="Zieltemperatur" stroke="var(--color-success)" strokeWidth={3} dot={false} isAnimationActive={false} connectNulls />
+                            </LineChart>
+                        </ResponsiveContainer>
+                    </div>
+                )}
+            </section>
+        );
+    }
+}

--- a/src/containers/Production/TemperatureTimeline/ProductionTemperatureTimeline.tsx
+++ b/src/containers/Production/TemperatureTimeline/ProductionTemperatureTimeline.tsx
@@ -147,12 +147,12 @@ export class ProductionTemperatureTimeline extends React.Component<ProductionTem
         return (
             <section className="temperatureTimeline" aria-label="Temperatur-Timeline">
                 <div className="temperatureTimeline__header">
-                    <div>
-                        <h3>Temperatur-Timeline</h3>
-                        <p>Isttemperatur, Zieltemperatur und Prozessschritte über den gesamten Brautag.</p>
+                    <div className="temperatureTimeline__titleArea">
+                        <h3 className="temperatureTimeline__title">Temperaturverlauf</h3>
+                        <p className="temperatureTimeline__description">Isttemperatur, Zieltemperatur und Prozessschritte über den gesamten Brautag.</p>
                     </div>
                     <div className="temperatureTimeline__progress" aria-label={`Braufortschritt ${Math.round(progressPercent)} Prozent`}>
-                        <span>{Math.round(progressPercent)}%</span>
+                        <span>Fortschritt: {Math.round(progressPercent)}%</span>
                         <div className="temperatureTimeline__progressTrack">
                             <div className="temperatureTimeline__progressBar" style={{width: `${progressPercent}%`}} />
                         </div>

--- a/src/containers/Production/TemperatureTimeline/ProductionTemperatureTimeline.tsx
+++ b/src/containers/Production/TemperatureTimeline/ProductionTemperatureTimeline.tsx
@@ -10,9 +10,10 @@ import {
     XAxis,
     YAxis
 } from 'recharts';
-import {Beer, FermentationSteps} from '../../../model/Beer';
+import {Beer} from '../../../model/Beer';
 import {BrewingStatus} from '../../../model/brewingStatus.types';
 import {TimeFormatter} from '../../../utils/TimeFormatter';
+import {buildTemperatureTimelineModel} from './temperatureTimelineModel';
 import {TimelineMeasurement} from '../../../utils/DataCollector/dataCollector';
 import './ProductionTemperatureTimeline.css';
 
@@ -23,111 +24,7 @@ interface ProductionTemperatureTimelineProps {
     fallbackTemperature: number;
 }
 
-interface TimelinePoint {
-    elapsedSeconds: number;
-    actualTemperature?: number;
-    targetTemperature?: number;
-}
-
-interface PlannedStep {
-    name: string;
-    startSeconds: number;
-    endSeconds: number;
-    targetTemperature?: number;
-}
-
-const COOKING_STEP_NAME = 'Kochen';
-const DEFAULT_STEP_SECONDS = 60;
-
 export class ProductionTemperatureTimeline extends React.Component<ProductionTemperatureTimelineProps> {
-    getSafeNumber = (aValue: unknown): number | undefined => {
-        const value = Number(aValue);
-        return Number.isFinite(value) ? value : undefined;
-    }
-
-    getCurrentElapsedSeconds = (): number => {
-        const elapsed = this.getSafeNumber(this.props.brewingStatus?.elapsedTime);
-        return elapsed !== undefined && elapsed > 0 ? elapsed : 0;
-    }
-
-    getCurrentActualTemperature = (): number | undefined => {
-        const statusTemperature = this.getSafeNumber(this.props.brewingStatus?.temperature?.current);
-        if (statusTemperature !== undefined && statusTemperature > 0) {
-            return statusTemperature;
-        }
-        const fallback = this.getSafeNumber(this.props.fallbackTemperature);
-        return fallback !== undefined && fallback > 0 ? fallback : undefined;
-    }
-
-    getCurrentTargetTemperature = (): number | undefined => {
-        const target = this.getSafeNumber(this.props.brewingStatus?.temperature?.target);
-        return target !== undefined && target > 0 ? target : undefined;
-    }
-
-    buildPlannedSteps = (): PlannedStep[] => {
-        const {selectedBeer} = this.props;
-        if (selectedBeer === undefined) {
-            return [];
-        }
-        const fermentationSteps = Array.isArray(selectedBeer.fermentation) ? selectedBeer.fermentation : [];
-        const plannedFermentationSteps = fermentationSteps.map((step: FermentationSteps) => ({
-            name: step.type || 'Prozessschritt',
-            durationSeconds: Math.max((this.getSafeNumber(step.time) ?? 0) * 60, DEFAULT_STEP_SECONDS),
-            targetTemperature: this.getSafeNumber(step.temperature)
-        }));
-        const cookingMinutes = this.getSafeNumber(selectedBeer.cookingTime) ?? this.getSafeNumber(selectedBeer.wortBoiling?.totalTime);
-        const cookingTemperature = this.getSafeNumber(selectedBeer.cookingTemperatur);
-        const allSteps = [
-            ...plannedFermentationSteps,
-            ...(cookingMinutes !== undefined && cookingMinutes > 0 ? [{
-                name: COOKING_STEP_NAME,
-                durationSeconds: cookingMinutes * 60,
-                targetTemperature: cookingTemperature
-            }] : [])
-        ];
-        let cursor = 0;
-        return allSteps.map((step) => {
-            const plannedStep: PlannedStep = {
-                name: step.name,
-                startSeconds: cursor,
-                endSeconds: cursor + step.durationSeconds,
-                targetTemperature: step.targetTemperature
-            };
-            cursor = plannedStep.endSeconds;
-            return plannedStep;
-        });
-    }
-
-    buildTimelinePoints = (): TimelinePoint[] => {
-        const pointsBySecond = new Map<number, TimelinePoint>();
-        this.props.measurements.forEach((measurement) => {
-            const elapsed = this.getSafeNumber(measurement.elapsedTime);
-            if (elapsed === undefined || elapsed < 0) {
-                return;
-            }
-            const elapsedSeconds = Math.floor(elapsed);
-            pointsBySecond.set(elapsedSeconds, {
-                elapsedSeconds,
-                actualTemperature: this.getSafeNumber(measurement.Temperature),
-                targetTemperature: this.getSafeNumber(measurement.TargetTemperature)
-            });
-        });
-        const currentElapsedSeconds = Math.floor(this.getCurrentElapsedSeconds());
-        const currentPoint = pointsBySecond.get(currentElapsedSeconds) ?? {elapsedSeconds: currentElapsedSeconds};
-        pointsBySecond.set(currentElapsedSeconds, {
-            ...currentPoint,
-            actualTemperature: currentPoint.actualTemperature ?? this.getCurrentActualTemperature(),
-            targetTemperature: currentPoint.targetTemperature ?? this.getCurrentTargetTemperature()
-        });
-        return Array.from(pointsBySecond.values()).sort((a, b) => a.elapsedSeconds - b.elapsedSeconds);
-    }
-
-    getChartEndSeconds = (plannedSteps: PlannedStep[], points: TimelinePoint[]): number => {
-        const plannedEnd = plannedSteps.length > 0 ? plannedSteps[plannedSteps.length - 1].endSeconds : 0;
-        const lastPoint = points.length > 0 ? points[points.length - 1].elapsedSeconds : 0;
-        return Math.max(plannedEnd, lastPoint, DEFAULT_STEP_SECONDS);
-    }
-
     formatAxisTime = (elapsedSeconds: number): string => {
         return TimeFormatter.formatSecondsToHMS(Math.max(0, elapsedSeconds));
     }
@@ -137,12 +34,9 @@ export class ProductionTemperatureTimeline extends React.Component<ProductionTem
     }
 
     render() {
-        const plannedSteps = this.buildPlannedSteps();
-        const points = this.buildTimelinePoints();
-        const currentElapsedSeconds = this.getCurrentElapsedSeconds();
-        const chartEndSeconds = this.getChartEndSeconds(plannedSteps, points);
-        const progressPercent = Math.min(100, Math.max(0, (currentElapsedSeconds / chartEndSeconds) * 100));
-        const hasChartData = plannedSteps.length > 0 || points.some((point) => point.actualTemperature !== undefined || point.targetTemperature !== undefined);
+        const model = buildTemperatureTimelineModel(this.props.selectedBeer, this.props.brewingStatus, this.props.measurements, this.props.fallbackTemperature);
+        const {steps, points, nowSeconds, endSeconds, progressPercent} = model;
+        const hasChartData = steps.length > 0 || points.some((point) => point.actualTemperature !== undefined || point.targetTemperature !== undefined);
 
         return (
             <section className="temperatureTimeline" aria-label="Temperatur-Timeline">
@@ -161,20 +55,20 @@ export class ProductionTemperatureTimeline extends React.Component<ProductionTem
                 {!hasChartData ? this.renderEmptyState() : (
                     <div className="temperatureTimeline__chart">
                         <ResponsiveContainer width="100%" height="100%">
-                            <LineChart data={points} margin={{top: 10, right: 28, bottom: 10, left: 0}}>
+                            <LineChart data={points} margin={{top: 18, right: 28, bottom: 14, left: 4}}>
                                 <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.18)" />
-                                <XAxis dataKey="elapsedSeconds" type="number" domain={[0, chartEndSeconds]} tickFormatter={this.formatAxisTime} stroke="var(--color-light-text)" />
-                                <YAxis domain={[0, 105]} unit="°C" stroke="var(--color-light-text)" />
+                                <XAxis dataKey="elapsedSeconds" type="number" domain={[0, endSeconds]} tickFormatter={this.formatAxisTime} stroke="var(--color-light-text)" />
+                                <YAxis domain={[0, 110]} unit="°C" tickCount={6} stroke="var(--color-light-text)" />
                                 <Tooltip labelFormatter={(value) => `Zeit: ${this.formatAxisTime(Number(value))}`} formatter={(value, name) => [`${Number(value).toFixed(1)} °C`, name === 'actualTemperature' ? 'Isttemperatur' : 'Zieltemperatur']} />
-                                {plannedSteps.map((step, index) => (
-                                    <ReferenceArea key={`${step.name}-${step.startSeconds}`} x1={step.startSeconds} x2={step.endSeconds} fill={index % 2 === 0 ? 'rgba(76, 175, 80, 0.10)' : 'rgba(33, 150, 243, 0.10)'} stroke="rgba(255,255,255,0.18)" label={{value: step.name, position: 'insideTop', fill: 'var(--color-light-text)', fontSize: 12}} />
+                                {steps.map((step, index) => (
+                                    <ReferenceArea key={`${step.name}-${step.startSeconds}`} x1={step.startSeconds} x2={step.endSeconds} fill={index % 2 === 0 ? 'rgba(76, 175, 80, 0.10)' : 'rgba(33, 150, 243, 0.10)'} stroke="rgba(255,255,255,0.18)" label={step.showLabel ? {value: step.name, position: 'insideTop', fill: 'var(--color-light-text)', fontSize: 11} : undefined} />
                                 ))}
-                                {plannedSteps.map((step) => (
-                                    <ReferenceLine key={`${step.name}-end`} x={step.endSeconds} stroke="rgba(255,255,255,0.35)" strokeDasharray="4 4" />
+                                {steps.map((step) => (
+                                    <ReferenceLine key={`${step.name}-end`} x={step.endSeconds} stroke="rgba(255,255,255,0.24)" strokeDasharray="4 4" />
                                 ))}
-                                <ReferenceLine x={currentElapsedSeconds} stroke="var(--color-accent)" strokeWidth={2} label={{value: 'Jetzt', position: 'top', fill: 'var(--color-accent)', fontSize: 12}} />
-                                <Line type="monotone" dataKey="actualTemperature" name="Isttemperatur" stroke="var(--color-warning)" strokeWidth={3} dot={{r: 2}} isAnimationActive={false} connectNulls />
-                                <Line type="stepAfter" dataKey="targetTemperature" name="Zieltemperatur" stroke="var(--color-success)" strokeWidth={3} dot={false} isAnimationActive={false} connectNulls />
+                                <ReferenceLine x={nowSeconds} stroke="var(--color-accent)" strokeWidth={2} label={{value: 'Jetzt', position: 'top', fill: 'var(--color-accent)', fontSize: 12}} />
+                                <Line type="monotone" dataKey="actualTemperature" name="Isttemperatur" stroke="var(--color-warning)" strokeWidth={2} dot={{r: 1.5}} isAnimationActive={false} connectNulls />
+                                <Line type="stepAfter" dataKey="targetTemperature" name="Zieltemperatur" stroke="var(--color-success)" strokeWidth={2} dot={false} isAnimationActive={false} connectNulls />
                             </LineChart>
                         </ResponsiveContainer>
                     </div>

--- a/src/containers/Production/TemperatureTimeline/temperatureTimelineModel.test.ts
+++ b/src/containers/Production/TemperatureTimeline/temperatureTimelineModel.test.ts
@@ -1,0 +1,65 @@
+import {RestExecutionMode} from '../../../enums/eRestExecutionMode';
+import {Beer} from '../../../model/Beer';
+import {BrewingStatus, ProcessMode, ProcessPhase, ProcessState, WaitingFor} from '../../../model/brewingStatus.types';
+import {TimelineMeasurement} from '../../../utils/DataCollector/dataCollector';
+import {buildTemperatureTimelineModel} from './temperatureTimelineModel';
+
+const beer = {
+    cookingTime: 60,
+    cookingTemperatur: 99,
+    fermentation: [
+        {type: 'Einmaischen', temperature: 57},
+        ...[1, 2, 3, 4].map(index => ({type: `Rast ${index}`, temperature: 60 + index * 3, time: 20, executionMode: RestExecutionMode.TIMED})),
+        {type: 'Abmaischen', temperature: 78}
+    ]
+} as Beer;
+
+const status = (overrides: Partial<BrewingStatus> = {}): BrewingStatus => ({
+    elapsedTime: 120,
+    currentTime: 1783885211,
+    process: {state: ProcessState.ACTIVE},
+    currentStep: {index: 6, count: 7, phase: ProcessPhase.MASHING_OUT, mode: ProcessMode.HEATING, name: 'Aufheizen für Abmaischen', elapsedTime: 120},
+    temperature: {current: 34, target: 45},
+    hardware: {}, waiting: {waitingFor: WaitingFor.NONE, canConfirm: false}, error: {},
+    ...overrides
+});
+
+const point = (elapsedTime: number, stepIndex: number, stepPhase: ProcessPhase, stepMode: ProcessMode): TimelineMeasurement => ({
+    elapsedTime, currentTime: 0, Temperature: 34, TargetTemperature: 45,
+    stepIndex, stepPhase, stepMode
+});
+
+describe('temperature timeline model', () => {
+    it('places a late-started collector in the same process band as the process overview', () => {
+        const model = buildTemperatureTimelineModel(beer, status(), [point(120, 6, ProcessPhase.MASHING_OUT, ProcessMode.HEATING)], 0);
+
+        expect(model.steps).toHaveLength(15);
+        expect(model.steps[11].name).toBe('Aufheizen für Abmaischen');
+        expect(model.nowSeconds).toBeGreaterThanOrEqual(model.steps[11].startSeconds);
+        expect(model.nowSeconds).toBeLessThanOrEqual(model.steps[11].endSeconds);
+        expect(model.points.at(-1)?.elapsedSeconds).toBe(model.nowSeconds);
+        expect(model.progressPercent).toBeGreaterThan(50);
+    });
+
+    it('normalizes resetting step elapsed values into one cumulative axis', () => {
+        const measurements = [
+            point(300, 1, ProcessPhase.MASHING_IN, ProcessMode.HEATING),
+            point(20, 1, ProcessPhase.MASHING_IN, ProcessMode.WAITING),
+            point(600, 2, ProcessPhase.RAST, ProcessMode.TIMER_RUNNING),
+            point(40, 3, ProcessPhase.RAST, ProcessMode.HEATING)
+        ];
+        const active = status({elapsedTime: 40, currentStep: {index: 3, phase: ProcessPhase.RAST, mode: ProcessMode.HEATING, elapsedTime: 40}});
+        const model = buildTemperatureTimelineModel(beer, active, measurements, 0);
+        const xValues = model.points.map(item => item.elapsedSeconds);
+
+        expect(xValues).toEqual([...xValues].sort((left, right) => left - right));
+        expect(model.nowSeconds).toBe(940);
+        expect(model.steps[4].startSeconds).toBeLessThanOrEqual(model.nowSeconds);
+        expect(model.steps[4].endSeconds).toBeGreaterThanOrEqual(model.nowSeconds);
+    });
+
+    it('uses 100 percent for a finished brew', () => {
+        const model = buildTemperatureTimelineModel(beer, status({process: {state: ProcessState.FINISHED}}), [], 0);
+        expect(model.progressPercent).toBe(100);
+    });
+});

--- a/src/containers/Production/TemperatureTimeline/temperatureTimelineModel.test.ts
+++ b/src/containers/Production/TemperatureTimeline/temperatureTimelineModel.test.ts
@@ -33,10 +33,10 @@ describe('temperature timeline model', () => {
     it('places a late-started collector in the same process band as the process overview', () => {
         const model = buildTemperatureTimelineModel(beer, status(), [point(120, 6, ProcessPhase.MASHING_OUT, ProcessMode.HEATING)], 0);
 
-        expect(model.steps).toHaveLength(15);
-        expect(model.steps[11].name).toBe('Aufheizen für Abmaischen');
-        expect(model.nowSeconds).toBeGreaterThanOrEqual(model.steps[11].startSeconds);
-        expect(model.nowSeconds).toBeLessThanOrEqual(model.steps[11].endSeconds);
+        expect(model.steps).toHaveLength(14);
+        expect(model.steps[10].name).toBe('Aufheizen für Abmaischen');
+        expect(model.nowSeconds).toBeGreaterThanOrEqual(model.steps[10].startSeconds);
+        expect(model.nowSeconds).toBeLessThanOrEqual(model.steps[10].endSeconds);
         expect(model.points.at(-1)?.elapsedSeconds).toBe(model.nowSeconds);
         expect(model.progressPercent).toBeGreaterThan(50);
     });
@@ -61,5 +61,64 @@ describe('temperature timeline model', () => {
     it('uses 100 percent for a finished brew', () => {
         const model = buildTemperatureTimelineModel(beer, status({process: {state: ProcessState.FINISHED}}), [], 0);
         expect(model.progressPercent).toBe(100);
+    });
+
+    it('shows thermal process rows, hides heating labels and omits display-only rows', () => {
+        const model = buildTemperatureTimelineModel(beer, status(), [], 0);
+        const heating = model.steps.find(step => step.entryType === 'HEATING');
+        const rast = model.steps.find(step => step.name === 'Rast 1');
+
+        expect(heating).toBeDefined();
+        expect(heating?.showLabel).toBe(false);
+        expect(rast?.showLabel).toBe(true);
+        expect(model.steps.some(step => step.entryType === 'DISPLAY')).toBe(false);
+        expect(model.steps.some(step => step.name === 'Jod Probe')).toBe(false);
+    });
+
+    it('does not allocate time or a boundary for a display-only process row', () => {
+        const model = buildTemperatureTimelineModel(beer, undefined, [], 0);
+        const lastRast = model.steps.find(step => step.name === 'Rast 4');
+        const mashOutHeating = model.steps.find(step => step.name === 'Aufheizen für Abmaischen');
+
+        expect(lastRast).toBeDefined();
+        expect(mashOutHeating?.startSeconds).toBe(lastRast?.endSeconds);
+    });
+
+    it('grows an overdue heating phase, shifts only future rows and keeps now inside the active row', () => {
+        const atFiveMinutes = status({
+            elapsedTime: 300,
+            currentStep: {index: 6, phase: ProcessPhase.MASHING_OUT, mode: ProcessMode.HEATING, elapsedTime: 300}
+        });
+        const atSevenMinutes = status({
+            elapsedTime: 420,
+            currentStep: {index: 6, phase: ProcessPhase.MASHING_OUT, mode: ProcessMode.HEATING, elapsedTime: 420}
+        });
+        const fiveMinuteModel = buildTemperatureTimelineModel(beer, atFiveMinutes, [point(300, 6, ProcessPhase.MASHING_OUT, ProcessMode.HEATING)], 0);
+        const sevenMinuteModel = buildTemperatureTimelineModel(beer, atSevenMinutes, [point(420, 6, ProcessPhase.MASHING_OUT, ProcessMode.HEATING)], 0);
+        const activeAtFive = fiveMinuteModel.steps[10];
+        const activeAtSeven = sevenMinuteModel.steps[10];
+
+        expect(activeAtSeven.startSeconds).toBe(activeAtFive.startSeconds);
+        expect(activeAtSeven.endSeconds - activeAtSeven.startSeconds).toBe(420);
+        expect(sevenMinuteModel.steps[9]).toEqual(fiveMinuteModel.steps[9]);
+        expect(sevenMinuteModel.steps[11].startSeconds - fiveMinuteModel.steps[11].startSeconds).toBe(120);
+        expect(sevenMinuteModel.nowSeconds).toBeGreaterThanOrEqual(activeAtSeven.startSeconds);
+        expect(sevenMinuteModel.nowSeconds).toBeLessThanOrEqual(activeAtSeven.endSeconds);
+        expect(sevenMinuteModel.endSeconds - fiveMinuteModel.endSeconds).toBe(120);
+    });
+
+    it('keeps observed boundaries stable when intermediate temperature detail is removed', () => {
+        const fullHistory = [
+            point(0, 1, ProcessPhase.MASHING_IN, ProcessMode.HEATING),
+            point(120, 1, ProcessPhase.MASHING_IN, ProcessMode.HEATING),
+            point(300, 1, ProcessPhase.MASHING_IN, ProcessMode.WAITING),
+            point(360, 2, ProcessPhase.RAST, ProcessMode.HEATING)
+        ];
+        const trimmedHistory = [fullHistory[0], fullHistory[2], fullHistory[3]];
+        const active = status({elapsedTime: 360, currentStep: {index: 2, phase: ProcessPhase.RAST, mode: ProcessMode.HEATING, elapsedTime: 60}});
+        const beforeTrim = buildTemperatureTimelineModel(beer, active, fullHistory, 0);
+        const afterTrim = buildTemperatureTimelineModel(beer, active, trimmedHistory, 0);
+
+        expect(afterTrim.steps.slice(0, 3)).toEqual(beforeTrim.steps.slice(0, 3));
     });
 });

--- a/src/containers/Production/TemperatureTimeline/temperatureTimelineModel.ts
+++ b/src/containers/Production/TemperatureTimeline/temperatureTimelineModel.ts
@@ -62,7 +62,11 @@ export const buildTemperatureTimelineModel = (
     measurements: TimelineMeasurement[],
     fallbackTemperature: number
 ): TemperatureTimelineModel => {
-    const processSteps = selectedBeer ? createProcessSteps(selectedBeer) : [];
+    // DISPLAY rows belong to the process overview, but have no independent
+    // thermal duration and must not consume space on the temperature axis.
+    const processSteps = selectedBeer
+        ? createProcessSteps(selectedBeer).filter(step => step.entryType !== ProcessListEntryType.DISPLAY)
+        : [];
     const activeIndex = processSteps.length && brewingStatus
         ? getActiveProcessStepIndex(processSteps, brewingStatus.currentStep.index ?? 0, brewingStatus.currentStep)
         : -1;
@@ -108,7 +112,13 @@ export const buildTemperatureTimelineModel = (
         if (index === activeIndex) endSeconds = Math.max(endSeconds, nowSeconds);
         if (index < activeIndex && nextObservedStart === undefined) endSeconds = Math.max(endSeconds, startSeconds + getPlannedDuration(step));
         endSeconds = Math.max(startSeconds + 1, endSeconds);
-        steps.push({...step, startSeconds, endSeconds, targetTemperature: step.detail?.temperature, showLabel: endSeconds - startSeconds >= MIN_LABEL_SECONDS});
+        steps.push({
+            ...step,
+            startSeconds,
+            endSeconds,
+            targetTemperature: step.detail?.temperature,
+            showLabel: step.entryType !== ProcessListEntryType.HEATING && endSeconds - startSeconds >= MIN_LABEL_SECONDS
+        });
         cursor = endSeconds;
     });
 

--- a/src/containers/Production/TemperatureTimeline/temperatureTimelineModel.ts
+++ b/src/containers/Production/TemperatureTimeline/temperatureTimelineModel.ts
@@ -1,0 +1,136 @@
+import {Beer} from '../../../model/Beer';
+import {BrewingStatus, ProcessState} from '../../../model/brewingStatus.types';
+import {TimelineMeasurement} from '../../../utils/DataCollector/dataCollector';
+import {createProcessSteps, getActiveProcessStepIndex, ProcessListEntryType, ProcessListStep} from '../ProcessList/ProcessList';
+
+export interface TimelineStep extends ProcessListStep {
+    startSeconds: number;
+    endSeconds: number;
+    targetTemperature?: number;
+    showLabel: boolean;
+}
+
+export interface TimelinePoint {
+    elapsedSeconds: number;
+    actualTemperature?: number;
+    targetTemperature?: number;
+}
+
+export interface TemperatureTimelineModel {
+    steps: TimelineStep[];
+    points: TimelinePoint[];
+    nowSeconds: number;
+    endSeconds: number;
+    progressPercent: number;
+}
+
+const DEFAULT_UNTIMED_STEP_SECONDS = 5 * 60;
+const MIN_LABEL_SECONDS = 3 * 60;
+
+const safeNumber = (value: unknown): number | undefined => {
+    const numberValue = Number(value);
+    return Number.isFinite(numberValue) ? numberValue : undefined;
+};
+
+const getPlannedDuration = (step: ProcessListStep): number => {
+    if (step.entryType === ProcessListEntryType.DISPLAY) return DEFAULT_UNTIMED_STEP_SECONDS;
+    const duration = safeNumber(step.detail?.duration);
+    // Recipe rest durations are stored in minutes; cooking is already converted by createProcessSteps.
+    if (duration !== undefined && duration > 0) {
+        return step.phase === 'COOKING' ? duration : duration * 60;
+    }
+    return DEFAULT_UNTIMED_STEP_SECONDS;
+};
+
+const getMeasurementStepIndex = (steps: ProcessListStep[], measurement: TimelineMeasurement): number => {
+    return getActiveProcessStepIndex(steps, measurement.stepIndex ?? 0, {
+        index: measurement.stepIndex,
+        phase: measurement.stepPhase,
+        mode: measurement.stepMode,
+        name: measurement.stepName
+    });
+};
+
+/**
+ * Builds one cumulative axis for status samples, process bands and the now marker.
+ * elapsedTime is monotonic on newer controllers but older/history payloads may reset
+ * at status transitions; a decrease is therefore converted into a cumulative offset.
+ */
+export const buildTemperatureTimelineModel = (
+    selectedBeer: Beer | undefined,
+    brewingStatus: BrewingStatus | undefined,
+    measurements: TimelineMeasurement[],
+    fallbackTemperature: number
+): TemperatureTimelineModel => {
+    const processSteps = selectedBeer ? createProcessSteps(selectedBeer) : [];
+    const activeIndex = processSteps.length && brewingStatus
+        ? getActiveProcessStepIndex(processSteps, brewingStatus.currentStep.index ?? 0, brewingStatus.currentStep)
+        : -1;
+
+    let offset = 0;
+    let previousRaw = 0;
+    const normalized = measurements.map((measurement, index) => {
+        const raw = Math.max(0, safeNumber(measurement.elapsedTime) ?? 0);
+        if (index > 0 && raw < previousRaw) offset += previousRaw;
+        previousRaw = raw;
+        return {...measurement, timelineSeconds: offset + raw};
+    }).sort((left, right) => left.timelineSeconds - right.timelineSeconds);
+
+    const observedStarts = new Map<number, number>();
+    normalized.forEach(measurement => {
+        if (measurement.stepIndex === undefined) return;
+        const index = getMeasurementStepIndex(processSteps, measurement);
+        observedStarts.set(index, Math.min(observedStarts.get(index) ?? Number.POSITIVE_INFINITY, measurement.timelineSeconds));
+    });
+
+    const statusElapsed = Math.max(0, safeNumber(brewingStatus?.elapsedTime) ?? 0);
+    const lastObserved = normalized.at(-1)?.timelineSeconds ?? 0;
+    let nowSeconds = Math.max(statusElapsed, lastObserved);
+
+    // If collection started in the middle of a brew and elapsedTime is step-local,
+    // place the current step after all preceding planned bands instead of at x=0.
+    const plannedBeforeCurrent = processSteps.slice(0, Math.max(0, activeIndex)).reduce((sum, step) => sum + getPlannedDuration(step), 0);
+    const currentStepElapsed = Math.max(0, safeNumber(brewingStatus?.currentStep.elapsedTime) ?? statusElapsed);
+    if (activeIndex > 0 && !Array.from(observedStarts.keys()).some(index => index < activeIndex)) {
+        const shift = Math.max(0, plannedBeforeCurrent + currentStepElapsed - nowSeconds);
+        normalized.forEach(measurement => { measurement.timelineSeconds += shift; });
+        nowSeconds += shift;
+        observedStarts.set(activeIndex, plannedBeforeCurrent);
+    }
+
+    const steps: TimelineStep[] = [];
+    let cursor = 0;
+    processSteps.forEach((step, index) => {
+        const observedStart = observedStarts.get(index);
+        const nextObservedStart = observedStarts.get(index + 1);
+        const startSeconds = Math.max(cursor, observedStart ?? cursor);
+        let endSeconds = nextObservedStart ?? startSeconds + getPlannedDuration(step);
+        if (index === activeIndex) endSeconds = Math.max(endSeconds, nowSeconds);
+        if (index < activeIndex && nextObservedStart === undefined) endSeconds = Math.max(endSeconds, startSeconds + getPlannedDuration(step));
+        endSeconds = Math.max(startSeconds + 1, endSeconds);
+        steps.push({...step, startSeconds, endSeconds, targetTemperature: step.detail?.temperature, showLabel: endSeconds - startSeconds >= MIN_LABEL_SECONDS});
+        cursor = endSeconds;
+    });
+
+    const currentActual = safeNumber(brewingStatus?.temperature.current) ?? safeNumber(fallbackTemperature);
+    const currentTarget = safeNumber(brewingStatus?.temperature.target);
+    const pointsBySecond = new Map<number, TimelinePoint>();
+    normalized.forEach(measurement => {
+        const elapsedSeconds = Math.floor(measurement.timelineSeconds);
+        pointsBySecond.set(elapsedSeconds, {
+            elapsedSeconds,
+            actualTemperature: safeNumber(measurement.Temperature),
+            targetTemperature: safeNumber(measurement.TargetTemperature)
+        });
+    });
+    pointsBySecond.set(Math.floor(nowSeconds), {
+        ...(pointsBySecond.get(Math.floor(nowSeconds)) ?? {elapsedSeconds: Math.floor(nowSeconds)}),
+        actualTemperature: currentActual,
+        targetTemperature: currentTarget
+    });
+
+    const finished = brewingStatus?.process.state === ProcessState.FINISHED;
+    const endSeconds = Math.max(nowSeconds, steps.at(-1)?.endSeconds ?? 0, 60);
+    const progressPercent = finished ? 100 : Math.min(100, Math.max(0, nowSeconds * 100 / endSeconds));
+    return {steps, points: Array.from(pointsBySecond.values()).sort((a, b) => a.elapsedSeconds - b.elapsedSeconds), nowSeconds, endSeconds, progressPercent};
+};

--- a/src/utils/DataCollector/dataCollector.test.ts
+++ b/src/utils/DataCollector/dataCollector.test.ts
@@ -39,7 +39,7 @@ describe('dataCollector', (): void => {
     expect(dataCollector.getAllDataAsJSONString()).toBe(JSON.stringify({groupedData: {}}, null, 2));
   });
 
-  it('keeps the newest measurements when the status group exceeds the configured maximum', (): void => {
+  it('keeps the process boundary and newest measurements when a status group exceeds the maximum', (): void => {
     for (let aIndex = 0; aIndex < MAX_MEASUREMENTS_PER_STATUS_GROUP + 5; aIndex += 1) {
       dataCollector.setBrewingStatus(createStatus(aIndex));
     }
@@ -50,7 +50,8 @@ describe('dataCollector', (): void => {
     const aMeasurements = Object.values(aParsedData.groupedData)[0];
 
     expect(dataCollector.getMeasurementCount()).toBe(MAX_MEASUREMENTS_PER_STATUS_GROUP);
-    expect(aMeasurements[0].Temperature).toBe(5);
+    expect(aMeasurements[0].Temperature).toBe(0);
+    expect(aMeasurements[1].Temperature).toBe(6);
     expect(aMeasurements.at(-1)?.Temperature).toBe(MAX_MEASUREMENTS_PER_STATUS_GROUP + 4);
   });
 });

--- a/src/utils/DataCollector/dataCollector.test.ts
+++ b/src/utils/DataCollector/dataCollector.test.ts
@@ -54,3 +54,17 @@ describe('dataCollector', (): void => {
     expect(aMeasurements.at(-1)?.Temperature).toBe(MAX_MEASUREMENTS_PER_STATUS_GROUP + 4);
   });
 });
+
+describe('timeline measurement order', () => {
+  beforeEach(() => dataCollector.reset());
+
+  it('preserves collection order when a previous status group becomes active again', () => {
+    const heating = createStatus(40);
+    const waiting = {...createStatus(41), currentStep: {...createStatus(41).currentStep, mode: ProcessMode.WAITING}};
+    dataCollector.setBrewingStatus(heating);
+    dataCollector.setBrewingStatus(waiting);
+    dataCollector.setBrewingStatus({...heating, elapsedTime: 42, temperature: {...heating.temperature, current: 42}});
+
+    expect(dataCollector.getTimelineMeasurements().map(item => item.Temperature)).toEqual([40, 41, 42]);
+  });
+});

--- a/src/utils/DataCollector/dataCollector.ts
+++ b/src/utils/DataCollector/dataCollector.ts
@@ -1,7 +1,7 @@
 import { BrewingStatus } from '../../model/brewingStatus.types';
 import { getStatusChangeKey } from '../brewingStatus/selectors';
 
-interface BrewingStatusMeasurement {
+export interface TimelineMeasurement {
   elapsedTime: number;
   currentTime: number;
   Temperature: number;
@@ -9,7 +9,7 @@ interface BrewingStatusMeasurement {
 }
 
 type BrewingStatusGrouped = {
-  [statusKey: string]: BrewingStatusMeasurement[];
+  [statusKey: string]: TimelineMeasurement[];
 };
 
 export const MAX_MEASUREMENTS_PER_STATUS_GROUP = 1000;
@@ -21,7 +21,7 @@ class DataCollector {
 
   setBrewingStatus(aStatus: BrewingStatus): void {
     const aStatusKey = getStatusChangeKey(aStatus);
-    const aCurrentMeasurement: BrewingStatusMeasurement = {
+    const aCurrentMeasurement: TimelineMeasurement = {
       elapsedTime: aStatus.elapsedTime,
       currentTime: aStatus.currentTime,
       // Compatibility output for existing charts and exports.
@@ -34,7 +34,7 @@ class DataCollector {
     }
 
     const aLastStored = this.groupedData[aStatusKey].at(-1);
-    if (!aLastStored || aLastStored.Temperature !== aCurrentMeasurement.Temperature) {
+    if (!aLastStored || aLastStored.Temperature !== aCurrentMeasurement.Temperature || aLastStored.TargetTemperature !== aCurrentMeasurement.TargetTemperature || aLastStored.elapsedTime !== aCurrentMeasurement.elapsedTime) {
       this.groupedData[aStatusKey].push(aCurrentMeasurement);
       this.trimStatusGroup(aStatusKey);
     }
@@ -58,6 +58,10 @@ class DataCollector {
     if (aStatusGroup.length > MAX_MEASUREMENTS_PER_STATUS_GROUP) {
       aStatusGroup.splice(0, aStatusGroup.length - MAX_MEASUREMENTS_PER_STATUS_GROUP);
     }
+  }
+
+  getTimelineMeasurements(): TimelineMeasurement[] {
+    return Object.values(this.groupedData).flat().map((measurement) => ({ ...measurement }));
   }
 
   getAllDataAsBlob(): Blob {

--- a/src/utils/DataCollector/dataCollector.ts
+++ b/src/utils/DataCollector/dataCollector.ts
@@ -1,4 +1,4 @@
-import { BrewingStatus } from '../../model/brewingStatus.types';
+import { BrewingStatus, ProcessMode, ProcessPhase } from '../../model/brewingStatus.types';
 import { getStatusChangeKey } from '../brewingStatus/selectors';
 
 export interface TimelineMeasurement {
@@ -6,6 +6,11 @@ export interface TimelineMeasurement {
   currentTime: number;
   Temperature: number;
   TargetTemperature: number;
+  stepIndex?: number;
+  stepPhase?: ProcessPhase;
+  stepMode?: ProcessMode;
+  stepName?: string;
+  collectionSequence?: number;
 }
 
 type BrewingStatusGrouped = {
@@ -18,6 +23,7 @@ class DataCollector {
   private brewingStatus: BrewingStatus | null = null;
   private groupedData: BrewingStatusGrouped = {};
   private lastStatusKey: string | null = null;
+  private collectionSequence = 0;
 
   setBrewingStatus(aStatus: BrewingStatus): void {
     const aStatusKey = getStatusChangeKey(aStatus);
@@ -27,6 +33,11 @@ class DataCollector {
       // Compatibility output for existing charts and exports.
       Temperature: Number(aStatus.temperature.current ?? 0),
       TargetTemperature: Number(aStatus.temperature.target ?? 0),
+      stepIndex: aStatus.currentStep.index,
+      stepPhase: aStatus.currentStep.phase,
+      stepMode: aStatus.currentStep.mode,
+      stepName: aStatus.currentStep.name,
+      collectionSequence: this.collectionSequence,
     };
 
     if (!this.groupedData[aStatusKey]) {
@@ -36,6 +47,7 @@ class DataCollector {
     const aLastStored = this.groupedData[aStatusKey].at(-1);
     if (!aLastStored || aLastStored.Temperature !== aCurrentMeasurement.Temperature || aLastStored.TargetTemperature !== aCurrentMeasurement.TargetTemperature || aLastStored.elapsedTime !== aCurrentMeasurement.elapsedTime) {
       this.groupedData[aStatusKey].push(aCurrentMeasurement);
+      this.collectionSequence += 1;
       this.trimStatusGroup(aStatusKey);
     }
 
@@ -47,6 +59,7 @@ class DataCollector {
     this.brewingStatus = null;
     this.groupedData = {};
     this.lastStatusKey = null;
+    this.collectionSequence = 0;
   }
 
   getMeasurementCount(): number {
@@ -61,7 +74,9 @@ class DataCollector {
   }
 
   getTimelineMeasurements(): TimelineMeasurement[] {
-    return Object.values(this.groupedData).flat().map((measurement) => ({ ...measurement }));
+    return Object.values(this.groupedData).flat()
+      .sort((aLeft, aRight) => (aLeft.collectionSequence ?? 0) - (aRight.collectionSequence ?? 0))
+      .map((measurement) => ({ ...measurement }));
   }
 
   getAllDataAsBlob(): Blob {

--- a/src/utils/DataCollector/dataCollector.ts
+++ b/src/utils/DataCollector/dataCollector.ts
@@ -69,7 +69,9 @@ class DataCollector {
   private trimStatusGroup(aStatusKey: string): void {
     const aStatusGroup = this.groupedData[aStatusKey];
     if (aStatusGroup.length > MAX_MEASUREMENTS_PER_STATUS_GROUP) {
-      aStatusGroup.splice(0, aStatusGroup.length - MAX_MEASUREMENTS_PER_STATUS_GROUP);
+      // Keep the first sample as the stable process-boundary anchor while
+      // trimming old temperature detail behind it.
+      aStatusGroup.splice(1, aStatusGroup.length - MAX_MEASUREMENTS_PER_STATUS_GROUP);
     }
   }
 


### PR DESCRIPTION
### Motivation
- Provide a horizontal temperature timeline in the free lower area of the Production view to show actual temperature, target temperature, planned process-step windows, and overall brew progress for a 1920×1080 layout.
- Reuse existing runtime and recipe data and the in-app `dataCollector` history to avoid parallel Redux state and keep compatibility with existing status shapes.

### Description
- Add a class component `ProductionTemperatureTimeline` (Recharts) that renders actual temperature, step-wise target temperature, planned process-step bands, step-end markers, a current-time `Jetzt` marker, and a brew progress bar using recipe and normalized `BrewingStatus` data; file: `src/containers/Production/TemperatureTimeline/ProductionTemperatureTimeline.tsx` and styles in `ProductionTemperatureTimeline.css`.
- Integrate the timeline into the existing Production info area by replacing the empty info placeholder with the timeline and passing `selectedBeer`, `brewingStatus`, `fallbackTemperature`, and historical measurements from `dataCollector.getTimelineMeasurements()`; change in `src/containers/Production/Production.tsx`.
- Extend the `dataCollector` API to export a `TimelineMeasurement` type and add a read-only accessor `getTimelineMeasurements()` so the chart uses collected status samples instead of new storage; file: `src/utils/DataCollector/dataCollector.ts`.
- Increase the height of the lower Production grid row (`grid-template-rows`) to allocate the horizontal timeline area; change in `src/containers/Production/Production.css`.

### Testing
- Attempted to run the Production unit tests with `npm test -- --runTestsByPath src/containers/Production/Production.test.tsx --runInBand`, but the test run could not start because project dependencies were not installed and `react-scripts` could not be resolved locally (test aborted).
- Attempted `npm install --ignore-scripts` to install dependencies, but the install failed due to registry access errors (HTTP `403 Forbidden`) while fetching packages, so no automated tests could complete.
- Project changes were committed locally and staged for review as part of this PR (commit created on the working branch).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a635ee4aef0832f96af74e4e400d04b)