### PR TITLE
Fix planned rest durations shown as 0 min in Production process overview

### DIFF
--- a/src/containers/Production/ProcessList/ProcessList.test.tsx
+++ b/src/containers/Production/ProcessList/ProcessList.test.tsx
@@ -3,7 +3,7 @@ import {render, screen} from '@testing-library/react';
 import '@testing-library/jest-dom';
 import {Beer} from '../../../model/Beer';
 import {BrewingStatus, ProcessMode, ProcessPhase, ProcessState, WaitingFor} from '../../../model/brewingStatus.types';
-import {createProcessSteps, getActiveProcessStepIndex, ProcessList} from './ProcessList';
+import {createProcessSteps, getActiveProcessStepIndex, ProcessList, ProcessListDurationUnit, ProcessListEntryType} from './ProcessList';
 
 const selectedBeer = {
     id: 'beer-1',
@@ -21,9 +21,9 @@ const selectedBeer = {
     cookingTemperatur: 100,
     fermentation: [
         {type: 'Einmaischen', temperature: 57},
-        {type: 'Rast 1', temperature: 63, time: 900},
-        {type: 'Rast 2', temperature: 68, time: 900},
-        {type: 'Rast 3', temperature: 72, time: 900},
+        {type: 'Rast 1', temperature: 63, time: 20},
+        {type: 'Rast 2', temperature: 68, time: 60},
+        {type: 'Rast 3', temperature: 72, time: 5},
         {type: 'Abmaischen', temperature: 78},
     ],
     malts: [],
@@ -186,6 +186,27 @@ describe('ProcessList compact production overview', () => {
         expect(screen.getAllByText(/72 °C/).length).toBeGreaterThan(0);
         expect(screen.getByText('Bestätigung erforderlich')).toBeInTheDocument();
         expect(screen.getByText('100 °C · 60 min')).toBeInTheDocument();
+    });
+
+    it('shows each configured recipe rest duration in minutes', () => {
+        render(<ProcessList selectedBeer={selectedBeer} currentStepIndex={0} />);
+
+        expect(screen.getByText('63 °C · 20 min')).toBeInTheDocument();
+        expect(screen.getByText('68 °C · 60 min')).toBeInTheDocument();
+        expect(screen.getByText('72 °C · 5 min')).toBeInTheDocument();
+    });
+
+    it('keeps planned durations on process rows only and preserves their unit', () => {
+        const steps = createProcessSteps(selectedBeer);
+        const heatingSteps = steps.filter(step => step.entryType === ProcessListEntryType.HEATING);
+        const rests = steps.filter(step => step.phase === ProcessPhase.RAST && step.entryType === ProcessListEntryType.PROCESS);
+
+        expect(heatingSteps.every(step => step.detail?.duration === undefined)).toBe(true);
+        expect(rests.map(step => [step.name, step.detail?.duration, step.detail?.durationUnit])).toEqual([
+            ['Rast 1', 20, ProcessListDurationUnit.MINUTES],
+            ['Rast 2', 60, ProcessListDurationUnit.MINUTES],
+            ['Rast 3', 5, ProcessListDurationUnit.MINUTES]
+        ]);
     });
 
     it('renders the remaining time as a single countdown value', () => {

--- a/src/containers/Production/ProcessList/ProcessList.tsx
+++ b/src/containers/Production/ProcessList/ProcessList.tsx
@@ -11,9 +11,15 @@ export enum ProcessListEntryType {
     DISPLAY = "DISPLAY"
 }
 
+export enum ProcessListDurationUnit {
+    MINUTES = "MINUTES",
+    SECONDS = "SECONDS"
+}
+
 export interface ProcessStepDetail {
     temperature?: number;
     duration?: number;
+    durationUnit?: ProcessListDurationUnit;
     confirmationRequired?: boolean;
 }
 
@@ -116,7 +122,10 @@ export class ProcessList extends React.Component<ProcessListProps, ProcessListSt
             details.push(`${step.detail.temperature} °C`);
         }
         if (typeof step.detail?.duration === 'number' && Number.isFinite(step.detail.duration) && step.detail.duration > 0) {
-            details.push(`${Math.round(step.detail.duration / 60)} min`);
+            const durationMinutes = step.detail.durationUnit === ProcessListDurationUnit.SECONDS
+                ? step.detail.duration / 60
+                : step.detail.duration;
+            details.push(`${Math.round(durationMinutes)} min`);
         }
         if (step.detail?.confirmationRequired) {
             details.push('Bestätigung erforderlich');
@@ -390,7 +399,7 @@ export function createProcessSteps(selectedBeer: Beer): ProcessListStep[] {
         const isConfirmationHold = (step.executionMode ?? RestExecutionMode.TIMED) === RestExecutionMode.CONFIRMATION_HOLD;
         if (isRastName || isConfirmationHold) {
             processSteps.push({ name: `Aufheizen für ${step.type}`, entryType: ProcessListEntryType.HEATING, controlStepIndex, phase: ProcessPhase.RAST, detail: {temperature: step.temperature} });
-            processSteps.push({ name: step.type, entryType: ProcessListEntryType.PROCESS, controlStepIndex, phase: ProcessPhase.RAST, detail: {temperature: step.temperature, duration: step.time, confirmationRequired: isConfirmationHold} });
+            processSteps.push({ name: step.type, entryType: ProcessListEntryType.PROCESS, controlStepIndex, phase: ProcessPhase.RAST, detail: {temperature: step.temperature, duration: step.time, durationUnit: ProcessListDurationUnit.MINUTES, confirmationRequired: isConfirmationHold} });
             controlStepIndex++;
             lastRastIndex = processSteps.length - 1;
         }
@@ -411,7 +420,7 @@ export function createProcessSteps(selectedBeer: Beer): ProcessListStep[] {
 
     // Kochen
     processSteps.push({ name: 'Aufheizen auf Kochen', entryType: ProcessListEntryType.HEATING, controlStepIndex, phase: ProcessPhase.COOKING, detail: {temperature: selectedBeer.cookingTemperatur} });
-    processSteps.push({ name: 'Kochen', entryType: ProcessListEntryType.PROCESS, controlStepIndex, phase: ProcessPhase.COOKING, detail: {temperature: selectedBeer.cookingTemperatur, duration: selectedBeer.cookingTime * 60} });
+    processSteps.push({ name: 'Kochen', entryType: ProcessListEntryType.PROCESS, controlStepIndex, phase: ProcessPhase.COOKING, detail: {temperature: selectedBeer.cookingTemperatur, duration: selectedBeer.cookingTime * 60, durationUnit: ProcessListDurationUnit.SECONDS} });
     controlStepIndex++;
 
     return processSteps;


### PR DESCRIPTION
### Motivation

- Users reported that recipe rests (Rasten) in the `Weiterer Ablauf` list always showed `0 min` despite valid recipe durations; the temperature was correct but the planned duration displayed as zero. 
- Investigation showed a unit/mapping problem: fermentation rest `time` values are stored in minutes but were treated as if they were seconds when formatting for the UI, producing `Math.round(<minutes>/60) → 0` for durations < 60. 

### Description

- Added an explicit duration unit enum `ProcessListDurationUnit` and a `durationUnit` field to `ProcessStepDetail` so each process row carries its time unit (minutes for recipe rests, seconds for cooking timeline values). (`src/containers/Production/ProcessList/ProcessList.tsx`)
- When building the visible process list in `createProcessSteps`, fermentation rests now set `duration` to the recipe `time` and set `durationUnit: MINUTES`, while the cooking step keeps its existing seconds value and is marked `durationUnit: SECONDS`. (`createProcessSteps` in `ProcessList.tsx`)
- `renderStepDetails` now converts seconds to minutes only when `durationUnit === ProcessListDurationUnit.SECONDS` and otherwise displays the duration value directly, avoiding the previous unconditional division by 60 that caused small minute values to become `0`. (`renderStepDetails` in `ProcessList.tsx`)
- Ensured heating rows still have no invented duration and only show temperature as before. (`ProcessList.tsx`) 
- Tests were extended to cover the intended behavior and to assert that rests of `20`, `60`, and short values render as `20 min`, `60 min`, and `5 min` respectively, and that heating steps do not receive durations. (`src/containers/Production/ProcessList/ProcessList.test.tsx`)

### Testing

- Added unit test assertions in `src/containers/Production/ProcessList/ProcessList.test.tsx` to validate: a 20-minute rest displays `20 min`, a 60-minute rest displays `60 min`, short rests display correctly, multiple rests show their individual values, and heating steps show no duration; these tests were committed with the change. 
- `git diff --check` and a local commit were performed successfully (commit `de986f4`).
- Attempted to run the test command `CI=true npm test -- --runInBand src/containers/Production/ProcessList/ProcessList.test.tsx` but the repository execution environment lacked installed dependencies (`node_modules`) and `npm ci` failed due to registry access (`403 Forbidden`), so the test suite could not be executed in this environment; the test files are present and should pass when run in a CI/local environment with dependencies installed. 

Files changed: `src/containers/Production/ProcessList/ProcessList.tsx`, `src/containers/Production/ProcessList/ProcessList.test.tsx`.

Root cause: rendering divided an already-minute-valued `FermentationSteps.time` by 60 unconditionally, yielding `0 min` for short rests; the value itself was not lost in mapping but formatted with the wrong unit conversion. The fix preserves internal units (recipe rests in minutes, cooking in seconds) and formats accordingly.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a86165c2c38832f953341952dff823e)