### PR TITLE
Compact legend + chart style tweaks for ProductionTemperatureTimeline and unit tests

### DIFF
--- a/src/containers/Production/TemperatureTimeline/ProductionTemperatureTimeline.css
+++ b/src/containers/Production/TemperatureTimeline/ProductionTemperatureTimeline.css
@@ -32,14 +32,22 @@
     word-break: normal;
 }
 
-.temperatureTimeline__description {
+.temperatureTimeline__legend {
     margin: 0.25rem 0 0;
     font-size: 0.82rem;
     line-height: 1.25;
-    opacity: 0.78;
-    white-space: normal;
-    overflow-wrap: normal;
-    word-break: normal;
+    display: flex;
+    align-items: center;
+    gap: 1.25rem;
+    white-space: nowrap;
+}
+
+.temperatureTimeline__legendActual {
+    color: var(--color-warning);
+}
+
+.temperatureTimeline__legendTarget {
+    color: var(--color-success);
 }
 
 .temperatureTimeline__progress {

--- a/src/containers/Production/TemperatureTimeline/ProductionTemperatureTimeline.test.tsx
+++ b/src/containers/Production/TemperatureTimeline/ProductionTemperatureTimeline.test.tsx
@@ -1,0 +1,78 @@
+import React from 'react';
+import {render, screen} from '@testing-library/react';
+import {ProductionTemperatureTimeline} from './ProductionTemperatureTimeline';
+
+jest.mock('recharts', () => {
+    const React = require('react');
+    const Container = ({children}: {children?: React.ReactNode}) => <div>{children}</div>;
+
+    return {
+        ResponsiveContainer: Container,
+        LineChart: Container,
+        CartesianGrid: () => null,
+        XAxis: () => null,
+        YAxis: () => null,
+        Tooltip: () => null,
+        ReferenceArea: () => null,
+        ReferenceLine: (props: Record<string, unknown>) => (
+            <div
+                data-testid="reference-line"
+                data-stroke={String(props.stroke)}
+                data-stroke-width={String(props.strokeWidth)}
+                data-label={JSON.stringify(props.label)}
+            />
+        ),
+        Line: (props: Record<string, unknown>) => (
+            <div
+                data-testid={`temperature-line-${props.dataKey}`}
+                data-type={String(props.type)}
+                data-stroke={String(props.stroke)}
+                data-stroke-width={String(props.strokeWidth)}
+                data-stroke-opacity={props.strokeOpacity === undefined ? '' : String(props.strokeOpacity)}
+                data-dot={String(props.dot)}
+            />
+        )
+    };
+});
+
+describe('ProductionTemperatureTimeline', () => {
+    it('renders distinct measurement and target curves without permanent dots', () => {
+        render(
+            <ProductionTemperatureTimeline
+                measurements={[{elapsedTime: 1, currentTime: 1, Temperature: 62, TargetTemperature: 63}]}
+                fallbackTemperature={0}
+            />
+        );
+
+        const actualLine = screen.getByTestId('temperature-line-actualTemperature');
+        const targetLine = screen.getByTestId('temperature-line-targetTemperature');
+
+        expect(actualLine).toHaveAttribute('data-type', 'linear');
+        expect(actualLine).toHaveAttribute('data-stroke', 'var(--color-warning)');
+        expect(actualLine).toHaveAttribute('data-stroke-width', '2');
+        expect(actualLine).toHaveAttribute('data-dot', 'false');
+        expect(targetLine).toHaveAttribute('data-type', 'stepAfter');
+        expect(targetLine).toHaveAttribute('data-stroke', 'var(--color-success)');
+        expect(targetLine).toHaveAttribute('data-stroke-width', '1.5');
+        expect(targetLine).toHaveAttribute('data-stroke-opacity', '0.8');
+        expect(targetLine).toHaveAttribute('data-dot', 'false');
+    });
+
+    it('shows the compact color-coded legend and preserves the now marker', () => {
+        render(
+            <ProductionTemperatureTimeline
+                measurements={[{elapsedTime: 1, currentTime: 1, Temperature: 62, TargetTemperature: 63}]}
+                fallbackTemperature={0}
+            />
+        );
+
+        expect(screen.getByText('Isttemperatur')).toHaveClass('temperatureTimeline__legendActual');
+        expect(screen.getByText('Zieltemperatur')).toHaveClass('temperatureTimeline__legendTarget');
+        expect(screen.queryByText('Isttemperatur, Zieltemperatur und Prozessschritte über den gesamten Brautag.')).not.toBeInTheDocument();
+
+        const nowMarker = screen.getByTestId('reference-line');
+        expect(nowMarker).toHaveAttribute('data-stroke', 'var(--color-accent)');
+        expect(nowMarker).toHaveAttribute('data-stroke-width', '2');
+        expect(nowMarker.getAttribute('data-label')).toContain('Jetzt');
+    });
+});

--- a/src/containers/Production/TemperatureTimeline/ProductionTemperatureTimeline.tsx
+++ b/src/containers/Production/TemperatureTimeline/ProductionTemperatureTimeline.tsx
@@ -43,7 +43,10 @@ export class ProductionTemperatureTimeline extends React.Component<ProductionTem
                 <div className="temperatureTimeline__header">
                     <div className="temperatureTimeline__titleArea">
                         <h3 className="temperatureTimeline__title">Temperaturverlauf</h3>
-                        <p className="temperatureTimeline__description">Isttemperatur, Zieltemperatur und Prozessschritte über den gesamten Brautag.</p>
+                        <div className="temperatureTimeline__legend" aria-label="Temperaturkurven">
+                            <span className="temperatureTimeline__legendActual">Isttemperatur</span>
+                            <span className="temperatureTimeline__legendTarget">Zieltemperatur</span>
+                        </div>
                     </div>
                     <div className="temperatureTimeline__progress" aria-label={`Braufortschritt ${Math.round(progressPercent)} Prozent`}>
                         <span>Fortschritt: {Math.round(progressPercent)}%</span>
@@ -67,8 +70,8 @@ export class ProductionTemperatureTimeline extends React.Component<ProductionTem
                                     <ReferenceLine key={`${step.name}-end`} x={step.endSeconds} stroke="rgba(255,255,255,0.24)" strokeDasharray="4 4" />
                                 ))}
                                 <ReferenceLine x={nowSeconds} stroke="var(--color-accent)" strokeWidth={2} label={{value: 'Jetzt', position: 'top', fill: 'var(--color-accent)', fontSize: 12}} />
-                                <Line type="monotone" dataKey="actualTemperature" name="Isttemperatur" stroke="var(--color-warning)" strokeWidth={2} dot={{r: 1.5}} isAnimationActive={false} connectNulls />
-                                <Line type="stepAfter" dataKey="targetTemperature" name="Zieltemperatur" stroke="var(--color-success)" strokeWidth={2} dot={false} isAnimationActive={false} connectNulls />
+                                <Line type="linear" dataKey="actualTemperature" name="Isttemperatur" stroke="var(--color-warning)" strokeWidth={2} dot={false} isAnimationActive={false} connectNulls />
+                                <Line type="stepAfter" dataKey="targetTemperature" name="Zieltemperatur" stroke="var(--color-success)" strokeWidth={1.5} strokeOpacity={0.8} dot={false} isAnimationActive={false} connectNulls />
                             </LineChart>
                         </ResponsiveContainer>
                     </div>


### PR DESCRIPTION
### Motivation
- Reduce header clutter by replacing the long paragraph description with a compact, color-coded legend for the temperature curves.
- Improve visual clarity of the chart lines and markers so actual and target curves are visually distinct and permanent datapoint dots do not obscure the chart.
- Add unit tests to lock in the visual/DOM contract for the timeline and ensure the now marker and legend are rendered as expected.

### Description
- Replaced the long description paragraph with a compact legend by renaming `temperatureTimeline__description` to `temperatureTimeline__legend` and rendering two spans `temperatureTimeline__legendActual` and `temperatureTimeline__legendTarget` in the component `ProductionTemperatureTimeline`.
- Updated CSS in `ProductionTemperatureTimeline.css` to support the new legend layout and added color classes `temperatureTimeline__legendActual` and `temperatureTimeline__legendTarget` with `white-space: nowrap` and spacing adjustments.
- Tweaked chart rendering in `ProductionTemperatureTimeline.tsx` to use `type="linear"` and `dot={false}` for the actual temperature line, and `strokeWidth={1.5}` with `strokeOpacity={0.8}` for the target temperature line, while keeping the now `ReferenceLine` marker and its label.
- Added unit tests in `ProductionTemperatureTimeline.test.tsx` that mock `recharts` components and assert the lines, legend classes, and now marker attributes.

### Testing
- Added Jest/React Testing Library unit tests in `ProductionTemperatureTimeline.test.tsx` which validate the actual and target line props, legend classnames, and the now `ReferenceLine` attributes.
- Ran the unit test suite with `yarn test` and the new tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a86c32f37a8832f90c0142415e91960)