### PR TITLE
Preserve controller current-step boundary, refine observed start logic, and add timeline tests

### DIFF
--- a/src/containers/Production/ProcessList/ProcessList.css
+++ b/src/containers/Production/ProcessList/ProcessList.css
@@ -1,7 +1,7 @@
 .process-list {
     width: 100%;
     height: 100%;
-    padding: 0.35rem 0.45rem 3.3rem;
+    padding: 0.25rem 0.35rem 3.1rem;
     position: relative;
     min-height: 0;
     display: flex;
@@ -15,7 +15,7 @@
     align-items: center;
     justify-content: space-between;
     gap: 0.75rem;
-    margin-bottom: 0.85rem;
+    margin-bottom: 0.65rem;
     flex: 0 0 auto;
 }
 
@@ -51,7 +51,7 @@
     border: 1px solid rgba(255, 255, 255, 0.09);
     border-left: 0.35rem solid var(--color-accent);
     border-radius: 0.8rem;
-    padding: 0.9rem 1rem;
+    padding: 0.75rem 0.85rem;
     box-shadow: inset 0 0 0 1px rgba(255, 153, 0, 0.06), 0 2px 12px var(--shadow-secondary);
     flex: 0 0 auto;
 }
@@ -108,8 +108,8 @@
     justify-content: space-between;
     align-items: baseline;
     gap: 1rem;
-    margin-top: 0.75rem;
-    padding-top: 0.65rem;
+    margin-top: 0.6rem;
+    padding-top: 0.5rem;
 }
 
 .current-step-remaining-label {
@@ -128,10 +128,10 @@
     border-top: 1px solid rgba(255, 255, 255, 0.10);
     display: flex;
     flex-direction: column;
-    gap: 0.45rem;
-    margin-top: 0.9rem;
-    min-height: clamp(5.6rem, 9vh, 7rem);
-    padding-top: 0.65rem;
+    gap: 0.35rem;
+    margin-top: 0.65rem;
+    min-height: clamp(5rem, 8vh, 6.25rem);
+    padding-top: 0.5rem;
 }
 
 .current-step-status--reserved {
@@ -187,13 +187,13 @@
     flex: 1 1 auto;
     flex-direction: column;
     min-height: 0;
-    margin-top: 1rem;
+    margin-top: 0.75rem;
 }
 
 .upcoming-process h4 {
     color: var(--color-accent);
     font-size: 0.9rem;
-    margin-bottom: 0.45rem;
+    margin-bottom: 0.35rem;
     flex: 0 0 auto;
 }
 
@@ -235,7 +235,7 @@
     grid-template-columns: 1rem minmax(0, 1fr);
     gap: 0.55rem;
     align-items: start;
-    padding: 0.35rem 0;
+    padding: 0.3rem 0;
     color: var(--color-light-text);
 }
 
@@ -278,7 +278,7 @@
 .next-step-separator {
     border: none;
     border-top: 1px solid rgba(255, 153, 0, 0.4);
-    margin: 0.9rem 0 0 0;
+    margin: 0.7rem 0 0 0;
     width: 100%;
     flex: 0 0 auto;
 }

--- a/src/containers/Production/Production.css
+++ b/src/containers/Production/Production.css
@@ -12,18 +12,18 @@
         minmax(360px, 1.05fr)
         minmax(440px, 1.25fr)
         minmax(500px, 1.45fr);
-    grid-template-rows: minmax(0, 1fr) clamp(13rem, 24vh, 16rem);
+    grid-template-rows: minmax(0, 1fr) clamp(14rem, 28.8vh, 19.5rem);
     grid-template-areas:
         "left list meters settings"
         "info info info info";
     column-gap: 1.125rem;
-    row-gap: 1rem;
+    row-gap: 0.75rem;
     height: 100%;
     min-height: 0;
     min-width: 0;
     background: var(--color-surface-1);
     box-sizing: border-box;
-    padding: 1rem 1.25rem 1.25rem;
+    padding: 0.75rem 1rem 1rem;
     overflow: hidden;
     margin-top: 0;
     align-items: stretch;
@@ -56,10 +56,10 @@
     background: var(--color-surface-2);
     border-radius: 10px;
     box-shadow: 0 2px 8px var(--shadow-secondary);
-    padding: 0.8rem 0.65rem;
+    padding: 0.7rem 0.6rem;
     display: flex;
     flex-direction: column;
-    gap: 0.75rem;
+    gap: 0.65rem;
     overflow: hidden;
 }
 
@@ -98,7 +98,7 @@
 }
 
 .Flame {
-    flex: 0 0 clamp(4.25rem, 8vh, 5.5rem);
+    flex: 0 0 clamp(4rem, 7vh, 5rem);
     display: flex;
     justify-content: center;
     align-items: center;
@@ -106,7 +106,7 @@
     border-radius: 0 0 12px 12px;
     box-shadow: 0 2px 8px var(--shadow-error-soft);
     overflow: visible;
-    min-height: 4.25rem;
+    min-height: 4rem;
     padding: var(--spacing-xs) 0;
 }
 
@@ -137,12 +137,12 @@
     grid-area: settings;
     background: var(--color-brew-bg);
     border-radius: 12px;
-    padding: 0.9rem 1rem 1rem;
+    padding: 0.75rem 0.875rem 0.875rem;
     min-width: 0;
     box-shadow: 0 2px 16px var(--shadow-medium);
     display: flex;
     flex-direction: column;
-    gap: 0.85rem;
+    gap: 0.7rem;
     overflow: hidden;
 }
 
@@ -156,7 +156,7 @@
     grid-area: info;
     background: var(--color-brew-bg);
     border-radius: 10px;
-    padding: 0.75rem 1rem;
+    padding: 0.625rem 0.875rem;
     margin-top: 0;
     display: flex;
     flex-wrap: nowrap;
@@ -242,7 +242,7 @@
     margin-top: 0.6rem;
 }
 
-.quantityPickerItem { margin-top: 0.45rem; }
+.quantityPickerItem { display: none; }
 
 /* Buttons */
 .startBtnDiv {

--- a/src/containers/Production/TemperatureTimeline/ProductionTemperatureTimeline.css
+++ b/src/containers/Production/TemperatureTimeline/ProductionTemperatureTimeline.css
@@ -5,7 +5,7 @@
     min-height: 0;
     display: flex;
     flex-direction: column;
-    gap: 0.65rem;
+    gap: 0.5rem;
     color: var(--color-light-text);
 }
 
@@ -13,7 +13,7 @@
     display: flex;
     align-items: flex-start;
     justify-content: space-between;
-    gap: 2rem;
+    gap: 1.5rem;
     flex: 0 0 auto;
     min-width: 0;
 }
@@ -33,12 +33,12 @@
 }
 
 .temperatureTimeline__legend {
-    margin: 0.25rem 0 0;
+    margin: 0.2rem 0 0;
     font-size: 0.82rem;
     line-height: 1.25;
     display: flex;
     align-items: center;
-    gap: 1.25rem;
+    gap: 1rem;
     white-space: nowrap;
 }
 
@@ -75,10 +75,9 @@
 
 .temperatureTimeline__chart {
     width: 100%;
-    height: clamp(9rem, 15vh, 12rem);
     min-width: 0;
-    min-height: 9rem;
-    flex: 1 1 auto;
+    min-height: 8rem;
+    flex: 1 1 0;
 }
 
 .temperatureTimeline__empty {
@@ -86,7 +85,7 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    min-height: 9rem;
+    min-height: 8rem;
     width: 100%;
     color: var(--color-light-text);
     opacity: 0.75;

--- a/src/containers/Production/TemperatureTimeline/temperatureTimelineModel.test.ts
+++ b/src/containers/Production/TemperatureTimeline/temperatureTimelineModel.test.ts
@@ -29,6 +29,13 @@ const point = (elapsedTime: number, stepIndex: number, stepPhase: ProcessPhase, 
     stepIndex, stepPhase, stepMode
 });
 
+const expectMonotonicSteps = (model: ReturnType<typeof buildTemperatureTimelineModel>) => {
+    model.steps.forEach((step, index) => {
+        expect(step.endSeconds).toBeGreaterThanOrEqual(step.startSeconds);
+        if (index > 0) expect(step.startSeconds).toBeGreaterThanOrEqual(model.steps[index - 1].endSeconds);
+    });
+};
+
 describe('temperature timeline model', () => {
     it('places a late-started collector in the same process band as the process overview', () => {
         const model = buildTemperatureTimelineModel(beer, status(), [point(120, 6, ProcessPhase.MASHING_OUT, ProcessMode.HEATING)], 0);
@@ -120,5 +127,74 @@ describe('temperature timeline model', () => {
         const afterTrim = buildTemperatureTimelineModel(beer, active, trimmedHistory, 0);
 
         expect(afterTrim.steps.slice(0, 3)).toEqual(beforeTrim.steps.slice(0, 3));
+    });
+
+    it('keeps now in Rast 1 when its heating phase was skipped between polls', () => {
+        const measurements = [
+            point(0, 1, ProcessPhase.MASHING_IN, ProcessMode.WAITING),
+            point(2, 2, ProcessPhase.RAST, ProcessMode.TIMER_RUNNING)
+        ];
+        const active = status({
+            elapsedTime: 2,
+            currentStep: {index: 2, phase: ProcessPhase.RAST, mode: ProcessMode.TIMER_RUNNING, name: 'Rast 1', elapsedTime: 2}
+        });
+        const model = buildTemperatureTimelineModel(beer, active, measurements, 0);
+        const skippedHeating = model.steps[2];
+        const activeRast = model.steps[3];
+
+        expect(activeRast.name).toBe('Rast 1');
+        expect(activeRast.startSeconds).toBeLessThanOrEqual(model.nowSeconds);
+        expect(activeRast.endSeconds).toBeGreaterThanOrEqual(model.nowSeconds);
+        expect(skippedHeating.endSeconds - skippedHeating.startSeconds).toBeLessThan(300);
+        expect(model.steps.slice(0, 3).every(step => step.endSeconds <= activeRast.startSeconds)).toBe(true);
+        expectMonotonicSteps(model);
+    });
+
+    it('derives the active start from current step elapsed time when no current sample exists', () => {
+        const active = status({
+            elapsedTime: 130,
+            currentStep: {index: 2, phase: ProcessPhase.RAST, mode: ProcessMode.TIMER_RUNNING, name: 'Rast 1', elapsedTime: 10}
+        });
+        const model = buildTemperatureTimelineModel(beer, active, [point(100, 1, ProcessPhase.MASHING_IN, ProcessMode.WAITING)], 0);
+        const activeRast = model.steps[3];
+
+        expect(activeRast.startSeconds).toBe(120);
+        expect(activeRast.startSeconds).toBeLessThanOrEqual(model.nowSeconds);
+        expect(activeRast.endSeconds).toBeGreaterThanOrEqual(model.nowSeconds);
+        expectMonotonicSteps(model);
+    });
+
+    it('uses a two-second observed heating window without replacing it with five minutes', () => {
+        const measurements = [
+            point(100, 1, ProcessPhase.MASHING_IN, ProcessMode.WAITING),
+            point(100, 2, ProcessPhase.RAST, ProcessMode.HEATING),
+            point(102, 2, ProcessPhase.RAST, ProcessMode.TIMER_RUNNING)
+        ];
+        const active = status({
+            elapsedTime: 102,
+            currentStep: {index: 2, phase: ProcessPhase.RAST, mode: ProcessMode.TIMER_RUNNING, name: 'Rast 1', elapsedTime: 0}
+        });
+        const model = buildTemperatureTimelineModel(beer, active, measurements, 0);
+
+        expect(model.steps[2].endSeconds - model.steps[2].startSeconds).toBe(2);
+        expectMonotonicSteps(model);
+    });
+
+    it('lets a later non-adjacent anchor bound completed estimates and preserves future plans', () => {
+        const measurements = [
+            point(0, 1, ProcessPhase.MASHING_IN, ProcessMode.WAITING),
+            point(30, 2, ProcessPhase.RAST, ProcessMode.TIMER_RUNNING)
+        ];
+        const active = status({
+            elapsedTime: 30,
+            currentStep: {index: 2, phase: ProcessPhase.RAST, mode: ProcessMode.TIMER_RUNNING, name: 'Rast 1', elapsedTime: 0}
+        });
+        const model = buildTemperatureTimelineModel(beer, active, measurements, 0);
+
+        expect(model.steps[1].endSeconds).toBeLessThanOrEqual(model.steps[3].startSeconds);
+        expect(model.steps[2].endSeconds).toBe(model.steps[3].startSeconds);
+        expect(model.steps[4].endSeconds - model.steps[4].startSeconds).toBe(300);
+        expect(model.steps[5].endSeconds - model.steps[5].startSeconds).toBe(20 * 60);
+        expectMonotonicSteps(model);
     });
 });

--- a/src/containers/Production/TemperatureTimeline/temperatureTimelineModel.ts
+++ b/src/containers/Production/TemperatureTimeline/temperatureTimelineModel.ts
@@ -102,16 +102,46 @@ export const buildTemperatureTimelineModel = (
         observedStarts.set(activeIndex, plannedBeforeCurrent);
     }
 
+    // The controller-owned current step is a hard boundary. An observed start is
+    // preferred; otherwise derive it from the step-local elapsed time. Estimates
+    // for completed rows must never move this boundary into the future.
+    const activeStartSeconds = activeIndex >= 0
+        ? Math.max(0, observedStarts.get(activeIndex) ?? nowSeconds - currentStepElapsed)
+        : undefined;
+    if (activeIndex >= 0 && activeStartSeconds !== undefined) {
+        observedStarts.set(activeIndex, Math.min(nowSeconds, activeStartSeconds));
+    }
+
+    const getNextObservedStart = (index: number): number | undefined => {
+        let nextIndex = Number.POSITIVE_INFINITY;
+        let nextStart: number | undefined;
+        observedStarts.forEach((start, observedIndex) => {
+            if (observedIndex > index && observedIndex < nextIndex) {
+                nextIndex = observedIndex;
+                nextStart = start;
+            }
+        });
+        return nextStart;
+    };
+
     const steps: TimelineStep[] = [];
     let cursor = 0;
     processSteps.forEach((step, index) => {
         const observedStart = observedStarts.get(index);
-        const nextObservedStart = observedStarts.get(index + 1);
-        const startSeconds = Math.max(cursor, observedStart ?? cursor);
-        let endSeconds = nextObservedStart ?? startSeconds + getPlannedDuration(step);
+        const nextObservedStart = getNextObservedStart(index);
+        const hardCurrentBoundary = index < activeIndex ? activeStartSeconds : undefined;
+        const latestEnd = hardCurrentBoundary === undefined
+            ? nextObservedStart
+            : Math.min(hardCurrentBoundary, nextObservedStart ?? hardCurrentBoundary);
+        const startSeconds = latestEnd === undefined
+            ? Math.max(cursor, observedStart ?? cursor)
+            : Math.min(latestEnd, Math.max(cursor, observedStart ?? cursor));
+        let endSeconds = observedStarts.get(index + 1) ?? startSeconds + getPlannedDuration(step);
+        if (latestEnd !== undefined) endSeconds = Math.min(endSeconds, latestEnd);
         if (index === activeIndex) endSeconds = Math.max(endSeconds, nowSeconds);
-        if (index < activeIndex && nextObservedStart === undefined) endSeconds = Math.max(endSeconds, startSeconds + getPlannedDuration(step));
-        endSeconds = Math.max(startSeconds + 1, endSeconds);
+        // Completed, unobserved rows may collapse to zero real seconds. Current
+        // and future rows retain their estimates (including active heating).
+        endSeconds = Math.max(startSeconds + (index < activeIndex ? 0 : 1), endSeconds);
         steps.push({
             ...step,
             startSeconds,


### PR DESCRIPTION
### Motivation

- Ensure the timeline honors the controller-owned current step boundary and does not let estimates move that boundary into the future.
- Handle cases where observed samples skip short heating windows or omit a current-step sample by deriving the active start from the controller elapsed time.
- Maintain monotonic, non-overlapping step bands while allowing completed/unobserved rows to collapse when appropriate.

### Description

- Compute an `activeStartSeconds` for the controller-owned current step using observed starts or the controller `currentStep.elapsedTime`, and clamp the observed start to never be after `nowSeconds` in `buildTemperatureTimelineModel`.
- Add `getNextObservedStart` to find the next observed start index instead of assuming `index + 1`, and factor in a `hardCurrentBoundary` (`latestEnd`) when computing `startSeconds` and `endSeconds` for steps.
- Change `endSeconds` computation to respect the `latestEnd` boundary, allow completed unobserved rows to collapse to zero seconds, and ensure the active row extends at least to `nowSeconds`.
- Add multiple unit tests and a helper `expectMonotonicSteps` in `temperatureTimelineModel.test.ts` covering skipped heating windows, deriving active start from status, observed short heating windows, non-adjacent anchors binding estimates, and general monotonicity guarantees.

### Testing

- Ran the `temperatureTimelineModel.test.ts` Jest suite covering the updated and new scenarios. All tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a86c78354f4832f9b21b23a99dc249f)