### PR TITLE
Production-Ansicht: aktuellen Schritt in Mitte, redundante Gauges entfernen

### DIFF
--- a/src/containers/Production/ProcessList/ProcessList.css
+++ b/src/containers/Production/ProcessList/ProcessList.css
@@ -10,6 +10,17 @@
     color: var(--color-light-text);
 }
 
+.current-step-panel {
+    width: 100%;
+    min-height: 0;
+    padding: 0.8rem;
+    color: var(--color-light-text);
+    background: var(--color-surface-2);
+    border-radius: 14px;
+    box-shadow: 0 2px 8px var(--shadow-secondary);
+    overflow: hidden;
+}
+
 .process-card-header {
     display: flex;
     align-items: center;
@@ -198,7 +209,7 @@
 }
 
 .upcoming-process-scroll {
-    max-height: clamp(8rem, 32vh, 18rem);
+    flex: 1 1 auto;
     min-height: 0;
     overflow-y: auto;
     overflow-x: hidden;

--- a/src/containers/Production/ProcessList/ProcessList.tsx
+++ b/src/containers/Production/ProcessList/ProcessList.tsx
@@ -52,6 +52,7 @@ export interface ProcessListProps {
     isNextStepDisabled?: boolean;
     brewingStatus?: BrewingStatus;
     remainingSeconds?: number;
+    displayMode?: 'combined' | 'overview' | 'current';
 }
 
 interface ProcessListState {
@@ -281,7 +282,7 @@ export class ProcessList extends React.Component<ProcessListProps, ProcessListSt
     }
 
     render() {
-        const { selectedBeer, onNextStep, isNextStepDisabled = false, brewingStatus } = this.props;
+        const { selectedBeer, onNextStep, isNextStepDisabled = false, brewingStatus, displayMode = 'combined' } = this.props;
         const steps = createProcessSteps(selectedBeer);
         const hasRecipeProcess = steps.length > 0;
         const isProcessStarted = brewingStatus !== undefined && brewingStatus.process?.state !== ProcessState.IDLE;
@@ -289,6 +290,26 @@ export class ProcessList extends React.Component<ProcessListProps, ProcessListSt
         const activeStep = stepIndex >= 0 ? steps[stepIndex] : undefined;
         const upcomingSteps = stepIndex >= 0 ? steps.slice(stepIndex + 1) : steps;
         const progressLabel = stepIndex >= 0 ? `${stepIndex + 1} / ${steps.length}` : '';
+
+        const currentStepCard = hasRecipeProcess ? (
+            <>
+                <div className="current-process-label">Aktueller Schritt</div>
+                <section className="current-process-step" aria-label="Aktueller Prozessschritt">
+                    <div className="current-step-heading">
+                        <div>
+                            <h4>{isProcessStarted ? this.getCurrentStepTitle(activeStep) : 'Noch kein Brauvorgang gestartet'}</h4>
+                            <span className="current-step-badge">{isProcessStarted ? 'Aktiver Schritt' : 'Geplanter Ablauf'}</span>
+                        </div>
+                        {this.getCurrentStepMeta(activeStep, isProcessStarted)}
+                    </div>
+                    {this.renderStatusSection(isProcessStarted)}
+                </section>
+            </>
+        ) : <div className="process-empty-state">Kein Bier für den Brauvorgang ausgewählt.</div>;
+
+        if (displayMode === 'current') {
+            return <div className="current-step-panel">{currentStepCard}</div>;
+        }
 
         return (
             <div className="process-list">
@@ -313,20 +334,10 @@ export class ProcessList extends React.Component<ProcessListProps, ProcessListSt
                     <div className="process-empty-state">Kein Bier für den Brauvorgang ausgewählt.</div>
                 ) : (
                     <>
-                        <div className="current-process-label">Aktueller Schritt</div>
-                        <section className="current-process-step" aria-label="Aktueller Prozessschritt">
-                            <div className="current-step-heading">
-                                <div>
-                                    <h4>{isProcessStarted ? this.getCurrentStepTitle(activeStep) : 'Noch kein Brauvorgang gestartet'}</h4>
-                                    <span className="current-step-badge">{isProcessStarted ? 'Aktiver Schritt' : 'Geplanter Ablauf'}</span>
-                                </div>
-                                {this.getCurrentStepMeta(activeStep, isProcessStarted)}
-                            </div>
-                            {this.renderStatusSection(isProcessStarted)}
-                        </section>
+                        {displayMode === 'combined' && currentStepCard}
 
-                        <section className="upcoming-process" aria-label="Weiterer Ablauf">
-                            <h4>Weiterer Ablauf</h4>
+                        <section className="upcoming-process" aria-label="Ablauf">
+                            <h4>Ablauf</h4>
                             <div className="upcoming-process-scroll">
                                 {upcomingSteps.length > 0 ? (
                                     <ul>

--- a/src/containers/Production/Production.css
+++ b/src/containers/Production/Production.css
@@ -66,7 +66,7 @@
 .meters {
     grid-area: meters;
     display: grid;
-    grid-template-rows: minmax(0, 1fr) minmax(0, 1fr);
+    grid-template-rows: minmax(12rem, auto) minmax(0, 1fr);
     gap: 1rem;
 }
 
@@ -110,8 +110,7 @@
     padding: var(--spacing-xs) 0;
 }
 
-/* Agitator und Temperatur mittig */
-.Agitator,
+/* Temperaturanzeige mittig */
 .Temp {
     background: var(--color-brew-bg);
     border-radius: 14px;
@@ -121,14 +120,6 @@
     min-height: 0;
     min-width: 0;
     overflow: hidden;
-}
-
-.Agitator {
-    flex-wrap: nowrap;
-    gap: 0.75rem;
-}
-
-.Temp {
     padding: 0 0.75rem;
 }
 

--- a/src/containers/Production/Production.test.tsx
+++ b/src/containers/Production/Production.test.tsx
@@ -78,6 +78,20 @@ const renderProduction = (aOverrides: Partial<React.ComponentProps<typeof Produc
 
 describe('Production start button', () => {
 
+    it('places the current step above the sole temperature gauge and keeps the process column focused on the upcoming flow', () => {
+        const {container} = renderProduction({brewingStatus: createBrewingStatus(ProcessState.IDLE)});
+        const meters = container.querySelector('.meters') as HTMLElement;
+        const processColumn = container.querySelector('.list') as HTMLElement;
+
+        expect(meters.querySelector('.current-step-panel')).toBeInTheDocument();
+        expect(meters.querySelector('.Temp')).toBeInTheDocument();
+        expect(meters.querySelectorAll('.GaugeContainer')).toHaveLength(1);
+        expect(meters.querySelector('[aria-label="Aktueller Prozessschritt"]')).toHaveTextContent('Noch kein Brauvorgang gestartet');
+        expect(processColumn).toHaveTextContent('Ablauf');
+        expect(processColumn.querySelector('.current-process-step')).not.toBeInTheDocument();
+        expect(container.querySelector('.Water')).toHaveTextContent('0,0 l');
+    });
+
     it('keeps the start button enabled when no brew is running', () => {
         renderProduction({brewingStatus: createBrewingStatus(ProcessState.IDLE), isPollingRunning: false});
         expect(screen.getByRole('button', {name: 'Start'})).not.toBeDisabled();

--- a/src/containers/Production/Production.tsx
+++ b/src/containers/Production/Production.tsx
@@ -636,28 +636,6 @@ export class Production extends React.Component<ProductionProps, ProductionState
             </div>);
     }
 
-    renderAgitator() {
-        const infinitySymbol = '\u221E';
-        const {currentAgitatorSpeed, agitatorSpeed} = this.props;
-        // Werte absichern
-        const gaugeValue = isNaN(Number(agitatorSpeed)) ? 0 : Number(agitatorSpeed);
-        const gaugeTarget = isNaN(Number(currentAgitatorSpeed)) ? 0 : Number(currentAgitatorSpeed);
-        const currentFillLiters = this.getDisplayedWaterLiters();
-        const currentTargetLiters = this.getCurrentWaterFillTargetLiters();
-        return (<div className="Agitator">
-
-            <div className="GaugeContainer">
-                <Gauge showAreas={true} value={gaugeValue} targetValue={gaugeTarget} height={200} offset={1}
-                       minValue={0}
-                       maxValue={this.MAX_AGITATOR_SPEED} label={infinitySymbol}/>
-            </div>
-            <div className="GaugeContainer">
-                <Gauge showAreas={false} value={currentFillLiters} targetValue={currentTargetLiters} height={200}
-                       offset={0.5} minValue={0} maxValue={this.MAX_WATER_LEVEL} label={"Liter"}/>
-            </div>
-        </div>);
-    }
-
     renderWater() {
         const {currentAgitatorSpeed, brewingStatus} = this.props;
         const displayedWaterLiters = this.getDisplayedWaterLiters();
@@ -718,8 +696,16 @@ export class Production extends React.Component<ProductionProps, ProductionState
         }
         const isNextStepDisabled = !this.isControllerAvailable() || !this.isNextProcedureStepAvailable();
         return (
-            <ProcessList selectedBeer={selectedBeer} currentStepIndex={brewingStatus?.currentStep?.index ?? 0} currentStep={brewingStatus?.currentStep} brewingStatus={brewingStatus} remainingSeconds={this.state.displayedRemainingSeconds} onNextStep={this.handleNextProcedureStep} isNextStepDisabled={isNextStepDisabled} />
+            <ProcessList displayMode="overview" selectedBeer={selectedBeer} currentStepIndex={brewingStatus?.currentStep?.index ?? 0} currentStep={brewingStatus?.currentStep} brewingStatus={brewingStatus} remainingSeconds={this.state.displayedRemainingSeconds} onNextStep={this.handleNextProcedureStep} isNextStepDisabled={isNextStepDisabled} />
         );
+    }
+
+    renderCurrentStep() {
+        const {selectedBeer, brewingStatus} = this.props;
+        if (selectedBeer === undefined) {
+            return null;
+        }
+        return <ProcessList displayMode="current" selectedBeer={selectedBeer} currentStepIndex={brewingStatus?.currentStep?.index ?? 0} currentStep={brewingStatus?.currentStep} brewingStatus={brewingStatus} remainingSeconds={this.state.displayedRemainingSeconds} />;
     }
 
 
@@ -744,7 +730,7 @@ export class Production extends React.Component<ProductionProps, ProductionState
                     {this.renderProcessList()}  {/* Hier deine List-Renderfunktion */}
                 </div>
                 <div className="meters">
-                    {this.renderAgitator()}
+                    {this.renderCurrentStep()}
                     {this.renderTemperature()}
                 </div>
                 {this.renderSettings()}


### PR DESCRIPTION
### Motivation
- Verbessern der Informationshierarchie in der `Production`-Ansicht, sodass die mittlere Spalte den aktuellen Brauzustand (aktueller Schritt + Temperatur-Gauge) zeigt und die linke Spalte den weiteren Ablauf fokussiert.
- Redundante Anzeigen (Liter-Gauge und Umdrehungs-/Rührwerk-Gauge) in der mittleren Spalte entfernen, ohne Steuerungslogik, Redux-State oder die Komponenten selbst zu löschen.
- Layoutänderungen sollen klein gehalten und bestehende Komponenten wiederverwendet werden, damit Verhalten und Cross-Repo-Verträge unverändert bleiben.

### Description
- Entfernt die beiden oberen Gauges in der mittleren Spalte und ersetzt das mittlere Panel durch eine vertikale Reihenfolge: oben der wiederverwendete `Aktueller Schritt`-Bereich (aus `ProcessList`) und darunter die bestehende Temperaturanzeige; relevante Änderungen sind in `src/containers/Production/Production.tsx` und `src/containers/Production/Production.css` umgesetzt.
- `ProcessList` wurde um ein optionales `displayMode`-Prop erweitert und der bestehende `Aktueller Schritt`-Block als wiederverwendbare Karte extrahiert, so dass er als eigenständige Karte in der Mitte (`displayMode="current"`) oder kombiniert in der linken Spalte (`displayMode="combined"`) gerendert werden kann; Änderungen in `src/containers/Production/ProcessList/ProcessList.tsx` und `src/containers/Production/ProcessList/ProcessList.css`.
- Die Prozessliste links zeigt nun nur noch die Überschrift (`Prozess`), den Prozesszähler, die Liste kommender Schritte und den `Nächster Schritt`-Button; die Bereichsüberschrift wurde auf `Ablauf` gekürzt und die Scroll-/Höhenverteilung so angepasst, dass mehr kommende Schritte sichtbar sind; relevante Dateien: `src/containers/Production/ProcessList/ProcessList.tsx`, `src/containers/Production/ProcessList/ProcessList.css`.
- Dateien geändert: `src/containers/Production/ProcessList/ProcessList.tsx`, `src/containers/Production/ProcessList/ProcessList.css`, `src/containers/Production/Production.tsx`, `src/containers/Production/Production.css`, `src/containers/Production/Production.test.tsx`; keine Löschung von Gauge- oder Kontrollkomponenten, und keine Änderungen an Redux-State, Epics oder Steuerungslogik wurden vorgenommen.

### Testing
- Unit-Tests: vorhandene `ProcessList`-Tests wurden beibehalten und weiter abgedeckt, und es wurde ein Layout/tegrationstest ergänzt in `src/containers/Production/Production.test.tsx`, der prüft, dass die aktuelle Schritt-Karte über dem Temperatur-Gauge erscheint und die linke Spalte den Ablauf zeigt.
- Testausführung: Versuch, die relevanten Tests (`ProcessList.test.tsx` und `Production.test.tsx`) mit dem Projekt-Test-Runner zu starten, schlug in dieser Umgebung fehl, da Abhängigkeiten (`node_modules`) nicht installiert sind und ein Zugriff auf Registry/`react-scripts` nicht möglich war; deshalb konnten automatisierte Tests hier nicht vollständig ausgeführt.
- Weitere Prüfungen: lokale statische Prüfungen wie `git diff --check` und Code-Änderungsübersicht wurden angewendet und ergaben keine Code-Style-Fehler, und es wurden bewusst keine Änderungen an Redux/Prozesslogik, Timeline-Model oder DataCollector vorgenommen, wie in den Projektregeln gefordert.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a871e0e5f78832f919d68288418b9e7)