### PR TITLE
Add manual water-fill handling and fix displayed/committed recipe water accounting

### DIFF
--- a/src/containers/Production/Production.test.tsx
+++ b/src/containers/Production/Production.test.tsx
@@ -357,7 +357,7 @@ describe('Production recipe water filling', () => {
         expect(screen.queryByText('30,0 l')).not.toBeInTheDocument();
     });
 
-    it('adds Nachguss exactly once after the process leaves MASHING_OUT_CONFIRMATION for a later phase', () => {
+    it('does not add transferred Nachguss back to the current vessel after mashing out', () => {
         const waitingForMashingOut = createBrewingStatus(ProcessState.ACTIVE);
         waitingForMashingOut.currentStep.phase = ProcessPhase.MASHING_OUT;
         waitingForMashingOut.currentStep.mode = ProcessMode.WAITING;
@@ -374,10 +374,10 @@ describe('Production recipe water filling', () => {
         rerender(<Production {...props} brewingStatus={waitingForMashingOut} waterStatus={{filledLiters: 21, targetLiters: 21, openClose: false}} />);
         expect(screen.queryByText('30,0 l')).not.toBeInTheDocument();
         rerender(<Production {...props} brewingStatus={cooking} waterStatus={{filledLiters: 21, targetLiters: 21, openClose: false}} />);
-        expect(screen.getByText('Brauwasser gesamt')).toBeInTheDocument();
-        expect(screen.getByText('30,0 l')).toBeInTheDocument();
+        expect(screen.getAllByText('Hauptguss').length).toBeGreaterThan(0);
+        expect(screen.getByText('21,0 l')).toBeInTheDocument();
         rerender(<Production {...props} brewingStatus={cooking} waterStatus={{filledLiters: 21, targetLiters: 21, openClose: false}} />);
-        expect(screen.getByText('30,0 l')).toBeInTheDocument();
+        expect(screen.getByText('21,0 l')).toBeInTheDocument();
         expect(screen.queryByText('39,0 l')).not.toBeInTheDocument();
     });
 

--- a/src/containers/Production/Production.tsx
+++ b/src/containers/Production/Production.tsx
@@ -34,7 +34,7 @@ import {calculateHopSchedule, getDueHopAddition, HopAddition} from "./utils/hopS
 import {getRemainingSecondsFromStatus, shouldCountdownLocally, tickRemainingSeconds} from "./utils/productionCountdown";
 import {isAgitatorActive, isControllerAvailable as getIsControllerAvailable, isHeaterActive} from "./utils/productionStatus";
 import {RecipeWaterFill, RecipeWaterFillStatus} from "./waterFill/recipeWaterFill.types";
-import {completeWaterFill, createInitialRecipeWaterFillStatus, failWaterFill, markValveOpened, resetWaterFill, startWaterFill} from "./waterFill/recipeWaterFillState";
+import {completeWaterFill, createInitialRecipeWaterFillStatus, failWaterFill, markValveOpened, resetWaterFill, startManualWaterFill, startWaterFill} from "./waterFill/recipeWaterFillState";
 import {ProductionDialogs} from "./components/ProductionDialogs";
 import {ProductionTemperatureTimeline} from "./TemperatureTimeline/ProductionTemperatureTimeline";
 import {getDisplayedWaterLiters as selectDisplayedWaterLiters, getWaterLabel, getWaterTargetLiters, isRecipeWaterButtonDisabled as selectRecipeWaterButtonDisabled, isWaterFillingActive as selectWaterFillingActive, shouldIncludeSpargeAfterMashingOut as selectShouldIncludeSpargeAfterMashingOut, sanitizeLiters} from "./waterFill/recipeWaterFillSelectors";
@@ -174,7 +174,7 @@ export class Production extends React.Component<ProductionProps, ProductionState
             this.setState({brewingIsRunning: false});
         }
 
-        if (this.state.recipeWaterFill.activeFillType !== undefined && waterStatus?.openClose === true && !prevProps.waterStatus?.openClose) {
+        if (this.state.recipeWaterFill.isFillActive && waterStatus?.openClose === true && !prevProps.waterStatus?.openClose) {
             this.setState((prevState) => ({recipeWaterFill: markValveOpened(prevState.recipeWaterFill)}));
         }
 
@@ -363,7 +363,7 @@ export class Production extends React.Component<ProductionProps, ProductionState
 
     completePendingRecipeWaterFill = (aPreviousFilledLiters?: number): void => {
         const {recipeWaterFill} = this.state;
-        if ((!recipeWaterFill.activeFillWasOpened && aPreviousFilledLiters === undefined) || recipeWaterFill.activeFillType === undefined) {
+        if ((!recipeWaterFill.activeFillWasOpened && aPreviousFilledLiters === undefined) || !recipeWaterFill.isFillActive) {
             this.setState((prevState) => ({waterSwitchState: false, recipeWaterFill: {...prevState.recipeWaterFill, activeFillWasOpened: false}}));
             return;
         }
@@ -465,8 +465,11 @@ export class Production extends React.Component<ProductionProps, ProductionState
         const {waterSwitchState, liters,} = this.state;
         const {startWaterFilling} = this.props;
         if (!waterSwitchState) {
-            this.setState({waterSwitchState: true});
-            startWaterFilling(liters);
+            this.setState((prevState) => ({
+                waterSwitchState: true,
+                waterFillingError: false,
+                recipeWaterFill: startManualWaterFill(prevState.recipeWaterFill)
+            }), () => startWaterFilling(liters));
         } else {
             this.setState({waterSwitchState: false});
         }

--- a/src/containers/Production/waterFill/recipeWaterFill.test.ts
+++ b/src/containers/Production/waterFill/recipeWaterFill.test.ts
@@ -1,5 +1,5 @@
 import {ProcessPhase, ProcessState, WaitingFor} from '../../../model/brewingStatus.types';
-import {completeWaterFill, createInitialRecipeWaterFillStatus, failWaterFill, markValveOpened, resetWaterFill, startWaterFill} from './recipeWaterFillState';
+import {completeWaterFill, createInitialRecipeWaterFillStatus, failWaterFill, markValveOpened, resetWaterFill, startManualWaterFill, startWaterFill} from './recipeWaterFillState';
 import {getDisplayedWaterLiters, isRecipeWaterButtonDisabled, sanitizeLiters, shouldIncludeSpargeAfterMashingOut} from './recipeWaterFillSelectors';
 
 describe('recipe water fill state', () => {
@@ -38,9 +38,57 @@ describe('recipe water fill state', () => {
         const previousStatus = {waiting: {waitingFor: WaitingFor.MASHING_OUT_CONFIRMATION, canConfirm: true}};
         const currentStatus = {process: {state: ProcessState.ACTIVE}, currentStep: {phase: ProcessPhase.COOKING}};
         expect(shouldIncludeSpargeAfterMashingOut(mashCompleted, previousStatus, currentStatus)).toBe(true);
-        expect(getDisplayedWaterLiters({...mashCompleted, isSpargeIncluded: true})).toBe(30);
+        expect(getDisplayedWaterLiters({...mashCompleted, isSpargeIncluded: true})).toBe(22);
         expect(sanitizeLiters(Number.NaN)).toBe(0);
         expect(sanitizeLiters(undefined)).toBe(0);
         expect(sanitizeLiters(-1)).toBe(0);
+    });
+
+    it('accumulates consecutive manual fills in an initially empty vessel', () => {
+        const first = completeWaterFill(markValveOpened(startManualWaterFill(createInitialRecipeWaterFillStatus())), 2);
+        const second = completeWaterFill(markValveOpened(startManualWaterFill(first)), 2);
+        expect(first.currentWaterLiters).toBe(2);
+        expect(second.currentWaterLiters).toBe(4);
+    });
+
+    it('keeps completed sparge water and accumulates multiple manual additions', () => {
+        const sparge = completeWaterFill(markValveOpened(startWaterFill(createInitialRecipeWaterFillStatus(), 'sparge')), 5);
+        const plusTwo = completeWaterFill(markValveOpened(startManualWaterFill(sparge)), 2);
+        const plusOne = completeWaterFill(markValveOpened(startManualWaterFill(plusTwo)), 1);
+        expect(sparge.currentWaterLiters).toBe(5);
+        expect(plusTwo.currentWaterLiters).toBe(7);
+        expect(plusOne.currentWaterLiters).toBe(8);
+        expect(plusOne.completedSpargeLiters).toBe(5);
+    });
+
+    it('resets the vessel at mash start and does not carry prepared sparge water over', () => {
+        const sparge = completeWaterFill(markValveOpened(startWaterFill(createInitialRecipeWaterFillStatus(), 'sparge')), 5);
+        const supplementedSparge = completeWaterFill(markValveOpened(startManualWaterFill(sparge)), 2);
+        const mashStarted = startWaterFill(supplementedSparge, 'mash');
+        const mashCompleted = completeWaterFill(markValveOpened(mashStarted), 5);
+        expect(supplementedSparge.currentWaterLiters).toBe(7);
+        expect(mashStarted.currentWaterLiters).toBe(0);
+        expect(mashCompleted.currentWaterLiters).toBe(5);
+        expect(mashCompleted.currentWaterLiters).not.toBe(12);
+    });
+
+    it('accumulates manual additions after mash and uses measured rather than requested liters', () => {
+        const mash = completeWaterFill(markValveOpened(startWaterFill(createInitialRecipeWaterFillStatus(), 'mash')), 20);
+        const measuredAddition = completeWaterFill(markValveOpened(startManualWaterFill(mash)), 4.8);
+        const finalAddition = completeWaterFill(markValveOpened(startManualWaterFill(measuredAddition)), 3);
+        expect(measuredAddition.currentWaterLiters).toBe(24.8);
+        expect(finalAddition.currentWaterLiters).toBe(27.8);
+        expect(finalAddition.completedMashLiters).toBe(20);
+    });
+
+    it('shows committed water plus the current measurement without committing poll snapshots', () => {
+        const mash = completeWaterFill(markValveOpened(startWaterFill(createInitialRecipeWaterFillStatus(), 'mash')), 20);
+        const filling = markValveOpened(startManualWaterFill(mash));
+        expect(getDisplayedWaterLiters(filling, {filledLiters: 1.5, targetLiters: 5, openClose: true})).toBe(21.5);
+        expect(getDisplayedWaterLiters(filling, {filledLiters: 2, targetLiters: 5, openClose: true})).toBe(22);
+        expect(filling.currentWaterLiters).toBe(20);
+        const completed = completeWaterFill(filling, 4.8);
+        expect(completed.currentWaterLiters).toBe(24.8);
+        expect(completeWaterFill(completed, 4.8).currentWaterLiters).toBe(24.8);
     });
 });

--- a/src/containers/Production/waterFill/recipeWaterFill.types.ts
+++ b/src/containers/Production/waterFill/recipeWaterFill.types.ts
@@ -4,11 +4,13 @@ export type WaterFillState = 'IDLE' | 'FILLING' | 'COMPLETED' | 'ERROR';
 
 export interface RecipeWaterFillStatus {
     activeFillType?: WaterFillType;
+    isFillActive: boolean;
     spargeState: WaterFillState;
     mashState: WaterFillState;
     completedSpargeLiters: number;
     completedMashLiters: number;
     currentFillLiters: number;
+    currentWaterLiters: number;
     activeFillWasOpened: boolean;
     isSpargeIncluded: boolean;
 }

--- a/src/containers/Production/waterFill/recipeWaterFillSelectors.ts
+++ b/src/containers/Production/waterFill/recipeWaterFillSelectors.ts
@@ -13,16 +13,10 @@ export const sanitizeLiters = (aValue: unknown): number => {
 };
 
 export const getDisplayedWaterLiters = (aStatus: RecipeWaterFillStatus, aWaterStatus?: WaterStatusSnapshot): number => {
-    if (aStatus.isSpargeIncluded) {
-        return aStatus.completedMashLiters + aStatus.completedSpargeLiters;
+    if (aStatus.isFillActive || aWaterStatus?.openClose === true) {
+        return sanitizeLiters(aStatus.currentWaterLiters) + sanitizeLiters(aWaterStatus?.filledLiters);
     }
-    if (aStatus.activeFillType !== undefined || aWaterStatus?.openClose === true) {
-        return sanitizeLiters(aWaterStatus?.filledLiters);
-    }
-    if (aStatus.mashState === 'COMPLETED') {
-        return aStatus.completedMashLiters;
-    }
-    return sanitizeLiters(aStatus.currentFillLiters);
+    return sanitizeLiters(aStatus.currentWaterLiters);
 };
 
 export const getWaterTargetLiters = (aStatus: RecipeWaterFillStatus, aRecipeLiters: number, aWaterStatus?: WaterStatusSnapshot): number => {
@@ -36,14 +30,13 @@ export const getWaterTargetLiters = (aStatus: RecipeWaterFillStatus, aRecipeLite
 };
 
 export const getWaterLabel = (aStatus: RecipeWaterFillStatus): string => {
-    if (aStatus.isSpargeIncluded) return 'Brauwasser gesamt';
     if (aStatus.activeFillType === 'SPARGE' || (aStatus.spargeState === 'COMPLETED' && aStatus.mashState === 'IDLE')) return 'Nachguss';
     if (aStatus.activeFillType === 'MASH' || aStatus.mashState === 'COMPLETED') return 'Hauptguss';
     return 'Aktueller Füllvorgang';
 };
 
 export const isWaterFillingActive = (aStatus: RecipeWaterFillStatus, aWaterSwitchState: boolean, aWaterStatus?: WaterStatusSnapshot): boolean =>
-    aWaterSwitchState || aStatus.activeFillType !== undefined || aWaterStatus?.openClose === true;
+    aWaterSwitchState || aStatus.isFillActive || aWaterStatus?.openClose === true;
 
 export const isRecipeWaterButtonDisabled = (aFill: RecipeWaterFill, aStatus: RecipeWaterFillStatus, aVolume: number | undefined, aControllerAvailable: boolean, aIsActive: boolean): boolean => {
     if (aVolume === undefined || !aControllerAvailable || aIsActive) return true;

--- a/src/containers/Production/waterFill/recipeWaterFillState.ts
+++ b/src/containers/Production/waterFill/recipeWaterFillState.ts
@@ -2,11 +2,13 @@ import {RecipeWaterFill, RecipeWaterFillStatus, WaterFillType} from './recipeWat
 
 export const createInitialRecipeWaterFillStatus = (): RecipeWaterFillStatus => ({
     activeFillType: undefined,
+    isFillActive: false,
     spargeState: 'IDLE',
     mashState: 'IDLE',
     completedSpargeLiters: 0,
     completedMashLiters: 0,
     currentFillLiters: 0,
+    currentWaterLiters: 0,
     activeFillWasOpened: false,
     isSpargeIncluded: false
 });
@@ -18,26 +20,41 @@ export const startWaterFill = (aStatus: RecipeWaterFillStatus, aFill: RecipeWate
     return {
         ...aStatus,
         activeFillType,
+        isFillActive: true,
         currentFillLiters: 0,
+        // Recipe fills start a new physical vessel-water phase. In particular,
+        // starting mash water means the previously prepared sparge water has
+        // already been transferred out of the brewing vessel.
+        currentWaterLiters: 0,
         activeFillWasOpened: false,
         mashState: activeFillType === 'MASH' ? 'FILLING' : aStatus.mashState,
         spargeState: activeFillType === 'SPARGE' ? 'FILLING' : aStatus.spargeState
     };
 };
 
+export const startManualWaterFill = (aStatus: RecipeWaterFillStatus): RecipeWaterFillStatus => ({
+    ...aStatus,
+    activeFillType: undefined,
+    isFillActive: true,
+    currentFillLiters: 0,
+    activeFillWasOpened: false
+});
+
 export const markValveOpened = (aStatus: RecipeWaterFillStatus): RecipeWaterFillStatus => ({...aStatus, activeFillWasOpened: true});
 
 export const completeWaterFill = (aStatus: RecipeWaterFillStatus, aCompletedLiters: number): RecipeWaterFillStatus => {
     const completedLiters = Math.max(0, Number.isFinite(aCompletedLiters) ? aCompletedLiters : 0);
     const activeFillType = aStatus.activeFillType;
-    if (activeFillType === undefined) {
+    if (!aStatus.isFillActive) {
         return {...aStatus, activeFillWasOpened: false};
     }
     return {
         ...aStatus,
         activeFillType: undefined,
+        isFillActive: false,
         activeFillWasOpened: false,
         currentFillLiters: completedLiters,
+        currentWaterLiters: aStatus.currentWaterLiters + completedLiters,
         completedMashLiters: activeFillType === 'MASH' ? completedLiters : aStatus.completedMashLiters,
         completedSpargeLiters: activeFillType === 'SPARGE' ? completedLiters : aStatus.completedSpargeLiters,
         mashState: activeFillType === 'MASH' ? 'COMPLETED' : aStatus.mashState,
@@ -48,6 +65,7 @@ export const completeWaterFill = (aStatus: RecipeWaterFillStatus, aCompletedLite
 export const failWaterFill = (aStatus: RecipeWaterFillStatus): RecipeWaterFillStatus => ({
     ...aStatus,
     activeFillType: undefined,
+    isFillActive: false,
     activeFillWasOpened: false,
     currentFillLiters: 0,
     spargeState: aStatus.activeFillType === 'SPARGE' ? 'ERROR' : aStatus.spargeState,

--- a/src/reducers/productionReducer.test.ts
+++ b/src/reducers/productionReducer.test.ts
@@ -13,4 +13,13 @@ describe('productionReducer waterStatus', () => {
 
         expect(nextState.waterStatus).toEqual(waterStatus);
     });
+
+    it('clears a previous request failure when a new water fill starts', () => {
+        const failedState = {...initialProductionState, isWaterFillingSuccessful: false};
+
+        const nextState = productionReducer(failedState, ProductionActions.startWaterFilling(2));
+
+        expect(nextState.liters).toBe(2);
+        expect(nextState.isWaterFillingSuccessful).toBe(true);
+    });
 });

--- a/src/reducers/productionReducer.ts
+++ b/src/reducers/productionReducer.ts
@@ -67,7 +67,7 @@ const productionReducer = (
             return { ...aState, agitatorIsRunning: aAction.payload.agitatorIsRunning };
         }
         case ProductionActions.ActionTypes.START_WATER_FILLING: {
-            return { ...aState, liters: aAction.payload.liters };
+            return { ...aState, liters: aAction.payload.liters, isWaterFillingSuccessful: true };
         }
         case ProductionActions.ActionTypes.START_WATER_FILLING_SUCCESS: {
             return { ...aState, isWaterFillingSuccessful: aAction.payload.isWaterFillingSuccessful };


### PR DESCRIPTION
### Motivation

- Prevent transferred sparge water from being double-counted or re-added to the current vessel after mashing out and support manual additions that are measured by the controller.
- Make UI water display and button state reflect actual measured water and manual fill operations instead of only requested recipe fills.

### Description

- Introduce `isFillActive` and `currentWaterLiters` to `RecipeWaterFillStatus` and add a `startManualWaterFill` action to represent manual/measured fills without starting a recipe fill type.
- Change state transition logic in `recipeWaterFillState` so recipe fills reset vessel water when mash starts, manual fills accumulate into `currentWaterLiters`, and `completeWaterFill` updates `currentWaterLiters` accordingly.
- Update selectors in `recipeWaterFillSelectors` to compute displayed liters from committed `currentWaterLiters` plus current measurement when a fill is active or valve is open, and to use `isFillActive` for active-fill checks and labels.
- Modify `Production` component to use `isFillActive` checks, call `startManualWaterFill` when toggling manual water switch (and clear previous error state), and adjust pending-completion logic to rely on `isFillActive`.
- Clear previous water-fill failure state when a new `START_WATER_FILLING` action is dispatched by setting `isWaterFillingSuccessful: true` in the reducer.
- Update and add unit tests to cover manual fills, accumulation, interactions between sparge and mash, displayed liters behavior, and clearing a previous request failure.

### Testing

- Ran the unit tests for water-fill logic and production views including `src/containers/Production/waterFill/recipeWaterFill.test.ts` and `src/containers/Production/Production.test.ts` using the test runner (`yarn test`), and the modified/added tests passed.
- Executed reducer tests in `src/reducers/productionReducer.test.ts` to verify clearing previous failures on `START_WATER_FILLING`, and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a88a4d89420832fb5368373a765ee60)