### PR TITLE
Fix cumulative water level tracking across fill operations

### DIFF
--- a/docs/codex/data-flow.md
+++ b/docs/codex/data-flow.md
@@ -42,6 +42,9 @@ Needs verification: backend ordering of `GET beers`, because the UI treats the l
 - UI posts `Command/FillWaterAutomatic:{liters}`.
 - On success, an RxJS interval polls `GET WaterStatus` every 1000 ms and stores normalized `{ filledLiters, targetLiters, openClose }`; the confirmed control API also supports `GET WaterStatus/` and always returns an object shape.
 - Needs verification: current `takeUntil` code uses a one-shot `from(ProductionRepository.getWaterStatus())`; confirm intended continuous stop behavior.
+- The production UI keeps `recipeWaterFill.currentWaterLiters` as the committed vessel-water snapshot for the complete lifetime of a fill operation. Poll values are displayed as that stable base plus `WaterStatus.filledLiters`; they are not committed into the base while the valve is open.
+- A newly dispatched fill does not immediately make the prior, closed `WaterStatus` current. The UI displays only the committed base until it observes `openClose: true` for the new operation. The first such status is displayed immediately, including a legitimate partial value such as `0.3` liters.
+- On the first transition from `openClose: true` to `false`, the final measured `filledLiters` is committed exactly once. A final value above `targetLiters` remains visible and is not clamped because the controller contract defines `filledLiters` as the measured operation amount.
 
 ## Confirm/waiting flow
 
@@ -66,4 +69,3 @@ Needs verification: backend ordering of `GET beers`, because the UI treats the l
 - When normalized process state becomes `FINISHED`, UI shows a finish dialog.
 - Confirming stops polling and creates a `FinishedBrew` with generated UUID, selected beer name/id, date, default metrics, state `FERMENTATION`, active `true`, and `brewValues` JSON from `dataCollector`.
 - It posts this through finished-brew repository via beer epics.
-

--- a/docs/codex/known-risks.md
+++ b/docs/codex/known-risks.md
@@ -24,6 +24,7 @@
 ## Remaining PI control verification items
 
 - Exact operational meaning of `WaterStatus.filledLiters / WaterStatus.targetLiters` beyond the UI display/control value remains Needs verification.
+- The UI can distinguish a stale status/double count from controller overfill, but this repository contains no runtime PI log for a reported physical fill. If a 2-liter request finishes with `filledLiters: 2.3`, the resulting cumulative 4.3 liters is intentional UI behavior; the valve timing, sensor measurement, and water after-run are **Needs verification** in the PI-control repository/logs.
 - Long-term stability of `GET /temperatur/0` remains Needs verification.
 - Socket.io `overheat` payload shape remains Needs verification.
 - Initial empty `Status` behavior remains Needs verification unless PI control guarantees a complete structured/default status object.

--- a/src/containers/Production/waterFill/recipeWaterFill.test.ts
+++ b/src/containers/Production/waterFill/recipeWaterFill.test.ts
@@ -91,4 +91,37 @@ describe('recipe water fill state', () => {
         expect(completed.currentWaterLiters).toBe(24.8);
         expect(completeWaterFill(completed, 4.8).currentWaterLiters).toBe(24.8);
     });
+
+    it('ignores the previous operation status until the new valve-open status is observed', () => {
+        const firstCompleted = completeWaterFill(markValveOpened(startManualWaterFill(createInitialRecipeWaterFillStatus())), 2);
+        const secondStarted = startManualWaterFill(firstCompleted);
+
+        expect(getDisplayedWaterLiters(secondStarted, {filledLiters: 2, targetLiters: 2, openClose: false})).toBe(2);
+
+        const firstNewPoll = markValveOpened(secondStarted);
+        expect(getDisplayedWaterLiters(firstNewPoll, {filledLiters: 0.3, targetLiters: 2, openClose: true})).toBe(2.3);
+    });
+
+    it('keeps the fill base stable across polls and commits the final measurement exactly once', () => {
+        const firstCompleted = completeWaterFill(markValveOpened(startManualWaterFill(createInitialRecipeWaterFillStatus())), 2);
+        const filling = markValveOpened(startManualWaterFill(firstCompleted));
+
+        [0.3, 0.7, 1.2, 1.7, 2].forEach((filledLiters) => {
+            expect(getDisplayedWaterLiters(filling, {filledLiters, targetLiters: 2, openClose: true})).toBeCloseTo(2 + filledLiters);
+            expect(filling.currentWaterLiters).toBe(2);
+        });
+
+        const completed = completeWaterFill(filling, 2);
+        expect(completed.currentWaterLiters).toBe(4);
+        expect(getDisplayedWaterLiters(completed, {filledLiters: 2, targetLiters: 2, openClose: false})).toBe(4);
+    });
+
+    it('preserves a real controller overfill instead of clamping it to the target', () => {
+        const firstCompleted = completeWaterFill(markValveOpened(startManualWaterFill(createInitialRecipeWaterFillStatus())), 2);
+        const filling = markValveOpened(startManualWaterFill(firstCompleted));
+        const completed = completeWaterFill(filling, 2.3);
+
+        expect(getDisplayedWaterLiters(filling, {filledLiters: 2.3, targetLiters: 2, openClose: true})).toBe(4.3);
+        expect(completed.currentWaterLiters).toBe(4.3);
+    });
 });

--- a/src/containers/Production/waterFill/recipeWaterFillSelectors.ts
+++ b/src/containers/Production/waterFill/recipeWaterFillSelectors.ts
@@ -13,7 +13,10 @@ export const sanitizeLiters = (aValue: unknown): number => {
 };
 
 export const getDisplayedWaterLiters = (aStatus: RecipeWaterFillStatus, aWaterStatus?: WaterStatusSnapshot): number => {
-    if (aStatus.isFillActive || aWaterStatus?.openClose === true) {
+    // Starting a new request does not synchronously reset the controller's last
+    // WaterStatus.  Only use its measurement once the new operation has actually
+    // been observed open; until then currentWaterLiters is the stable fill base.
+    if ((aStatus.isFillActive && aStatus.activeFillWasOpened) || aWaterStatus?.openClose === true) {
         return sanitizeLiters(aStatus.currentWaterLiters) + sanitizeLiters(aWaterStatus?.filledLiters);
     }
     return sanitizeLiters(aStatus.currentWaterLiters);


### PR DESCRIPTION
### Motivation

- Prevent using a stale/previous `WaterStatus.filledLiters` when starting a new fill so the UI does not show an immediate erroneous jump (e.g. 2.0 → 4.0). 
- Keep the committed vessel base stable for the whole fill lifecycle and only commit the final measured amount exactly once, while still showing live partial measurements (e.g. 2.0 → 2.3 → … → 4.0 or 4.3 when controller reports overfill).

### Description

- Change `getDisplayedWaterLiters` to only add the controller `WaterStatus.filledLiters` when the new fill operation has actually been observed open (`activeFillWasOpened` or `waterStatus.openClose === true`), otherwise show the stable committed base only (`src/containers/Production/waterFill/recipeWaterFillSelectors.ts`).
- Add regression tests that cover: ignoring the previous operation's closed status at new-start, showing the first real partial poll (e.g. `0.3`), keeping the fill base stable across polls and committing the final measurement exactly once, and preserving a real controller overfill (tests in `src/containers/Production/waterFill/recipeWaterFill.test.ts`).
- Document the behavioral contract in the local docs to make the UI/controller boundary explicit (`docs/codex/data-flow.md`) and note that confirming controller overfill requires PI-controller log verification (`docs/codex/known-risks.md`).

### Testing

- Ran a quick repository check `git diff --check` which passed locally in the environment.
- Added unit tests for the water-fill selector and lifecycle logic, but running `npm test` / `react-scripts test` in this environment failed because `react-scripts` could not be installed due to npm registry access returning HTTP 403, so the new tests could not be executed here (environment limitation). 
- The intended automated test coverage is the new/updated Jest tests in `src/containers/Production/waterFill/recipeWaterFill.test.ts` and existing production water-fill selector tests; they should pass in a CI environment with node modules installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8959a6b570832fbf14910008d45453)