### PR TITLE
Anlagenalarm: Dialog- und Header-Darstellung implementiert

### DIFF
--- a/docs/codex/data-flow.md
+++ b/docs/codex/data-flow.md
@@ -28,6 +28,7 @@ Needs verification: backend ordering of `GET beers`, because the UI treats the l
 - Poll interval is 1000 ms after start brewing.
 - Each `GET Status/` response is passed through `normalizeBrewingStatus`.
 - The normalizer carries the response's `alarms` list into `BrewingStatus.alarms` and defaults a missing legacy node to `[]`.
+- The desktop production UI derives an active equipment alarm from `alarms` and displays it through the existing production modal and header status components. Dismissing the modal is local presentation state for the current continuous alarm cycle and does not dispatch an action or call an API.
 - Normalized status is stored in `productionReducer.brewingStatus` and in `dataCollector`.
 - Polling stops when normalized process state is `FINISHED`, `ABORTED`, or `ERROR`.
 

--- a/docs/codex/domain-model.md
+++ b/docs/codex/domain-model.md
@@ -27,7 +27,7 @@ Validation rejects missing/non-positive mash-in, mash-out, and rest temperatures
 
 Runtime status is normalized into process state, current step, temperature, hardware, waiting, and error groups. UI behavior depends on:
 
-- `alarms`: a normalized list of `{ type, active }` control alarms. A missing legacy field becomes `[]`; alarms are stored only and are not evaluated or displayed yet.
+- `alarms`: a normalized list of `{ type, active }` control alarms. A missing legacy field becomes `[]`. The desktop production UI evaluates only an explicitly active `EQUIPMENT_ALARM`, shows it in the existing modal system, and prioritizes its text in the existing header status display; unknown alarm types remain ignored.
 
 - `process.state`: controls active/finished/aborted/error labels and polling termination.
 - `currentStep.phase`: drives labels, hop reminders, mobile type display, and process display.

--- a/src/containers/MainView/Header/Header.connect.ts
+++ b/src/containers/MainView/Header/Header.connect.ts
@@ -8,6 +8,7 @@ const mapStateToProps = (state: any) => ({
     currentView: state.applicationReducer.view,
     messages: state.applicationReducer.message,
     backendStatus: state.productionReducer.isBackenAvailable,
+    brewingStatus: state.productionReducer.brewingStatus,
 });
 
 const mapDispatchToProps = (dispatch: any) => ({

--- a/src/containers/MainView/Header/Header.test.tsx
+++ b/src/containers/MainView/Header/Header.test.tsx
@@ -2,6 +2,14 @@ import React from 'react';
 import {render, screen, fireEvent} from '@testing-library/react';
 import {Header} from './Header';
 import {Views} from '../../../enums/eViews';
+import {AlarmType, BrewingStatus, ProcessMode, ProcessPhase, ProcessState, WaitingFor} from '../../../model/brewingStatus.types';
+
+const brewingStatus = (activeAlarm: boolean): BrewingStatus => ({
+    elapsedTime: 0, currentTime: 0, process: {state: ProcessState.ACTIVE},
+    currentStep: {phase: ProcessPhase.RAST, mode: ProcessMode.HEATING}, temperature: {}, hardware: {},
+    waiting: {waitingFor: WaitingFor.NONE, canConfirm: false}, error: {},
+    alarms: activeAlarm ? [{type: AlarmType.EQUIPMENT_ALARM, active: true}] : []
+});
 
 describe('Header navigation', () => {
     it('keeps existing settings navigation and adds version navigation', (): void => {
@@ -41,5 +49,17 @@ describe('Header navigation', () => {
         expect(screen.getByTitle('Dashboard').querySelector('svg')).toBeInTheDocument();
         expect(screen.getByTitle('Hauptansicht').parentElement).toHaveClass('icons-container');
         expect(screen.getByText(/Backend:/)).toBeInTheDocument();
+    });
+
+    it('prioritizes the equipment alarm and restores existing status messages after it ends', (): void => {
+        const props = {setViewState: jest.fn(), currentView: Views.PRODUCTION, removeAllMessages: jest.fn(), backendStatus: true, messages: ['Aufheizen']};
+        const {rerender} = render(<Header {...props} brewingStatus={brewingStatus(false)} />);
+        expect(screen.getByText('Aufheizen')).toBeInTheDocument();
+        rerender(<Header {...props} brewingStatus={brewingStatus(true)} />);
+        expect(screen.getByRole('alert')).toHaveTextContent('ANLAGENALARM – Anlage prüfen');
+        expect(screen.queryByText('Aufheizen')).not.toBeInTheDocument();
+        rerender(<Header {...props} brewingStatus={brewingStatus(false)} />);
+        expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+        expect(screen.getByText('Aufheizen')).toBeInTheDocument();
     });
 });

--- a/src/containers/MainView/Header/Header.tsx
+++ b/src/containers/MainView/Header/Header.tsx
@@ -3,6 +3,8 @@ import './Header.css';
 import {Views} from "../../../enums/eViews";
 import StatusDisplay from './StatusDisplay';
 import DashboardIcon from '@mui/icons-material/Dashboard';
+import {BrewingStatus} from '../../../model/brewingStatus.types';
+import {equipmentAlarmDisplay, isEquipmentAlarmActive} from '../../../utils/brewingStatus/alarmDisplay';
 
 
 
@@ -12,6 +14,7 @@ interface HeaderProps {
     messages?: string[];
     removeAllMessages: () => void;
     backendStatus: boolean;
+    brewingStatus?: BrewingStatus;
 }
 
 interface HeaderState {
@@ -64,7 +67,8 @@ export class Header extends React.Component<HeaderProps, HeaderState> {
     }
 
     render() {
-       const { messages = [] , removeAllMessages, backendStatus } = this.props; // Default-Wert für messages ist ein leeres Array
+       const { messages = [] , removeAllMessages, backendStatus, brewingStatus } = this.props; // Default-Wert für messages ist ein leeres Array
+       const equipmentAlarmText = isEquipmentAlarmActive(brewingStatus) ? equipmentAlarmDisplay.headerText : undefined;
 
         return (
             <div className="Header">
@@ -141,7 +145,7 @@ export class Header extends React.Component<HeaderProps, HeaderState> {
                 </div>
                 <div className="header-status">
                   <div className="status-display-wrapper">
-                    <StatusDisplay backendStatus={backendStatus} messages={messages} disableScrollAnimation={true} removeAllMessages={removeAllMessages}/>
+                    <StatusDisplay backendStatus={backendStatus} messages={messages} priorityMessage={equipmentAlarmText} disableScrollAnimation={true} removeAllMessages={removeAllMessages}/>
                   </div>
                   <div className="time">
                     <span>{this.state.currentDate}</span>

--- a/src/containers/MainView/Header/StatusDisplay.css
+++ b/src/containers/MainView/Header/StatusDisplay.css
@@ -104,3 +104,8 @@
   align-items: center;
   gap: 0.2rem;
 }
+
+.alarm-message .message {
+  color: var(--color-error);
+  font-weight: bold;
+}

--- a/src/containers/MainView/Header/StatusDisplay.tsx
+++ b/src/containers/MainView/Header/StatusDisplay.tsx
@@ -6,6 +6,7 @@ interface StatusDisplayProps {
   messages?: string[];
   disableScrollAnimation?: boolean;
   removeAllMessages: () => void;
+  priorityMessage?: string;
 }
 
 interface StatusDisplayState {}
@@ -61,7 +62,7 @@ class StatusDisplay extends React.Component<StatusDisplayProps, StatusDisplaySta
   };
 
   render() {
-    const { backendStatus, messages, removeAllMessages } = this.props;
+    const { backendStatus, messages, removeAllMessages, priorityMessage } = this.props;
 
     const backendClass = backendStatus ? 'Online' : 'Offline';
     return (
@@ -72,7 +73,13 @@ class StatusDisplay extends React.Component<StatusDisplayProps, StatusDisplaySta
             ×
           </span>
         </div>
-        {messages && messages.length > 0 && (
+        {priorityMessage ? (
+          <div className="messages alarm-message" role="alert">
+            <div className="message-row">
+              <span className="message">{priorityMessage}</span>
+            </div>
+          </div>
+        ) : messages && messages.length > 0 && (
           <div className="messages" ref={this.messagesRef}>
             {messages.map((msg, idx) => (
               <div className="message-row" key={idx}>

--- a/src/containers/Production/Production.test.tsx
+++ b/src/containers/Production/Production.test.tsx
@@ -3,7 +3,7 @@ import {render, screen, fireEvent, waitFor} from '@testing-library/react';
 import {Production} from './Production';
 import {Beer} from '../../model/Beer';
 import {ToggleState} from '../../enums/eToggleState';
-import {BrewingStatus, ProcessMode, ProcessPhase, ProcessState, WaitingFor} from '../../model/brewingStatus.types';
+import {AlarmType, BrewingStatus, ProcessMode, ProcessPhase, ProcessState, WaitingFor} from '../../model/brewingStatus.types';
 
 const createBeer = (aMashVolume: number | undefined = 18, aSpargeVolume: number | undefined = 12, aId: string = '1'): Beer => ({
     id: aId,
@@ -178,6 +178,45 @@ describe('Production controller availability dialog', () => {
 
         expect(screen.queryByText('Die Brau-Steuerung ist nicht erreichbar')).not.toBeInTheDocument();
         expect(screen.queryByText('Fehler beim Backend-Check')).not.toBeInTheDocument();
+    });
+});
+
+describe('Production equipment alarm dialog', () => {
+    const withEquipmentAlarm = (aStatus: BrewingStatus): BrewingStatus => ({
+        ...aStatus,
+        alarms: [{type: AlarmType.EQUIPMENT_ALARM, active: true}]
+    });
+
+    it('is absent without an alarm and visible immediately for an initially active alarm', () => {
+        const {unmount} = renderProduction();
+        expect(screen.queryByRole('dialog', {name: 'Anlagenalarm'})).not.toBeInTheDocument();
+        unmount();
+        renderProduction({brewingStatus: withEquipmentAlarm(createBrewingStatus(ProcessState.ACTIVE))});
+        expect(screen.getByRole('dialog', {name: 'Anlagenalarm'})).toBeInTheDocument();
+        expect(screen.getByText(/angeschlossene Anlagensteuerung meldet einen Fehler/)).toBeInTheDocument();
+    });
+
+    it('stays dismissed across active polls and reopens for a new alarm cycle', () => {
+        const inactive = createBrewingStatus(ProcessState.ACTIVE);
+        const active = withEquipmentAlarm(inactive);
+        const {rerender, props} = renderProduction({brewingStatus: inactive});
+        rerender(<Production {...props} brewingStatus={active} />);
+        fireEvent.click(screen.getByRole('button', {name: 'Schließen'}));
+        rerender(<Production {...props} brewingStatus={{...active}} />);
+        rerender(<Production {...props} brewingStatus={{...active}} />);
+        expect(screen.queryByRole('dialog', {name: 'Anlagenalarm'})).not.toBeInTheDocument();
+        rerender(<Production {...props} brewingStatus={inactive} />);
+        rerender(<Production {...props} brewingStatus={active} />);
+        expect(screen.getByRole('dialog', {name: 'Anlagenalarm'})).toBeInTheDocument();
+    });
+
+    it('closes automatically without user action when the alarm ends', () => {
+        const inactive = createBrewingStatus(ProcessState.ACTIVE);
+        const active = withEquipmentAlarm(inactive);
+        const {rerender, props} = renderProduction({brewingStatus: active});
+        expect(screen.getByRole('dialog', {name: 'Anlagenalarm'})).toBeInTheDocument();
+        rerender(<Production {...props} brewingStatus={inactive} />);
+        expect(screen.queryByRole('dialog', {name: 'Anlagenalarm'})).not.toBeInTheDocument();
     });
 });
 

--- a/src/containers/Production/Production.tsx
+++ b/src/containers/Production/Production.tsx
@@ -38,6 +38,7 @@ import {completeWaterFill, createInitialRecipeWaterFillStatus, failWaterFill, in
 import {ProductionDialogs} from "./components/ProductionDialogs";
 import {ProductionTemperatureTimeline} from "./TemperatureTimeline/ProductionTemperatureTimeline";
 import {getDisplayedWaterLiters as selectDisplayedWaterLiters, getWaterLabel, getWaterTargetLiters, isRecipeWaterButtonDisabled as selectRecipeWaterButtonDisabled, isWaterFillingActive as selectWaterFillingActive, shouldIncludeSpargeAfterMashingOut as selectShouldIncludeSpargeAfterMashingOut, sanitizeLiters} from "./waterFill/recipeWaterFillSelectors";
+import {equipmentAlarmDisplay, isEquipmentAlarmActive} from '../../utils/brewingStatus/alarmDisplay';
 
 export interface ProductionProps {
     selectedBeer?: Beer;
@@ -87,6 +88,7 @@ interface ProductionState {
     announcedHopTimes: number[];
     recipeWaterFill: RecipeWaterFillStatus;
     displayedRemainingSeconds: number | undefined;
+    equipmentAlarmDismissed: boolean;
 }
 
 export class Production extends React.Component<ProductionProps, ProductionState> {
@@ -124,7 +126,8 @@ export class Production extends React.Component<ProductionProps, ProductionState
             brewingIsRunning: false,
             announcedHopTimes: [],
             recipeWaterFill: createInitialRecipeWaterFillStatus(),
-            displayedRemainingSeconds: undefined
+            displayedRemainingSeconds: undefined,
+            equipmentAlarmDismissed: false
         }
     }
 
@@ -157,6 +160,10 @@ export class Production extends React.Component<ProductionProps, ProductionState
 
         if (prevProps.brewingStatus !== brewingStatus) {
             this.syncRemainingTimeFromStatus();
+        }
+
+        if (isEquipmentAlarmActive(prevProps.brewingStatus) && !isEquipmentAlarmActive(brewingStatus)) {
+            this.setState({equipmentAlarmDismissed: false});
         }
 
         if (prevProps.selectedBeer !== this.props.selectedBeer) {
@@ -713,6 +720,7 @@ export class Production extends React.Component<ProductionProps, ProductionState
 
     render() {
         const {showHopsDialog, showFinishDialog} = this.state;
+        const equipmentAlarmActive = isEquipmentAlarmActive(this.props.brewingStatus);
         return (
             <div className="containerProduction ">
                 <ProductionDialogs
@@ -721,6 +729,10 @@ export class Production extends React.Component<ProductionProps, ProductionState
                     showFinishDialog={showFinishDialog}
                     onConfirmHop={this.confirmHopDialog}
                     onConfirmFinish={this.confirmFinishDialog}
+                    showEquipmentAlarmDialog={equipmentAlarmActive && !this.state.equipmentAlarmDismissed}
+                    equipmentAlarmTitle={equipmentAlarmDisplay.title}
+                    equipmentAlarmMessage={equipmentAlarmDisplay.message}
+                    onDismissEquipmentAlarm={() => this.setState({equipmentAlarmDismissed: true})}
                 />
 
                 {this.renderHeader()}

--- a/src/containers/Production/components/ProductionDialogs.tsx
+++ b/src/containers/Production/components/ProductionDialogs.tsx
@@ -7,15 +7,28 @@ export interface ProductionDialogsProps {
     showFinishDialog: boolean;
     onConfirmHop: () => void;
     onConfirmFinish: () => void;
+    showEquipmentAlarmDialog: boolean;
+    equipmentAlarmTitle: string;
+    equipmentAlarmMessage: string;
+    onDismissEquipmentAlarm: () => void;
 }
 
 export class ProductionDialogs extends React.Component<ProductionDialogsProps> {
     render(): React.ReactNode {
-        const {showHopsDialog, hopName, showFinishDialog, onConfirmHop, onConfirmFinish} = this.props;
+        const {showHopsDialog, hopName, showFinishDialog, onConfirmHop, onConfirmFinish,
+            showEquipmentAlarmDialog, equipmentAlarmTitle, equipmentAlarmMessage, onDismissEquipmentAlarm} = this.props;
         return (
             <>
                 <ModalDialog onConfirm={onConfirmHop} type={DialogType.CONFIRM} open={showHopsDialog} content={'Bitte den ' + hopName + ' Hopfen zufügen!'} header="Hopfen Zufügen" />
                 <ModalDialog onConfirm={onConfirmFinish} type={DialogType.INFO} open={showFinishDialog} content="Das Bier ist fertig!" header="Fertig!" />
+                <ModalDialog
+                    onConfirm={onDismissEquipmentAlarm}
+                    type={DialogType.ERROR}
+                    open={showEquipmentAlarmDialog}
+                    content={equipmentAlarmMessage}
+                    header={equipmentAlarmTitle}
+                    confirmLabel="Schließen"
+                />
             </>
         );
     }

--- a/src/utils/brewingStatus/alarmDisplay.ts
+++ b/src/utils/brewingStatus/alarmDisplay.ts
@@ -1,0 +1,12 @@
+import {AlarmType, BrewingStatus} from '../../model/brewingStatus.types';
+
+export const equipmentAlarmDisplay = {
+    title: 'Anlagenalarm',
+    message: 'Die angeschlossene Anlagensteuerung meldet einen Fehler.\nBitte Anlage prüfen.',
+    headerText: 'ANLAGENALARM – Anlage prüfen'
+};
+
+export const isEquipmentAlarmActive = (aStatus?: BrewingStatus): boolean =>
+    aStatus?.alarms?.some((aAlarm) =>
+        aAlarm.type === AlarmType.EQUIPMENT_ALARM && aAlarm.active === true
+    ) === true;

--- a/src/utils/brewingStatus/selectors.test.ts
+++ b/src/utils/brewingStatus/selectors.test.ts
@@ -1,6 +1,7 @@
 import {getBrewingStatusLabel, getConfirmButtonLabel, getConfirmationType, getCountdownValue, isBrewingProcessActive, shouldShowConfirmButton, shouldShowCountdown, shouldShowWaitingDialog} from './selectors';
-import {BrewingStatus, ProcessMode, ProcessPhase, ProcessState, WaitingFor} from '../../model/brewingStatus.types';
+import {AlarmType, BrewingStatus, ProcessMode, ProcessPhase, ProcessState, WaitingFor} from '../../model/brewingStatus.types';
 import {ConfirmStates} from '../../enums/eConfirmStates';
+import {isEquipmentAlarmActive} from './alarmDisplay';
 
 const makeStatus = (aPart: Partial<BrewingStatus>): BrewingStatus => ({
   elapsedTime: 0, currentTime: 0,
@@ -11,6 +12,12 @@ const makeStatus = (aPart: Partial<BrewingStatus>): BrewingStatus => ({
 });
 
 describe('brewing selectors', () => {
+  it('recognizes only an explicitly active equipment alarm in the alarm list', () => {
+    expect(isEquipmentAlarmActive(makeStatus({}))).toBe(false);
+    expect(isEquipmentAlarmActive(makeStatus({alarms: [{type: 'FUTURE_ALARM', active: true}]}))).toBe(false);
+    expect(isEquipmentAlarmActive(makeStatus({alarms: [{type: AlarmType.EQUIPMENT_ALARM, active: false}]}))).toBe(false);
+    expect(isEquipmentAlarmActive(makeStatus({alarms: [{type: AlarmType.EQUIPMENT_ALARM, active: true}]}))).toBe(true);
+  });
   it('derives an active brewing process from process.state ACTIVE only', () => {
     expect(isBrewingProcessActive(undefined)).toBe(false);
     expect(isBrewingProcessActive(makeStatus({process:{state:ProcessState.IDLE}}))).toBe(false);


### PR DESCRIPTION
### Motivation

- Sichtbar machen, wenn ein fachlicher `EQUIPMENT_ALARM` im bereits vorhandenen Redux-/Polling-State gesetzt ist, und das bestehende Modal-/Header-System wiederverwenden. 
- Dialog nur als Präsentationsmechanismus implementieren; keine Quittierung, keine Backend-/Sound-/Push-Änderungen.

### Description

- Wiederverwendung der bestehenden Modal-Komponente `ModalDialog` (Pfad: `src/components/ModalDialog/ModalDialog.tsx`) über die bestehende `ProductionDialogs`-Hülle; kein neues Modal-System eingeführt. 
- Zentrale Ableitung des fachlich aktiven Anlagenalarms in `src/utils/brewingStatus/alarmDisplay.ts` mit `isEquipmentAlarmActive(aStatus)` anhand von `alarms.some(...)` auf `AlarmType.EQUIPMENT_ALARM` und `active === true`, plus deklarative Alarmtexte (`equipmentAlarmDisplay`).
- Lokaler Dismiss-State in der `Production`-Komponente (`equipmentAlarmDismissed` in `src/containers/Production/Production.tsx`), Sichtbarkeitsregel `dialogVisible = equipmentAlarmActive && !equipmentAlarmDismissed`, Rücksetzen des Dismiss-Flags beim Übergang `active -> inactive` und sofortiges Schließen des Dialogs, sobald `equipmentAlarmActive === false`.
- Header-Priorisierung: `Header` leitet bei aktivem Anlagenalarm einen `priorityMessage` an `StatusDisplay` weiter (Props- und connect-Anpassung in `src/containers/MainView/Header/*`), worauf `StatusDisplay` die Alarmmeldung mit hoher Priorität anzeigt; Styling nutzt vorhandene Fehlerfarbe ohne Animation (`src/containers/MainView/Header/StatusDisplay.css`).
- Tests ergänzt: Unit-Tests für die Dialog-Lebenszyklen und Header-Priorisierung in `src/containers/Production/Production.test.tsx`, `src/containers/MainView/Header/Header.test.tsx` und Ergänzung der Selector-Tests in `src/utils/brewingStatus/selectors.test.ts`.

### Testing

- `git diff --check` wurde ausgeführt und zeigte keine Probleme.
- Unit-Tests wurden lokal für die geänderten Dateien gestartet, konnten jedoch nicht vollständig ausgeführt, da die Testumgebung die Abhängigkeiten nicht installieren konnte (`npm ci`/`react-scripts` fehlten bzw. Registry-Zugriff schlug mit HTTP 403 fehl); die neuen Tests wurden dem Repository hinzugefügt (`Production` und `Header`-Tests) und sollten in der CI ausgeführt werden, sobald Abhängigkeiten verfügbar sind.
- Manueller Verifizierungsbericht: Komponenten-API-Änderungen sind auf Präsentationszustand beschränkt, es wurden keine Redux-Aktionen oder API-Aufrufe für Dismiss/Close hinzugefügt, sodass Alarm-Quittierung und Sound/Push unverändert vom Backend gesteuert bleiben.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8bf04c0060832fa4665da3f41a2bf3)