### PR TITLE
Fix production reducer agitator state type

### DIFF
--- a/src/reducers/productionReducer.test.ts
+++ b/src/reducers/productionReducer.test.ts
@@ -1,6 +1,7 @@
 import {ProductionActions} from '../actions/actions';
 import {initialProductionState, productionReducer} from './productionReducer';
 import {AlarmType, BrewingStatus, ProcessMode, ProcessPhase, ProcessState, WaitingFor} from '../model/brewingStatus.types';
+import {ToggleState} from '../enums/eToggleState';
 
 const statusWithAlarms = (alarms: BrewingStatus['alarms']): BrewingStatus => ({
     elapsedTime: 0,
@@ -46,5 +47,22 @@ describe('productionReducer brewingStatus alarms', () => {
 
         const clearedState = productionReducer(alarmState, ProductionActions.setBrewingStatus(statusWithAlarms([])));
         expect(clearedState.brewingStatus?.alarms).toEqual([]);
+    });
+});
+
+describe('productionReducer agitator state', () => {
+    it('stores the toggle state represented by the agitator command', () => {
+        const agitatorCommand = {
+            isTurnOn: true,
+            rotationsPerMinute: 30,
+            runningTime: 60,
+            breakTime: 15,
+            isIntervalTurnOn: false,
+            isHeatingAndStirringTurnOn: false,
+        };
+
+        const nextState = productionReducer(initialProductionState, ProductionActions.toggleAgitator(agitatorCommand));
+
+        expect(nextState.currentAgitatorState).toBe(ToggleState.ON);
     });
 });

--- a/src/reducers/productionReducer.ts
+++ b/src/reducers/productionReducer.ts
@@ -48,14 +48,17 @@ export const initialProductionState: ProductionReducerState = {
 const productionReducer = (
     aState: ProductionReducerState = initialProductionState,
     aAction: AllProductionActions
-) => {
+): ProductionReducerState => {
     switch (aAction.type) {
 
         case ProductionActions.ActionTypes.SET_TEMPERATURE: {
             return { ...aState, temperature: aAction.payload.temperature };
         }
         case ProductionActions.ActionTypes.TOGGLE_AGITATOR: {
-            return { ...aState, currentAgitatorState: aAction.payload.agitatorState };
+            return {
+                ...aState,
+                currentAgitatorState: aAction.payload.agitatorState.isTurnOn ? ToggleState.ON : ToggleState.OFF
+            };
         }
         case ProductionActions.ActionTypes.TOGGLE_AGITATOR_SUCCESS: {
             return { ...aState, isToggleAgitatorSuccess: aAction.payload.isToggleAgitatorSuccess };


### PR DESCRIPTION
### Motivation

- Tests and TypeScript reported an invalid assignment where `currentAgitatorState` (typed as `ToggleState`) was being set from a `MashAgitatorStates` object, causing a type error in `productionReducer.test.ts`.
- The reducer relied on inferred return types which allowed an incompatible branch shape; an explicit reducer return type prevents this widening.

### Description

- Add an explicit return type `: ProductionReducerState` to the `productionReducer` function to ensure all branches conform to the declared state shape.
- Map the agitator command to the reducer's `currentAgitatorState` by deriving `ToggleState.ON`/`ToggleState.OFF` from `payload.agitatorState.isTurnOn` instead of assigning the full `MashAgitatorStates` object.
- Add a unit test in `src/reducers/productionReducer.test.ts` that dispatches `ProductionActions.toggleAgitator(...)` and asserts `currentAgitatorState` becomes `ToggleState.ON`, and add the necessary `ToggleState` import.

### Testing

- Ran `git diff --check` and verified the working tree diffs; commit was created successfully.
- Attempted to run the focused unit test with `CI=true npm test -- --runInBand src/reducers/productionReducer.test.ts`, but the test run could not complete because dependency resolution / `react-scripts` invocation failed due to the environment/npm registry restrictions (HTTP 403) preventing test execution.
- No automated test failures reported from local repository checks; full Jest run could not be executed in this environment due to external dependency fetch failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8bfeacf988832fbd2b3d38833bc36b)