### PR TITLE
Support DECOCTION process steps in brewing UI

### DIFF
--- a/docs/codex/compatibility/cross-repo-contracts.md
+++ b/docs/codex/compatibility/cross-repo-contracts.md
@@ -49,6 +49,7 @@ Before changing any database/backend field or endpoint, check whether the UI use
 - `Beer.fermentation[].temperature`
 - `Beer.fermentation[].time`
 - `Beer.fermentation[].executionMode`
+- `Beer.fermentation[].procedureType` (`RAST` or `DECOCTION`); missing plus `CONFIRMATION_HOLD` remains a supported legacy decoction
 - `Beer.wortBoiling.hops[].name`
 - `Beer.wortBoiling.hops[].time`
 - `FinishedBrew.id`
@@ -62,6 +63,8 @@ Before changing any database/backend field or endpoint, check whether the UI use
 ## UI ↔ PI control
 
 The PI control app produces runtime/control data that the UI displays and uses for workflow behavior.
+
+The UI accepts `currentStep.phase: DECOCTION` as a public sequential mash phase and sends new decoction recipe steps with `procedureType: DECOCTION` plus `executionMode: CONFIRMATION_HOLD`. Database persistence of the new optional field is **Needs verification** in the database/backend repository.
 
 Before changing control output, check whether the UI uses it for:
 

--- a/docs/codex/data-flow.md
+++ b/docs/codex/data-flow.md
@@ -19,7 +19,7 @@ Needs verification: backend ordering of `GET beers`, because the UI treats the l
 ## Production start flow
 
 - Production view reads `beerDataReducer.beerToBrew` as `selectedBeer`.
-- `mapBeerToBrewingData(selectedBeer)` extracts Einmaischen and Abmaischen temperatures, cooking temperature/time, and normalized timed/confirmation rests. Missing or invalid top-level cooking temperature is replaced with `99` °C in the UI mapping before sending control data.
+- `mapBeerToBrewingData(selectedBeer)` extracts Einmaischen and Abmaischen temperatures, cooking temperature/time, and normalized timed/decoction steps. It emits explicit `RAST`/`DECOCTION` procedure types and upgrades legacy `CONFIRMATION_HOLD` steps to `DECOCTION`. Missing or invalid top-level cooking temperature is replaced with `99` °C in the UI mapping before sending control data.
 - On success, `SEND_BREWING_DATA` posts `BrewingData` to `POST Recipe/` and expects HTTP 201.
 - If successful, UI posts `Command/StartBrewing:""` and then begins status polling.
 

--- a/docs/codex/domain-model.md
+++ b/docs/codex/domain-model.md
@@ -6,7 +6,7 @@ Visible/used fields include:
 
 - Identity/display: `id`, `name`, `type`, `color`, `description`, `rating`.
 - Metrics: `alcohol`, `originalwort`, `bitterness`, `mashVolume`, `spargeVolume`, `cookingTime`, `cookingTemperatur`.
-- Production steps: `fermentation: FermentationSteps[]` where step `type` names `Einmaischen`, `Abmaischen`, and regular rests are significant.
+- Production steps: `fermentation: FermentationSteps[]` where `procedureType` classifies mash steps as `RAST` or `DECOCTION`; legacy `CONFIRMATION_HOLD` steps without it normalize to `DECOCTION`. Step `type` remains the display name.
 - Ingredients: `malts`, `wortBoiling.hops`, `fermentationMaturation.yeast`, optional `additionalIngredients`.
 
 `BeerDTO` differs from `Beer` for submission: `fermentationSteps` instead of `fermentation`, ingredient DTOs, and nullable `wortBoiling`/`fermentationMaturation`.
@@ -19,7 +19,7 @@ The PI/control payload is:
 - `MashupTemperature`: from recipe step `Einmaischen.temperature`.
 - `CookingTemperature`: from `beer.cookingTemperatur`, with UI fallback `99` °C only when the stored cooking temperature is missing or invalid.
 - `CookingTime`: from `beer.cookingTime`.
-- `Rasten`: normalized fermentation steps excluding fixed process step types `Einmaischen`, `Abmaischen`, and `Kochen`, unless a step uses `executionMode: CONFIRMATION_HOLD`.
+- `Rasten`: normalized fermentation steps excluding fixed process step types `Einmaischen`, `Abmaischen`, and `Kochen`. Normal rests are sent with `procedureType: RAST`; decoctions use `procedureType: DECOCTION` and `executionMode: CONFIRMATION_HOLD`.
 
 Validation rejects missing/non-positive mash-in, mash-out, and rest temperatures and timed rests without `time > 0`; missing/invalid top-level cooking temperature is not rejected and maps to the UI fallback `99` °C.
 

--- a/docs/codex/interfaces.md
+++ b/docs/codex/interfaces.md
@@ -69,7 +69,7 @@ interface BrewingStatus {
   currentStep: {
     index?: number;
     count?: number;
-    phase: 'NONE' | 'MASHING_IN' | 'RAST' | 'MASHING_OUT' | 'COOKING' | 'COOLING' | 'FINISHED';
+    phase: 'NONE' | 'MASHING_IN' | 'RAST' | 'DECOCTION' | 'MASHING_OUT' | 'COOKING' | 'COOLING' | 'FINISHED';
     mode: 'NONE' | 'HEATING' | 'HOLDING' | 'TIMER_RUNNING' | 'WAITING' | 'FINISHED' | 'ERROR';
     name?: string;
     duration?: number;

--- a/src/containers/DatabaseOverview/BeerForm.tsx
+++ b/src/containers/DatabaseOverview/BeerForm.tsx
@@ -5,6 +5,7 @@ import { HopUsage } from "../../enums/eHopUsage";
 import { HopTimeUnit } from "../../enums/eHopTimeUnit";
 import { normalizeHopDto, updateHopUsage, validateHopDto } from "./hopDefaults";
 import { isValidExecutionMode, normalizeFermentationStep } from "./fermentationDefaults";
+import { ProcedureType } from "../../enums/eProcedureType";
 import {isEqual} from "lodash";
 
 import {MashingType} from "../../enums/eMashingType";
@@ -189,9 +190,13 @@ export class BeerForm extends React.Component<BeerFormProps, BeerFormState> {
           if (name === "executionMode") {
               step.executionMode = value as RestExecutionMode;
               if (step.executionMode === RestExecutionMode.CONFIRMATION_HOLD) {
+                  step.procedureType = ProcedureType.DECOCTION;
                   delete step.time;
               } else if (step.time === undefined) {
+                  step.procedureType = ProcedureType.RAST;
                   step.time = 1;
+              } else {
+                  step.procedureType = ProcedureType.RAST;
               }
           } else if (name === "temperature" || name === "time") {
               const parsed = Number(value);
@@ -417,7 +422,7 @@ export class BeerForm extends React.Component<BeerFormProps, BeerFormState> {
             spargeVolume,
             cookingTime,
             cookingTemperatur,
-            fermentationSteps,
+            fermentationSteps: fermentationSteps.map((step) => normalizeFermentationStep(step)),
             maltsDTO,
             hopsDTO,
             yeastsDTO,
@@ -560,7 +565,7 @@ export class BeerForm extends React.Component<BeerFormProps, BeerFormState> {
             return {
                 fermentationSteps: [
                     ...prevState.fermentationSteps,
-                    { type: `Rast ${rastCount}`, temperature: 0, time: 1, executionMode: RestExecutionMode.TIMED }
+                    { type: `Rast ${rastCount}`, temperature: 0, time: 1, executionMode: RestExecutionMode.TIMED, procedureType: ProcedureType.RAST }
                 ],
             };
         });
@@ -661,7 +666,7 @@ export class BeerForm extends React.Component<BeerFormProps, BeerFormState> {
                 spargeVolume: selectedBeer.spargeVolume || 0,
                 cookingTime: selectedBeer.cookingTime || 0,
                 cookingTemperatur: selectedBeer.cookingTemperatur || 0,
-                fermentationSteps: selectedBeer.fermentation ? [...selectedBeer.fermentation] : [],
+                fermentationSteps: selectedBeer.fermentation ? selectedBeer.fermentation.map((step) => normalizeFermentationStep(step)) : [],
                 maltsDTO: selectedBeer.malts ? selectedBeer.malts.map(m => ({ id: m.id, name: m.name, quantity: m.quantity })) : [],
                 // Bestehende Rezepte ohne neue Felder werden im UI als Kochhopfen in Minuten dargestellt.
                 hopsDTO: selectedBeer.wortBoiling && selectedBeer.wortBoiling.hops ? selectedBeer.wortBoiling.hops.map(aHop => normalizeHopDto(aHop)) : [],
@@ -776,7 +781,7 @@ export class BeerForm extends React.Component<BeerFormProps, BeerFormState> {
                             const executionMode = this.getExecutionMode(step);
                             return <tr key={index}>
                                 <td>{isFixed ? <span className="readonly-table-value">{step.type}</span> : <select name="type" value={step.type} onChange={(e) => this.handleFermentationStepChange(e.target.value, e.target.name, index)} required={false}><option value="">Rast {rastCount}</option>{Object.values(MashingType).map((mashingType) => <option key={mashingType} value={mashingType}>{mashingType}</option>)}</select>}</td>
-                                <td>{isFixed ? <span className="muted-table-value">–</span> : <select name="executionMode" value={executionMode} onChange={(e) => this.handleFermentationStepChange(e.target.value, e.target.name, index)}><option value={RestExecutionMode.TIMED}>Zeitgesteuerte Rast</option><option value={RestExecutionMode.CONFIRMATION_HOLD}>Halten bis Bestätigung</option></select>}</td>
+                                <td>{isFixed ? <span className="muted-table-value">–</span> : <select name="executionMode" value={executionMode} onChange={(e) => this.handleFermentationStepChange(e.target.value, e.target.name, index)}><option value={RestExecutionMode.TIMED}>Zeitgesteuerte Rast</option><option value={RestExecutionMode.CONFIRMATION_HOLD}>Dekoktion (bis Bestätigung)</option></select>}</td>
                                 <td><input type="number" name="temperature" value={step.temperature} onChange={(e) => this.handleFermentationStepChange(e.target.value, e.target.name, index)} required={true} /></td>
                                 <td>{executionMode === RestExecutionMode.TIMED ? <input type="number" name="time" min={isFixed ? 0 : 1} value={step.time ?? ''} onChange={(e) => this.handleFermentationStepChange(e.target.value, e.target.name, index)} required={!isFixed} /> : <span className="muted-table-value">–</span>}</td>
                                 <td className="action-column">{index > 0 && !isFixed && <button type="button" className="cancel-btn brauhaus-button brauhaus-button-danger brauhaus-icon-button" onClick={() => this.removeFermentationStep(index)} title="Rast löschen" aria-label="Rast löschen">🗑️</button>}</td>

--- a/src/containers/DatabaseOverview/fermentationDefaults.test.ts
+++ b/src/containers/DatabaseOverview/fermentationDefaults.test.ts
@@ -1,10 +1,18 @@
 import { RestExecutionMode } from '../../enums/eRestExecutionMode';
 import { normalizeFermentationStep, isValidExecutionMode } from './fermentationDefaults';
+import {ProcedureType} from '../../enums/eProcedureType';
 
 describe('fermentationDefaults', () => {
     test('imported step without executionMode defaults to TIMED', () => {
         const step = normalizeFermentationStep({ type: 'Rast 1', temperature: 64, time: 40 });
         expect(step.executionMode).toBe(RestExecutionMode.TIMED);
+        expect(step.procedureType).toBe(ProcedureType.RAST);
+    });
+
+    test('legacy confirmation hold is normalized to DECOCTION without using its display name', () => {
+        const step = normalizeFermentationStep({type: 'Kochmaische', temperature: 66, executionMode: RestExecutionMode.CONFIRMATION_HOLD});
+
+        expect(step.procedureType).toBe(ProcedureType.DECOCTION);
     });
 
     test('imported CONFIRMATION_HOLD without time remains CONFIRMATION_HOLD', () => {

--- a/src/containers/DatabaseOverview/fermentationDefaults.ts
+++ b/src/containers/DatabaseOverview/fermentationDefaults.ts
@@ -1,17 +1,23 @@
 import { RestExecutionMode } from '../../enums/eRestExecutionMode';
 import { FermentationSteps } from '../../model/Beer';
+import { ProcedureType } from '../../enums/eProcedureType';
 
 const allowedExecutionModes = [RestExecutionMode.TIMED, RestExecutionMode.CONFIRMATION_HOLD];
 
 export const normalizeFermentationStep = (step: Partial<FermentationSteps>): FermentationSteps => {
     // Altrezepte ohne executionMode bleiben kompatibel und werden als TIMED behandelt.
-    const executionMode = step.executionMode ?? RestExecutionMode.TIMED;
+    const procedureType = step.procedureType
+        ?? (step.executionMode === RestExecutionMode.CONFIRMATION_HOLD ? ProcedureType.DECOCTION : ProcedureType.RAST);
+    const executionMode = procedureType === ProcedureType.DECOCTION
+        ? RestExecutionMode.CONFIRMATION_HOLD
+        : (step.executionMode ?? RestExecutionMode.TIMED);
 
     return {
         type: step.type ?? '',
         temperature: Number(step.temperature ?? 0),
         time: step.time,
         executionMode,
+        procedureType,
     };
 };
 

--- a/src/containers/Production/ProcessList/ProcessList.test.tsx
+++ b/src/containers/Production/ProcessList/ProcessList.test.tsx
@@ -4,6 +4,8 @@ import '@testing-library/jest-dom';
 import {Beer} from '../../../model/Beer';
 import {BrewingStatus, ProcessMode, ProcessPhase, ProcessState, WaitingFor} from '../../../model/brewingStatus.types';
 import {createProcessSteps, getActiveProcessStepIndex, ProcessList, ProcessListDurationUnit, ProcessListEntryType} from './ProcessList';
+import {ProcedureType} from '../../../enums/eProcedureType';
+import {RestExecutionMode} from '../../../enums/eRestExecutionMode';
 
 const selectedBeer = {
     id: 'beer-1',
@@ -37,6 +39,48 @@ const getActiveStepText = (controlStepIndex: number) => {
 };
 
 describe('ProcessList current-step mapping', () => {
+    it.each([
+        [['RAST', 'RAST']],
+        [['RAST', 'DECOCTION', 'RAST']],
+        [['RAST', 'DECOCTION', 'RAST', 'DECOCTION', 'RAST']],
+        [['DECOCTION', 'DECOCTION', 'RAST']],
+    ])('preserves every mash-step order and index for %j', (types) => {
+        const beer = {
+            ...selectedBeer,
+            fermentation: [
+                selectedBeer.fermentation[0],
+                ...types.map((type, index) => ({
+                    type: type === 'DECOCTION' ? `Dekoktion ${index + 1}` : `Rast ${index + 1}`,
+                    temperature: 64 + index,
+                    time: type === 'RAST' ? 10 : undefined,
+                    procedureType: type as ProcedureType,
+                    executionMode: type === 'DECOCTION' ? RestExecutionMode.CONFIRMATION_HOLD : RestExecutionMode.TIMED
+                })),
+                selectedBeer.fermentation.at(-1)!
+            ]
+        } as Beer;
+
+        const mashSteps = createProcessSteps(beer).filter(step =>
+            step.entryType === ProcessListEntryType.PROCESS &&
+            [ProcessPhase.RAST, ProcessPhase.DECOCTION].includes(step.phase!)
+        );
+        expect(mashSteps.map(step => step.phase)).toEqual(types.map(type => type as ProcessPhase));
+        expect(mashSteps.map(step => step.controlStepIndex)).toEqual(types.map((_, index) => index + 2));
+    });
+
+    it('places the iodine test after a final decoction and highlights that decoction', () => {
+        const beer = {...selectedBeer, fermentation: [
+            selectedBeer.fermentation[0],
+            {type: 'Rast 1', temperature: 64, time: 10, procedureType: ProcedureType.RAST},
+            {type: 'Kochmaische', temperature: 68, procedureType: ProcedureType.DECOCTION, executionMode: RestExecutionMode.CONFIRMATION_HOLD},
+            selectedBeer.fermentation.at(-1)!
+        ]} as Beer;
+        const steps = createProcessSteps(beer);
+        const decoctionIndex = steps.findIndex(step => step.name === 'Kochmaische' && step.entryType === ProcessListEntryType.PROCESS);
+
+        expect(steps[decoctionIndex + 1].name).toBe('Jod Probe');
+        expect(steps[getActiveProcessStepIndex(steps, 3, {index: 3, phase: ProcessPhase.DECOCTION, mode: ProcessMode.WAITING})].name).toBe('Kochmaische');
+    });
     it('builds visible process rows with shared control indices for heating and process entries', () => {
         expect(createProcessSteps(selectedBeer).map(step => `${step.controlStepIndex ?? '-'}:${step.name}`)).toEqual([
             '1:Aufheizen für Einmaischen',

--- a/src/containers/Production/ProcessList/ProcessList.tsx
+++ b/src/containers/Production/ProcessList/ProcessList.tsx
@@ -3,6 +3,7 @@ import './ProcessList.css';
 import {Beer, FermentationSteps} from "../../../model/Beer";
 import {RestExecutionMode} from "../../../enums/eRestExecutionMode";
 import {BrewingStatus, ProcessMode, ProcessPhase, ProcessState, WaitingFor} from "../../../model/brewingStatus.types";
+import {ProcedureType} from "../../../enums/eProcedureType";
 import {TimeFormatter} from "../../../utils/TimeFormatter";
 
 export enum ProcessListEntryType {
@@ -402,23 +403,25 @@ export function createProcessSteps(selectedBeer: Beer): ProcessListStep[] {
         controlStepIndex++;
     }
 
-    let lastRastIndex = -1;
+    let lastMashStepIndex = -1;
 
-    // Rasten
+    // Sequenzielle Maischeschritte (Rasten und Dekoktionen)
     fermentation.forEach((step: FermentationSteps) => {
-        const isRastName = /^Rast\s*\d+$/i.test(step.type);
         const isConfirmationHold = (step.executionMode ?? RestExecutionMode.TIMED) === RestExecutionMode.CONFIRMATION_HOLD;
-        if (isRastName || isConfirmationHold) {
-            processSteps.push({ name: `Aufheizen für ${step.type}`, entryType: ProcessListEntryType.HEATING, controlStepIndex, phase: ProcessPhase.RAST, detail: {temperature: step.temperature} });
-            processSteps.push({ name: step.type, entryType: ProcessListEntryType.PROCESS, controlStepIndex, phase: ProcessPhase.RAST, detail: {temperature: step.temperature, duration: step.time, durationUnit: ProcessListDurationUnit.MINUTES, confirmationRequired: isConfirmationHold} });
+        const procedureType = step.procedureType ?? (isConfirmationHold ? ProcedureType.DECOCTION : ProcedureType.RAST);
+        const isFixedStep = ['Einmaischen', 'Abmaischen', 'Kochen'].includes(step.type);
+        if (!isFixedStep) {
+            const phase = procedureType === ProcedureType.DECOCTION ? ProcessPhase.DECOCTION : ProcessPhase.RAST;
+            processSteps.push({ name: `Aufheizen für ${step.type}`, entryType: ProcessListEntryType.HEATING, controlStepIndex, phase, detail: {temperature: step.temperature} });
+            processSteps.push({ name: step.type || (phase === ProcessPhase.DECOCTION ? 'Dekoktion' : 'Rast'), entryType: ProcessListEntryType.PROCESS, controlStepIndex, phase, detail: {temperature: step.temperature, duration: step.time, durationUnit: ProcessListDurationUnit.MINUTES, confirmationRequired: procedureType === ProcedureType.DECOCTION} });
             controlStepIndex++;
-            lastRastIndex = processSteps.length - 1;
+            lastMashStepIndex = processSteps.length - 1;
         }
     });
 
-    // Jod-Probe nach letzter Rast
-    if (lastRastIndex !== -1) {
-        processSteps.splice(lastRastIndex + 1, 0, { name: 'Jod Probe', entryType: ProcessListEntryType.DISPLAY, detail: {confirmationRequired: true} });
+    // Jod-Probe nach letztem Maischeschritt (Rast oder Dekoktion)
+    if (lastMashStepIndex !== -1) {
+        processSteps.splice(lastMashStepIndex + 1, 0, { name: 'Jod Probe', entryType: ProcessListEntryType.DISPLAY, detail: {confirmationRequired: true} });
     }
 
     // Abmaischen

--- a/src/containers/Production/TemperatureTimeline/temperatureTimelineModel.test.ts
+++ b/src/containers/Production/TemperatureTimeline/temperatureTimelineModel.test.ts
@@ -3,6 +3,7 @@ import {Beer} from '../../../model/Beer';
 import {BrewingStatus, ProcessMode, ProcessPhase, ProcessState, WaitingFor} from '../../../model/brewingStatus.types';
 import {TimelineMeasurement} from '../../../utils/DataCollector/dataCollector';
 import {buildTemperatureTimelineModel} from './temperatureTimelineModel';
+import {ProcedureType} from '../../../enums/eProcedureType';
 
 const beer = {
     cookingTime: 60,
@@ -37,6 +38,25 @@ const expectMonotonicSteps = (model: ReturnType<typeof buildTemperatureTimelineM
 };
 
 describe('temperature timeline model', () => {
+    it('keeps multiple and consecutive decoctions as independent fallback-duration bands', () => {
+        const decoctionBeer = {...beer, fermentation: [
+            {type: 'Einmaischen', temperature: 57},
+            {type: 'Dekoktion 1', temperature: 64, executionMode: RestExecutionMode.CONFIRMATION_HOLD, procedureType: ProcedureType.DECOCTION},
+            {type: 'Dekoktion 2', temperature: 66, executionMode: RestExecutionMode.CONFIRMATION_HOLD, procedureType: ProcedureType.DECOCTION},
+            {type: 'Rast 1', temperature: 68, time: 20, executionMode: RestExecutionMode.TIMED, procedureType: ProcedureType.RAST},
+            {type: 'Abmaischen', temperature: 78}
+        ]} as Beer;
+        const active = status({currentStep: {index: 3, phase: ProcessPhase.DECOCTION, mode: ProcessMode.WAITING, name: 'Dekoktion 2', elapsedTime: 0}});
+        const model = buildTemperatureTimelineModel(decoctionBeer, active, [], 20);
+        const mashBands = model.steps.filter(step => step.entryType === 'PROCESS' && [ProcessPhase.RAST, ProcessPhase.DECOCTION].includes(step.phase!));
+
+        expect(mashBands.map(step => [step.name, step.phase])).toEqual([
+            ['Dekoktion 1', ProcessPhase.DECOCTION],
+            ['Dekoktion 2', ProcessPhase.DECOCTION],
+            ['Rast 1', ProcessPhase.RAST]
+        ]);
+        expect(mashBands.every(step => step.endSeconds > step.startSeconds)).toBe(true);
+    });
     it.each([500, 2000, 5000])('keeps the ordered fast path equivalent for %i chronological measurements', (measurementCount) => {
         const measurements = Array.from({length: measurementCount}, (_, index) => ({
             ...point(index, 1, ProcessPhase.MASHING_IN, ProcessMode.HEATING),

--- a/src/enums/eProcedureType.ts
+++ b/src/enums/eProcedureType.ts
@@ -1,0 +1,4 @@
+export enum ProcedureType {
+    RAST = "RAST",
+    DECOCTION = "DECOCTION"
+}

--- a/src/model/Beer.ts
+++ b/src/model/Beer.ts
@@ -1,11 +1,13 @@
 import { RestExecutionMode } from '../enums/eRestExecutionMode';
 import { HopTimeUnit } from '../enums/eHopTimeUnit';
 import { HopUsage } from '../enums/eHopUsage';
+import { ProcedureType } from '../enums/eProcedureType';
 export interface FermentationSteps {
     type: string;
     temperature: number;
     time?: number;
     executionMode?: RestExecutionMode;
+    procedureType?: ProcedureType;
 }
 
 export interface Malt {

--- a/src/model/BeerDTO.ts
+++ b/src/model/BeerDTO.ts
@@ -3,11 +3,13 @@ import { RestExecutionMode } from '../enums/eRestExecutionMode';
 import { HopTimeUnit } from '../enums/eHopTimeUnit';
 import { HopUsage } from '../enums/eHopUsage';
 import {AdditionalIngredientPhase, AdditionalIngredientTimeUnit} from "./Beer";
+import { ProcedureType } from '../enums/eProcedureType';
 export interface FermentationStepsDTO {
     type: string;
     temperature: number;
     time?: number;
     executionMode?: RestExecutionMode;
+    procedureType?: ProcedureType;
 }
 
 export interface MaltDTO {

--- a/src/model/brewingStatus.types.ts
+++ b/src/model/brewingStatus.types.ts
@@ -10,6 +10,7 @@ export enum ProcessPhase {
     NONE = "NONE",
     MASHING_IN = "MASHING_IN",
     RAST = "RAST",
+    DECOCTION = "DECOCTION",
     MASHING_OUT = "MASHING_OUT",
     COOKING = "COOKING",
     COOLING = "COOLING",

--- a/src/utils/brewingStatus/normalizeBrewingStatus.test.ts
+++ b/src/utils/brewingStatus/normalizeBrewingStatus.test.ts
@@ -2,6 +2,10 @@ import {normalizeBrewingStatus} from './normalizeBrewingStatus';
 import {AlarmType, ProcessMode, ProcessPhase, ProcessState, WaitingFor} from '../../model/brewingStatus.types';
 
 describe('normalizeBrewingStatus', () => {
+  it('accepts the public DECOCTION runtime phase', () => {
+    const s = normalizeBrewingStatus({currentStep: {phase: 'DECOCTION', mode: 'WAITING'}});
+    expect(s.currentStep.phase).toBe(ProcessPhase.DECOCTION);
+  });
   it('uses structured payload', () => {
     const s = normalizeBrewingStatus({process:{state:'ACTIVE'}, currentStep:{phase:'RAST', mode:'TIMER_RUNNING', remainingTime:12}, waiting:{waitingFor:'NONE', canConfirm:false}, temperature:{current:60,target:63}});
     expect(s.process.state).toBe(ProcessState.ACTIVE);

--- a/src/utils/brewingStatus/selectors.test.ts
+++ b/src/utils/brewingStatus/selectors.test.ts
@@ -39,9 +39,9 @@ describe('brewing selectors', () => {
   });
 
   it('handles decoction waiting label', () => {
-    const s = makeStatus({currentStep:{phase:ProcessPhase.RAST, mode:ProcessMode.WAITING}, waiting:{waitingFor:WaitingFor.DECOCTION_CONFIRMATION, canConfirm:true}});
+    const s = makeStatus({currentStep:{phase:ProcessPhase.DECOCTION, mode:ProcessMode.WAITING}, waiting:{waitingFor:WaitingFor.DECOCTION_CONFIRMATION, canConfirm:true}});
     expect(getConfirmButtonLabel(s)).toBe('Dickmaische bestätigen');
-    expect(getBrewingStatusLabel(s)).toContain('Dickmaische');
+    expect(getBrewingStatusLabel(s)).toContain('Dekoktion');
   });
 
   it('does not enable or show confirmation without a concrete confirm endpoint', () => {

--- a/src/utils/brewingStatus/selectors.ts
+++ b/src/utils/brewingStatus/selectors.ts
@@ -65,13 +65,14 @@ export const getBrewingStatusLabel = (aStatus?: BrewingStatus) => {
     const aPhase = aStatus.currentStep.phase; const aMode = aStatus.currentStep.mode; const aWaitingFor = aStatus.waiting.waitingFor;
     if (aMode === ProcessMode.WAITING && aPhase === ProcessPhase.MASHING_IN && aWaitingFor === WaitingFor.MASHING_IN_CONFIRMATION) return 'Einmaischen: bitte bestätigen';
     if (aMode === ProcessMode.WAITING && aPhase === ProcessPhase.RAST && aWaitingFor === WaitingFor.IODINE_TEST) return 'Warten auf Iodine-Test';
-    if (aMode === ProcessMode.WAITING && aPhase === ProcessPhase.RAST && aWaitingFor === WaitingFor.DECOCTION_CONFIRMATION) return 'Warten auf Dickmaische-Bestätigung';
+    if (aMode === ProcessMode.WAITING && aPhase === ProcessPhase.DECOCTION && aWaitingFor === WaitingFor.DECOCTION_CONFIRMATION) return 'Dekoktion: bitte bestätigen';
     if (aMode === ProcessMode.WAITING && aPhase === ProcessPhase.MASHING_OUT && aWaitingFor === WaitingFor.MASHING_OUT_CONFIRMATION) return 'Abmaischen und Nachguss abgeschlossen?';
     if (aMode === ProcessMode.WAITING && aPhase === ProcessPhase.COOKING && aWaitingFor === WaitingFor.BOILING_CONFIRMATION) return 'Warten auf Siedepunkt-Bestätigung';
     if (aPhase === ProcessPhase.MASHING_IN && aMode === ProcessMode.HEATING) return 'Einmaischen: Aufheizen läuft';
     if (aPhase === ProcessPhase.RAST && aMode === ProcessMode.HEATING) return 'Rast: Aufheizen auf Solltemperatur';
     if (aPhase === ProcessPhase.RAST && aMode === ProcessMode.HOLDING) return 'Rasttemperatur wird gehalten';
     if (aPhase === ProcessPhase.RAST && aMode === ProcessMode.TIMER_RUNNING) return 'Rast läuft';
+    if (aPhase === ProcessPhase.DECOCTION) return 'Dekoktion';
     if (aPhase === ProcessPhase.COOKING && aMode === ProcessMode.HEATING) return 'Kochen: Aufheizen';
     if (aPhase === ProcessPhase.COOKING && aMode === ProcessMode.TIMER_RUNNING) return 'Kochen läuft';
     return 'Brauprozess aktiv';

--- a/src/utils/brewingStatus/vesselContent.ts
+++ b/src/utils/brewingStatus/vesselContent.ts
@@ -9,7 +9,7 @@ export function getVesselContentType(aBrewingStatus: BrewingStatus | undefined):
         return VesselContentType.MASH;
     }
 
-    if (phase === ProcessPhase.RAST || phase === ProcessPhase.MASHING_OUT) {
+    if (phase === ProcessPhase.RAST || phase === ProcessPhase.DECOCTION || phase === ProcessPhase.MASHING_OUT) {
         return VesselContentType.MASH;
     }
 

--- a/src/utils/productionRecipe.test.ts
+++ b/src/utils/productionRecipe.test.ts
@@ -1,5 +1,6 @@
 import { mapBeerToBrewingData } from './productionRecipe';
 import { RestExecutionMode } from '../enums/eRestExecutionMode';
+import {ProcedureType} from '../enums/eProcedureType';
 import { Beer } from '../model/Beer';
 
 const makeBeer = (overrides?: Partial<Beer>): Beer => ({
@@ -86,6 +87,31 @@ describe('productionRecipe mapping', () => {
       expect.objectContaining({ type: 'Dickmaische führen', executionMode: RestExecutionMode.CONFIRMATION_HOLD })
     ]);
     expect(result.brewingData?.Rasten[0]).not.toHaveProperty('time');
+    expect(result.brewingData?.Rasten[0]).toMatchObject({
+      procedureType: ProcedureType.DECOCTION,
+      executionMode: RestExecutionMode.CONFIRMATION_HOLD
+    });
+  });
+
+  it('serializes normal rests with an explicit RAST procedure type', () => {
+    const result = normalizeFermentationStepsForProduction([
+      {type: 'Rast 1', temperature: 64, time: 20, executionMode: RestExecutionMode.TIMED}
+    ]);
+
+    expect(result.fermentationSteps).toEqual([
+      expect.objectContaining({procedureType: ProcedureType.RAST, executionMode: RestExecutionMode.TIMED})
+    ]);
+  });
+
+  it('enforces confirmation hold for a newly classified decoction', () => {
+    const result = normalizeFermentationStepsForProduction([
+      {type: '1. Dekoktion', temperature: 67, procedureType: ProcedureType.DECOCTION}
+    ]);
+
+    expect(result.fermentationSteps).toEqual([
+      expect.objectContaining({procedureType: ProcedureType.DECOCTION, executionMode: RestExecutionMode.CONFIRMATION_HOLD})
+    ]);
+    expect(result.fermentationSteps?.[0]).not.toHaveProperty('time');
   });
 
   it('uses 99 °C as fallback for missing or invalid cooking temperature only', () => {

--- a/src/utils/productionRecipe.ts
+++ b/src/utils/productionRecipe.ts
@@ -1,6 +1,7 @@
 import { Beer, FermentationSteps } from '../model/Beer';
 import { BrewingData } from '../model/BrewingData';
 import { RestExecutionMode } from '../enums/eRestExecutionMode';
+import { ProcedureType } from '../enums/eProcedureType';
 
 const isValidTemperature = (value: unknown) => typeof value === 'number' && Number.isFinite(value) && value > 0;
 const isValidTimedDuration = (value: unknown) => typeof value === 'number' && Number.isFinite(value) && value > 0;
@@ -18,7 +19,11 @@ export function normalizeFermentationStepsForProduction(steps: FermentationSteps
   const fixedProcessStepTypes = new Set(['Einmaischen', 'Abmaischen', 'Kochen']);
 
   for (const step of steps ?? []) {
-    const executionMode = step.executionMode ?? RestExecutionMode.TIMED;
+    const procedureType = step.procedureType
+      ?? (step.executionMode === RestExecutionMode.CONFIRMATION_HOLD ? ProcedureType.DECOCTION : ProcedureType.RAST);
+    const executionMode = procedureType === ProcedureType.DECOCTION
+      ? RestExecutionMode.CONFIRMATION_HOLD
+      : (step.executionMode ?? RestExecutionMode.TIMED);
 
     if (!isValidTemperature(step.temperature)) {
       return { ok: false, error: `Ungültige Rasttemperatur bei Schritt "${step.type}".` };
@@ -27,7 +32,7 @@ export function normalizeFermentationStepsForProduction(steps: FermentationSteps
     // Wichtig: executionMode steuert die Logik. time=0 markiert NICHT CONFIRMATION_HOLD.
     if (executionMode === RestExecutionMode.CONFIRMATION_HOLD) {
       const { time, ...restWithoutTime } = step;
-      normalized.push({ ...restWithoutTime, executionMode });
+      normalized.push({ ...restWithoutTime, executionMode, procedureType });
       continue;
     }
 
@@ -43,6 +48,7 @@ export function normalizeFermentationStepsForProduction(steps: FermentationSteps
     normalized.push({
       ...step,
       executionMode,
+      procedureType,
       time: step.time
     });
   }


### PR DESCRIPTION
### Motivation

- Der Backend-Vertrag führt `DECOCTION` als eigenen `procedureType` und als öffentliche Runtime-Phase ein, deshalb muss die UI Dekoktionen fachlich als eigene Maische-Schritte erkennen und darstellen.
- Bestehende Legacy-Rezepte mit `executionMode: CONFIRMATION_HOLD` müssen rückwärtskompatibel weiterhin als Dekoktion behandelt werden und beim Speichern schrittweise auf das neue Format migriert werden.
- Darstellung, Ablauf und Timeline sollen erhalten bleiben; Bestätigungslogik (`DECOCTION_CONFIRMATION` / `waiting.canConfirm`) muss weiterhin funktionieren, darf aber nicht mehr über `phase === RAST` erkannt werden.

### Description

- Neue zentrale Typen: hinzugefügt `src/enums/eProcedureType.ts` (`ProcedureType = RAST | DECOCTION`) und `ProcessPhase.DECOCTION` in `src/model/brewingStatus.types.ts` sowie das optionale `procedureType`-Feld in `src/model/Beer.ts` und `src/model/BeerDTO.ts`.
- Rezept-/Editor-Änderungen: `normalizeFermentationStep` und `normalizeFermentationStepsForProduction` normalisieren alte Rezepte (fehlendes `procedureType` + `CONFIRMATION_HOLD` → `DECOCTION`) und serialisieren künftig explizit `procedureType: RAST|DECOCTION` sowie für Dekoktionen `executionMode: CONFIRMATION_HOLD`; Form-Editor (`BeerForm`) setzt `procedureType` beim Moduswechsel und zeigt die Option als „Dekoktion (bis Bestätigung)“ an.
- Produktion / UI-Anzeige: `ProcessList` und Timeline-Modelle erzeugen nun separate Prozesszeilen für `DECOCTION` (eigener Phase/Index), die Jodprobe wird nach dem letzten Maischeschritt (RAST oder DECOCTION) eingefügt, die Vessel-/Status-Selektoren und Bestätigungs-Labels erkennen `DECOCTION` und `DECOCTION_CONFIRMATION` korrekt; `vesselContent` behandelt `DECOCTION` als Maischeinhalt.
- Tests & Doku: bestehende Tests wurden erweitert/ergänzt (ProcessList, Timeline, `productionRecipe`, Normalizer, Selector-Tests) und Dokumentation in `docs/codex/*` aktualisiert; Commit wurde erstellt: `078aa9545285512b664a5e871c585ef679077f1c` mit Nachricht `feat: support decoction process steps`.

### Testing

- Automatische Checks: `git diff --check` wurde ausgeführt und gab keine Treffer (code-style/whitespace-Check bestanden).
- Unit tests: neue/erweiterte Jest tests wurden hinzugefügt for cases: normale RAST, einzelne Dekoktion, mehrere bzw. direkt aufeinanderfolgende Dekoktionen, Dekoktion als letzter Maischeschritt, Runtime `DECOCTION`-phase mit `DECOCTION_CONFIRMATION`, und Legacy-Rezept-Normalisierung; Ausführung der Test-Suite vor Ort scheiterte jedoch, weil `npm ci` im Laufzeitumfeld durch die Registry (HTTP 403) blockiert wurde, weshalb `npm test` nicht vollständig ausgeführt werden konnte.
- Ergebnis: Änderungen sind lokal als Commit vorhanden und Tests wurden ergänzt, aber die vollständige Testausführung / Build konnte in dieser Umgebung nicht abgeschlossen werden wegen fehlendem Zugriff auf die Paket-Registry; CI/Test-Ausführung sollte in der regulären Entwicklerumgebung oder CI-Runner mit Zugriff auf npm ausgeführt werden.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8c28a91e14832f88a4e8fd42431123)