### PR TITLE
Normalize DECOCTION steps, number mash rests and update UI/production mappings

### DIFF
--- a/docs/codex/compatibility/cross-repo-contracts.md
+++ b/docs/codex/compatibility/cross-repo-contracts.md
@@ -66,6 +66,8 @@ The PI control app produces runtime/control data that the UI displays and uses f
 
 The UI accepts `currentStep.phase: DECOCTION` as a public sequential mash phase and sends new decoction recipe steps with `procedureType: DECOCTION` plus `executionMode: CONFIRMATION_HOLD`. Database persistence of the new optional field is **Needs verification** in the database/backend repository.
 
+An explicit `procedureType: RAST` with `executionMode: CONFIRMATION_HOLD` remains a RAST and is not routed to `Confirm/Decoction`. A general confirmation endpoint/status for this combination is not documented by the current control contract and is **Needs verification** in the PI/control repository.
+
 Before changing control output, check whether the UI uses it for:
 
 - status labels,

--- a/docs/codex/domain-model.md
+++ b/docs/codex/domain-model.md
@@ -19,7 +19,7 @@ The PI/control payload is:
 - `MashupTemperature`: from recipe step `Einmaischen.temperature`.
 - `CookingTemperature`: from `beer.cookingTemperatur`, with UI fallback `99` °C only when the stored cooking temperature is missing or invalid.
 - `CookingTime`: from `beer.cookingTime`.
-- `Rasten`: normalized fermentation steps excluding fixed process step types `Einmaischen`, `Abmaischen`, and `Kochen`. Normal rests are sent with `procedureType: RAST`; decoctions use `procedureType: DECOCTION` and `executionMode: CONFIRMATION_HOLD`.
+- `Rasten`: normalized fermentation steps excluding fixed process step types `Einmaischen`, `Abmaischen`, and `Kochen`. Normal rests are sent with `procedureType: RAST`; decoctions use `procedureType: DECOCTION` and `executionMode: CONFIRMATION_HOLD` and omit both `temperature` and `time`. The control app derives the main-mash target during decoction.
 
 Validation rejects missing/non-positive mash-in, mash-out, and rest temperatures and timed rests without `time > 0`; missing/invalid top-level cooking temperature is not rejected and maps to the UI fallback `99` °C.
 

--- a/src/containers/DatabaseOverview/BeerForm.tsx
+++ b/src/containers/DatabaseOverview/BeerForm.tsx
@@ -4,11 +4,10 @@ import {AdditionalIngredientDTO, BeerDTO, HopDTO, MaltDTO, YeastDTO} from "../..
 import { HopUsage } from "../../enums/eHopUsage";
 import { HopTimeUnit } from "../../enums/eHopTimeUnit";
 import { normalizeHopDto, updateHopUsage, validateHopDto } from "./hopDefaults";
-import { isValidExecutionMode, normalizeFermentationStep } from "./fermentationDefaults";
+import { isValidExecutionMode, normalizeFermentationStep, numberMashSteps } from "./fermentationDefaults";
 import { ProcedureType } from "../../enums/eProcedureType";
 import {isEqual} from "lodash";
 
-import {MashingType} from "../../enums/eMashingType";
 import {RestExecutionMode} from "../../enums/eRestExecutionMode";
 import './BeerForm.css'
 import {AdditionalIngredient} from "../../model/AdditionalIngredient";
@@ -117,6 +116,9 @@ export class BeerForm extends React.Component<BeerFormProps, BeerFormState> {
         this.state = {
             ...defaultState,
             ...(props.beerFormState || {}),
+            fermentationSteps: props.beerFormState?.fermentationSteps
+                ? numberMashSteps(props.beerFormState.fermentationSteps)
+                : defaultState.fermentationSteps,
             expandedSections: props.beerFormState?.expandedSections || defaultState.expandedSections,
         };
     }
@@ -160,7 +162,7 @@ export class BeerForm extends React.Component<BeerFormProps, BeerFormState> {
                 cookingTime: importedBeer.cookingTime || 0,
                 cookingTemperatur: importedBeer.cookingTemperatur || 0,
                 // Importierte Rasten werden defensiv normalisiert (Altformat ohne executionMode => TIMED).
-                fermentationSteps: importedBeer.fermentation ? importedBeer.fermentation.map((step) => normalizeFermentationStep(step)) : [],
+                fermentationSteps: importedBeer.fermentation ? numberMashSteps(importedBeer.fermentation) : [],
                 maltsDTO: importedBeer.malts ? importedBeer.malts.map(m => ({ id: m.id, name: m.name, quantity: m.quantity })) : [],
                 // Altrezepte ohne usage/timeUnit bleiben kompatibel und werden auf BOIL/MINUTES normiert.
                 hopsDTO: importedBeer.wortBoiling && importedBeer.wortBoiling.hops ? importedBeer.wortBoiling.hops.map(aHop => normalizeHopDto(aHop)) : [],
@@ -186,17 +188,20 @@ export class BeerForm extends React.Component<BeerFormProps, BeerFormState> {
        this.setState((prevState) => {
           const fermentationSteps = [...prevState.fermentationSteps];
           const step = fermentationSteps[index];
-          // Für TIMED/HOLD ein klares und rückwärtskompatibles Verhalten.
+          if (name === "procedureType") {
+              if (value === ProcedureType.DECOCTION) {
+                  fermentationSteps[index] = {type: 'Dekoktion', procedureType: ProcedureType.DECOCTION, executionMode: RestExecutionMode.CONFIRMATION_HOLD};
+              } else {
+                  fermentationSteps[index] = {type: step.type, procedureType: ProcedureType.RAST, executionMode: RestExecutionMode.TIMED, temperature: 1, time: 1};
+              }
+              return {fermentationSteps: numberMashSteps(fermentationSteps)};
+          }
           if (name === "executionMode") {
               step.executionMode = value as RestExecutionMode;
               if (step.executionMode === RestExecutionMode.CONFIRMATION_HOLD) {
-                  step.procedureType = ProcedureType.DECOCTION;
                   delete step.time;
               } else if (step.time === undefined) {
-                  step.procedureType = ProcedureType.RAST;
                   step.time = 1;
-              } else {
-                  step.procedureType = ProcedureType.RAST;
               }
           } else if (name === "temperature" || name === "time") {
               const parsed = Number(value);
@@ -213,15 +218,17 @@ export class BeerForm extends React.Component<BeerFormProps, BeerFormState> {
        });
     };
 
-    getExecutionMode = (step: FermentationSteps) => step.executionMode ?? RestExecutionMode.TIMED;
+    getExecutionMode = (step: FermentationSteps) => normalizeFermentationStep(step).executionMode ?? RestExecutionMode.TIMED;
 
     validateFermentationSteps = (steps: FermentationSteps[]) => {
         for (const step of steps) {
             const isFixed = this.fixedTypes.includes(step.type);
             if (isFixed) continue;
             const mode = this.getExecutionMode(step);
+            const procedureType = normalizeFermentationStep(step).procedureType;
             // Unbekannte Modi aus Importen nicht stillschweigend akzeptieren.
             if (!isValidExecutionMode(mode)) return false;
+            if (procedureType === ProcedureType.DECOCTION) continue;
             if (step.temperature === undefined || Number(step.temperature) <= 0) return false;
             if (mode === RestExecutionMode.TIMED && (step.time === undefined || Number(step.time) <= 0)) return false;
         }
@@ -562,7 +569,7 @@ export class BeerForm extends React.Component<BeerFormProps, BeerFormState> {
 
     addFermentationStep = () => {
         this.setState((prevState) => {
-            const rastCount = prevState.fermentationSteps.filter((s) => !Object.values(MashingType).includes(s.type as MashingType) || s.type === '').length + 1;
+            const rastCount = prevState.fermentationSteps.filter((s) => !this.fixedTypes.includes(s.type) && normalizeFermentationStep(s).procedureType === ProcedureType.RAST).length + 1;
             return {
                 fermentationSteps: [
                     ...prevState.fermentationSteps,
@@ -607,7 +614,7 @@ export class BeerForm extends React.Component<BeerFormProps, BeerFormState> {
         this.setState((prevState) => {
             const fermentationSteps = [...prevState.fermentationSteps];
             fermentationSteps.splice(index, 1);
-            return { fermentationSteps };
+            return { fermentationSteps: numberMashSteps(fermentationSteps) };
         });
     };
 
@@ -667,7 +674,7 @@ export class BeerForm extends React.Component<BeerFormProps, BeerFormState> {
                 spargeVolume: selectedBeer.spargeVolume || 0,
                 cookingTime: selectedBeer.cookingTime || 0,
                 cookingTemperatur: selectedBeer.cookingTemperatur || 0,
-                fermentationSteps: selectedBeer.fermentation ? selectedBeer.fermentation.map((step) => normalizeFermentationStep(step)) : [],
+                fermentationSteps: selectedBeer.fermentation ? numberMashSteps(selectedBeer.fermentation) : [],
                 maltsDTO: selectedBeer.malts ? selectedBeer.malts.map(m => ({ id: m.id, name: m.name, quantity: m.quantity })) : [],
                 // Bestehende Rezepte ohne neue Felder werden im UI als Kochhopfen in Minuten dargestellt.
                 hopsDTO: selectedBeer.wortBoiling && selectedBeer.wortBoiling.hops ? selectedBeer.wortBoiling.hops.map(aHop => normalizeHopDto(aHop)) : [],
@@ -777,14 +784,14 @@ export class BeerForm extends React.Component<BeerFormProps, BeerFormState> {
                     <table className="ingredient-table">
                         <thead><tr><th>Typ</th><th>Modus</th><th>Temp (°C)</th><th>Zeit (min)</th><th className="action-column">Aktion</th></tr></thead>
                         <tbody>{fermentationSteps?.map((step, index) => {
-                            const rastCount = fermentationSteps.slice(0, index + 1).filter((s) => !Object.values(MashingType).includes(s.type as MashingType) || s.type === '').length;
                             const isFixed = this.fixedTypes.includes(step.type);
                             const executionMode = this.getExecutionMode(step);
+                            const procedureType = normalizeFermentationStep(step).procedureType;
                             return <tr key={index}>
-                                <td>{isFixed ? <span className="readonly-table-value">{step.type}</span> : <select name="type" value={step.type} onChange={(e) => this.handleFermentationStepChange(e.target.value, e.target.name, index)} required={false}><option value="">Rast {rastCount}</option>{Object.values(MashingType).map((mashingType) => <option key={mashingType} value={mashingType}>{mashingType}</option>)}</select>}</td>
-                                <td>{isFixed ? <span className="muted-table-value">–</span> : <select name="executionMode" value={executionMode} onChange={(e) => this.handleFermentationStepChange(e.target.value, e.target.name, index)}><option value={RestExecutionMode.TIMED}>Zeitgesteuerte Rast</option><option value={RestExecutionMode.CONFIRMATION_HOLD}>Dekoktion (bis Bestätigung)</option></select>}</td>
-                                <td><input type="number" name="temperature" value={step.temperature} onChange={(e) => this.handleFermentationStepChange(e.target.value, e.target.name, index)} required={true} /></td>
-                                <td>{executionMode === RestExecutionMode.TIMED ? <input type="number" name="time" min={isFixed ? 0 : 1} value={step.time ?? ''} onChange={(e) => this.handleFermentationStepChange(e.target.value, e.target.name, index)} required={!isFixed} /> : <span className="muted-table-value">–</span>}</td>
+                                <td>{isFixed ? <span className="readonly-table-value">{step.type}</span> : <select aria-label={`Typ ${index + 1}`} name="procedureType" value={procedureType} onChange={(e) => this.handleFermentationStepChange(e.target.value, e.target.name, index)}><option value={ProcedureType.RAST}>{step.type}</option><option value={ProcedureType.DECOCTION}>Dekoktion</option></select>}</td>
+                                <td>{isFixed ? <span className="muted-table-value">–</span> : <select aria-label={`Modus ${index + 1}`} name="executionMode" value={executionMode} disabled={procedureType === ProcedureType.DECOCTION} onChange={(e) => this.handleFermentationStepChange(e.target.value, e.target.name, index)}><option value={RestExecutionMode.TIMED}>Zeitgesteuert</option><option value={RestExecutionMode.CONFIRMATION_HOLD}>Bis Bestätigung</option></select>}</td>
+                                <td>{procedureType === ProcedureType.DECOCTION ? <span className="muted-table-value">–</span> : <input type="number" name="temperature" value={step.temperature ?? ''} onChange={(e) => this.handleFermentationStepChange(e.target.value, e.target.name, index)} required={true} />}</td>
+                                <td>{procedureType !== ProcedureType.DECOCTION && executionMode === RestExecutionMode.TIMED ? <input type="number" name="time" min={isFixed ? 0 : 1} value={step.time ?? ''} onChange={(e) => this.handleFermentationStepChange(e.target.value, e.target.name, index)} required={!isFixed} /> : <span className="muted-table-value">–</span>}</td>
                                 <td className="action-column">{index > 0 && !isFixed && <button type="button" className="cancel-btn brauhaus-button brauhaus-button-danger brauhaus-icon-button" onClick={() => this.removeFermentationStep(index)} title="Rast löschen" aria-label="Rast löschen">🗑️</button>}</td>
                             </tr>;
                         })}</tbody>

--- a/src/containers/DatabaseOverview/fermentationDefaults.test.ts
+++ b/src/containers/DatabaseOverview/fermentationDefaults.test.ts
@@ -1,5 +1,5 @@
 import { RestExecutionMode } from '../../enums/eRestExecutionMode';
-import { normalizeFermentationStep, isValidExecutionMode } from './fermentationDefaults';
+import { normalizeFermentationStep, isValidExecutionMode, numberMashSteps } from './fermentationDefaults';
 import {ProcedureType} from '../../enums/eProcedureType';
 
 describe('fermentationDefaults', () => {
@@ -33,5 +33,26 @@ describe('fermentationDefaults', () => {
 
     test('invalid executionMode is rejected clearly by validator helper', () => {
         expect(isValidExecutionMode('SOMETHING_ELSE')).toBe(false);
+    });
+
+    test('explicit confirmation-hold RAST remains a RAST', () => {
+        const step = normalizeFermentationStep({type: 'Rast', temperature: 68, procedureType: ProcedureType.RAST, executionMode: RestExecutionMode.CONFIRMATION_HOLD});
+        expect(step).toMatchObject({procedureType: ProcedureType.RAST, executionMode: RestExecutionMode.CONFIRMATION_HOLD, temperature: 68});
+        expect(step.time).toBeUndefined();
+    });
+
+    test('decoctions contain no fake recipe temperature or time', () => {
+        const step = normalizeFermentationStep({type: 'Alt', temperature: 68, time: 10, procedureType: ProcedureType.DECOCTION});
+        expect(step).toEqual({type: 'Alt', procedureType: ProcedureType.DECOCTION, executionMode: RestExecutionMode.CONFIRMATION_HOLD});
+    });
+
+    test('numbers only RAST steps', () => {
+        expect(numberMashSteps([
+            {type: 'a', temperature: 62, procedureType: ProcedureType.RAST},
+            {type: 'b', procedureType: ProcedureType.DECOCTION},
+            {type: 'c', temperature: 68, procedureType: ProcedureType.RAST},
+            {type: 'd', procedureType: ProcedureType.DECOCTION},
+            {type: 'e', temperature: 72, procedureType: ProcedureType.RAST},
+        ]).map(step => step.type)).toEqual(['Rast 1', 'Dekoktion', 'Rast 2', 'Dekoktion', 'Rast 3']);
     });
 });

--- a/src/containers/DatabaseOverview/fermentationDefaults.ts
+++ b/src/containers/DatabaseOverview/fermentationDefaults.ts
@@ -12,13 +12,34 @@ export const normalizeFermentationStep = (step: Partial<FermentationSteps>): Fer
         ? RestExecutionMode.CONFIRMATION_HOLD
         : (step.executionMode ?? RestExecutionMode.TIMED);
 
+    if (procedureType === ProcedureType.DECOCTION) {
+        return {
+            type: step.type || 'Dekoktion',
+            executionMode: RestExecutionMode.CONFIRMATION_HOLD,
+            procedureType,
+        };
+    }
+
     return {
         type: step.type ?? '',
-        temperature: Number(step.temperature ?? 0),
+        temperature: step.temperature === undefined || step.temperature === null ? undefined : Number(step.temperature),
         time: step.time,
         executionMode,
         procedureType,
     };
+};
+
+export const numberMashSteps = (steps: FermentationSteps[]): FermentationSteps[] => {
+    let rastNumber = 0;
+    return steps.map((step) => {
+        if (["Einmaischen", "Abmaischen", "Kochen"].includes(step.type)) return step;
+        const normalized = normalizeFermentationStep(step);
+        if (normalized.procedureType === ProcedureType.DECOCTION) {
+            return {...normalized, type: 'Dekoktion'};
+        }
+        rastNumber += 1;
+        return {...normalized, type: `Rast ${rastNumber}`};
+    });
 };
 
 export const isValidExecutionMode = (value: unknown): value is RestExecutionMode => {

--- a/src/containers/Production/ProcessList/ProcessList.test.tsx
+++ b/src/containers/Production/ProcessList/ProcessList.test.tsx
@@ -80,6 +80,7 @@ describe('ProcessList current-step mapping', () => {
 
         expect(steps[decoctionIndex + 1].name).toBe('Jod Probe');
         expect(steps[getActiveProcessStepIndex(steps, 3, {index: 3, phase: ProcessPhase.DECOCTION, mode: ProcessMode.WAITING})].name).toBe('Kochmaische');
+        expect(steps.some(step => step.name === 'Aufheizen für Kochmaische')).toBe(false);
     });
     it('builds visible process rows with shared control indices for heating and process entries', () => {
         expect(createProcessSteps(selectedBeer).map(step => `${step.controlStepIndex ?? '-'}:${step.name}`)).toEqual([

--- a/src/containers/Production/ProcessList/ProcessList.tsx
+++ b/src/containers/Production/ProcessList/ProcessList.tsx
@@ -412,7 +412,7 @@ export function createProcessSteps(selectedBeer: Beer): ProcessListStep[] {
         const isFixedStep = ['Einmaischen', 'Abmaischen', 'Kochen'].includes(step.type);
         if (!isFixedStep) {
             const phase = procedureType === ProcedureType.DECOCTION ? ProcessPhase.DECOCTION : ProcessPhase.RAST;
-            processSteps.push({ name: `Aufheizen für ${step.type}`, entryType: ProcessListEntryType.HEATING, controlStepIndex, phase, detail: {temperature: step.temperature} });
+            if (procedureType === ProcedureType.RAST) processSteps.push({ name: `Aufheizen für ${step.type}`, entryType: ProcessListEntryType.HEATING, controlStepIndex, phase, detail: {temperature: step.temperature} });
             processSteps.push({ name: step.type || (phase === ProcessPhase.DECOCTION ? 'Dekoktion' : 'Rast'), entryType: ProcessListEntryType.PROCESS, controlStepIndex, phase, detail: {temperature: step.temperature, duration: step.time, durationUnit: ProcessListDurationUnit.MINUTES, confirmationRequired: procedureType === ProcedureType.DECOCTION} });
             controlStepIndex++;
             lastMashStepIndex = processSteps.length - 1;

--- a/src/model/Beer.ts
+++ b/src/model/Beer.ts
@@ -4,7 +4,7 @@ import { HopUsage } from '../enums/eHopUsage';
 import { ProcedureType } from '../enums/eProcedureType';
 export interface FermentationSteps {
     type: string;
-    temperature: number;
+    temperature?: number;
     time?: number;
     executionMode?: RestExecutionMode;
     procedureType?: ProcedureType;

--- a/src/model/BeerDTO.ts
+++ b/src/model/BeerDTO.ts
@@ -6,7 +6,7 @@ import {AdditionalIngredientPhase, AdditionalIngredientTimeUnit} from "./Beer";
 import { ProcedureType } from '../enums/eProcedureType';
 export interface FermentationStepsDTO {
     type: string;
-    temperature: number;
+    temperature?: number;
     time?: number;
     executionMode?: RestExecutionMode;
     procedureType?: ProcedureType;

--- a/src/utils/productionRecipe.test.ts
+++ b/src/utils/productionRecipe.test.ts
@@ -112,6 +112,15 @@ describe('productionRecipe mapping', () => {
       expect.objectContaining({procedureType: ProcedureType.DECOCTION, executionMode: RestExecutionMode.CONFIRMATION_HOLD})
     ]);
     expect(result.fermentationSteps?.[0]).not.toHaveProperty('time');
+    expect(result.fermentationSteps?.[0]).not.toHaveProperty('temperature');
+  });
+
+  it('does not infer DECOCTION from an explicit confirmation-hold RAST', () => {
+    const result = normalizeFermentationStepsForProduction([
+      {type: 'Rast 1', temperature: 68, procedureType: ProcedureType.RAST, executionMode: RestExecutionMode.CONFIRMATION_HOLD}
+    ]);
+    expect(result.fermentationSteps?.[0]).toMatchObject({procedureType: ProcedureType.RAST, executionMode: RestExecutionMode.CONFIRMATION_HOLD, temperature: 68});
+    expect(result.fermentationSteps?.[0]).not.toHaveProperty('time');
   });
 
   it('uses 99 °C as fallback for missing or invalid cooking temperature only', () => {
@@ -147,8 +156,8 @@ describe('productionRecipe mapping', () => {
       CookingTime: 70,
       CookingTemperature: 100,
       Rasten: [
-        { type: 'Rast1', temperature: 63, time: 40, executionMode: RestExecutionMode.TIMED },
-        { type: 'Dickmaische', temperature: 68, executionMode: RestExecutionMode.CONFIRMATION_HOLD }
+        { type: 'Rast1', temperature: 63, time: 40, procedureType: ProcedureType.RAST, executionMode: RestExecutionMode.TIMED },
+        { type: 'Dickmaische', procedureType: ProcedureType.DECOCTION, executionMode: RestExecutionMode.CONFIRMATION_HOLD }
       ]
     });
   });

--- a/src/utils/productionRecipe.ts
+++ b/src/utils/productionRecipe.ts
@@ -3,8 +3,8 @@ import { BrewingData } from '../model/BrewingData';
 import { RestExecutionMode } from '../enums/eRestExecutionMode';
 import { ProcedureType } from '../enums/eProcedureType';
 
-const isValidTemperature = (value: unknown) => typeof value === 'number' && Number.isFinite(value) && value > 0;
-const isValidTimedDuration = (value: unknown) => typeof value === 'number' && Number.isFinite(value) && value > 0;
+const isValidTemperature = (value: unknown): value is number => typeof value === 'number' && Number.isFinite(value) && value > 0;
+const isValidTimedDuration = (value: unknown): value is number => typeof value === 'number' && Number.isFinite(value) && value > 0;
 const FALLBACK_COOKING_TEMPERATURE_CELSIUS = 99;
 
 export interface ProductionRecipeNormalizationResult {
@@ -25,6 +25,14 @@ export function normalizeFermentationStepsForProduction(steps: FermentationSteps
       ? RestExecutionMode.CONFIRMATION_HOLD
       : (step.executionMode ?? RestExecutionMode.TIMED);
 
+    if (fixedProcessStepTypes.has(step.type)) continue;
+
+    if (procedureType === ProcedureType.DECOCTION) {
+      const {time, temperature, ...decoction} = step;
+      normalized.push({...decoction, procedureType, executionMode: RestExecutionMode.CONFIRMATION_HOLD});
+      continue;
+    }
+
     if (!isValidTemperature(step.temperature)) {
       return { ok: false, error: `Ungültige Rasttemperatur bei Schritt "${step.type}".` };
     }
@@ -33,11 +41,6 @@ export function normalizeFermentationStepsForProduction(steps: FermentationSteps
     if (executionMode === RestExecutionMode.CONFIRMATION_HOLD) {
       const { time, ...restWithoutTime } = step;
       normalized.push({ ...restWithoutTime, executionMode, procedureType });
-      continue;
-    }
-
-    // Ein-/Abmaischen/Kochen sind feste Prozessschritte über Top-Level-Felder und dürfen nicht als normale Rasten gesendet werden.
-    if (fixedProcessStepTypes.has(step.type)) {
       continue;
     }
 
@@ -59,8 +62,10 @@ export function normalizeFermentationStepsForProduction(steps: FermentationSteps
 export function mapBeerToBrewingData(beer: Beer): ProductionRecipeNormalizationResult {
   const ein = beer.fermentation.find(item => item.type === 'Einmaischen');
   const aus = beer.fermentation.find(item => item.type === 'Abmaischen');
+  const mashupTemperature = ein?.temperature;
+  const mashdownTemperature = aus?.temperature;
 
-  if (!ein || !aus || !isValidTemperature(ein.temperature) || !isValidTemperature(aus.temperature)) {
+  if (!isValidTemperature(mashupTemperature) || !isValidTemperature(mashdownTemperature)) {
     return { ok: false, error: 'Einmaischen/Abmaischen Temperatur fehlt oder ist ungültig.' };
   }
   if (!isValidTimedDuration(beer.cookingTime)) {
@@ -76,8 +81,8 @@ export function mapBeerToBrewingData(beer: Beer): ProductionRecipeNormalizationR
   return {
     ok: true,
     brewingData: {
-      MashdownTemperature: aus.temperature,
-      MashupTemperature: ein.temperature,
+      MashdownTemperature: mashdownTemperature,
+      MashupTemperature: mashupTemperature,
       CookingTemperature: cookingTemperature,
       CookingTime: beer.cookingTime,
       Rasten: normalizedStepsResult.fermentationSteps ?? []


### PR DESCRIPTION
### Motivation

- Make decoction (`DECOCTION`) a first-class `procedureType` that does not carry fake `temperature`/`time` values and is distinct from an explicit RAST with `CONFIRMATION_HOLD`.
- Ensure UI, production mapping and process list are consistent when importing, editing and serializing mash/rest steps, and provide stable automatic numbering for RAST steps.

### Description

- Added `numberMashSteps` and adjusted `normalizeFermentationStep` in `fermentationDefaults` so decoctions return only `type`, `procedureType` and `executionMode` and RAST steps preserve numeric `temperature`/`time`; `temperature` is now optional in `FermentationSteps`/`FermentationStepsDTO`.
- Updated `BeerForm` to use `numberMashSteps` when initializing, importing and selecting beers, changed the mash-step UI to select `procedureType` (RAST/DECOCTION), hide/disable temperature/time inputs for decoctions, and updated `handleFermentationStepChange`, `addFermentationStep`, `removeFermentationStep`, `getExecutionMode` and validation to respect the new normalization rules.
- Adjusted production mapping in `productionRecipe` to omit `temperature`/`time` for decoctions when serializing `Rasten`, enforce confirmation-hold for decoctions, and refine validation helpers with proper type predicates.
- Prevented rendering heating entries for decoction phases in `ProcessList` so no spurious "Aufheizen für ..." rows are created for `DECOCTION` steps.
- Updated and added unit tests to cover the new behavior in `fermentationDefaults.test.ts`, `productionRecipe.test.ts`, and `ProcessList.test.tsx`.

### Testing

- Ran the updated unit test suite including `fermentationDefaults.test.ts`, `productionRecipe.test.ts`, and `ProcessList.test.tsx`, and the tests for the affected components; all automated tests succeeded.
- Verified TypeScript compilation for the changed modules and adjusted types for optional `temperature` to ensure type checks passed.
- Regression checks: production serialization and UI mash-step interactions covered by the modified tests and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8c3bc8c260832f818976c6ecb9bffb)