### PR TITLE
Validate DECOCTION ordering: require prior RAST in mash plan

### DIFF
--- a/docs/codex/domain-model.md
+++ b/docs/codex/domain-model.md
@@ -7,6 +7,7 @@ Visible/used fields include:
 - Identity/display: `id`, `name`, `type`, `color`, `description`, `rating`.
 - Metrics: `alcohol`, `originalwort`, `bitterness`, `mashVolume`, `spargeVolume`, `cookingTime`, `cookingTemperatur`.
 - Production steps: `fermentation: FermentationSteps[]` where `procedureType` classifies mash steps as `RAST` or `DECOCTION`; legacy `CONFIRMATION_HOLD` steps without it normalize to `DECOCTION`. Step `type` remains the display name.
+- Recipe-editor validation requires every normalized `DECOCTION` to have an earlier non-fixed `RAST` in the mash-step order. Fixed steps such as `Einmaischen` do not satisfy this requirement; consecutive decoctions reuse the latest earlier RAST and remain valid.
 - Ingredients: `malts`, `wortBoiling.hops`, `fermentationMaturation.yeast`, optional `additionalIngredients`.
 
 `BeerDTO` differs from `Beer` for submission: `fermentationSteps` instead of `fermentation`, ingredient DTOs, and nullable `wortBoiling`/`fermentationMaturation`.

--- a/src/containers/DatabaseOverview/BeerForm.css
+++ b/src/containers/DatabaseOverview/BeerForm.css
@@ -325,6 +325,14 @@
     overflow-wrap: anywhere;
 }
 
+.ingredient-table tr.validation-error-row td {
+    background-color: color-mix(in srgb, var(--color-error-highlight) 12%, transparent);
+}
+
+.ingredient-table [aria-invalid="true"] {
+    border-color: var(--color-error-highlight);
+}
+
 .missing-ingredients-warning,
 .beer-form-info,
 .empty-section-note {

--- a/src/containers/DatabaseOverview/BeerForm.test.tsx
+++ b/src/containers/DatabaseOverview/BeerForm.test.tsx
@@ -3,6 +3,8 @@ import {fireEvent, render, screen} from '@testing-library/react';
 import {BeerForm} from './BeerForm';
 import {HopUsage} from '../../enums/eHopUsage';
 import {HopTimeUnit} from '../../enums/eHopTimeUnit';
+import {ProcedureType} from '../../enums/eProcedureType';
+import {RestExecutionMode} from '../../enums/eRestExecutionMode';
 
 const baseProps: React.ComponentProps<typeof BeerForm> = {
     onSubmitBeer: jest.fn(),
@@ -167,5 +169,34 @@ describe('BeerForm accordions', () => {
         expect(screen.getAllByRole('button', {name: /Malz löschen/})).toHaveLength(2);
         fireEvent.click(screen.getAllByRole('button', {name: /Malz löschen/})[0]);
         expect(screen.getAllByRole('button', {name: /Malz löschen/})).toHaveLength(1);
+    });
+
+    it('shows and clears the decoction order error immediately after procedure type changes', () => {
+        renderBeerForm({beerFormState: {fermentationSteps: [
+            {type: 'Rast 1', temperature: 65, time: 10, procedureType: ProcedureType.RAST, executionMode: RestExecutionMode.TIMED},
+            {type: 'Rast 2', temperature: 68, time: 10, procedureType: ProcedureType.RAST, executionMode: RestExecutionMode.TIMED},
+        ]}});
+        fireEvent.click(screen.getByRole('button', {name: /Maischeplan/}));
+
+        fireEvent.change(screen.getByLabelText('Typ 1'), {target: {value: ProcedureType.DECOCTION}});
+        expect(screen.getByText('Dekoktion benötigt eine vorherige Rast.')).toBeInTheDocument();
+        expect(screen.getByLabelText('Typ 1')).toHaveAttribute('aria-invalid', 'true');
+
+        fireEvent.change(screen.getByLabelText('Typ 1'), {target: {value: ProcedureType.RAST}});
+        expect(screen.queryByText('Dekoktion benötigt eine vorherige Rast.')).not.toBeInTheDocument();
+        expect(screen.getByLabelText('Typ 1')).toHaveAttribute('aria-invalid', 'false');
+    });
+
+    it('blocks saving when a decoction has no previous rast', () => {
+        const {props} = renderBeerForm({beerFormState: {fermentationSteps: [
+            {type: 'Dekoktion', procedureType: ProcedureType.DECOCTION, executionMode: RestExecutionMode.CONFIRMATION_HOLD},
+            {type: 'Rast 1', temperature: 65, time: 10, procedureType: ProcedureType.RAST, executionMode: RestExecutionMode.TIMED},
+        ]}});
+        fillValidRecipe();
+
+        fireEvent.click(screen.getByRole('button', {name: /Rezept speichern/}));
+
+        expect(screen.getByText(/Bitte prüfe den Maischeplan: Dekoktion benötigt eine vorherige Rast/)).toBeInTheDocument();
+        expect(props.onSubmitBeer).not.toHaveBeenCalled();
     });
 });

--- a/src/containers/DatabaseOverview/BeerForm.tsx
+++ b/src/containers/DatabaseOverview/BeerForm.tsx
@@ -4,7 +4,7 @@ import {AdditionalIngredientDTO, BeerDTO, HopDTO, MaltDTO, YeastDTO} from "../..
 import { HopUsage } from "../../enums/eHopUsage";
 import { HopTimeUnit } from "../../enums/eHopTimeUnit";
 import { normalizeHopDto, updateHopUsage, validateHopDto } from "./hopDefaults";
-import { isValidExecutionMode, normalizeFermentationStep, numberMashSteps } from "./fermentationDefaults";
+import { decoctionRequiresPreviousRastError, getFermentationStepValidationErrors, isValidExecutionMode, normalizeFermentationStep, numberMashSteps } from "./fermentationDefaults";
 import { ProcedureType } from "../../enums/eProcedureType";
 import {isEqual} from "lodash";
 
@@ -113,12 +113,17 @@ export class BeerForm extends React.Component<BeerFormProps, BeerFormState> {
         };
 
         // Wenn ein gespeicherter Formularstatus existiert, verwenden wir diesen, ansonsten den Standardstatus.
+        const fermentationSteps = props.beerFormState?.fermentationSteps
+            ? numberMashSteps(props.beerFormState.fermentationSteps)
+            : defaultState.fermentationSteps;
         this.state = {
             ...defaultState,
             ...(props.beerFormState || {}),
-            fermentationSteps: props.beerFormState?.fermentationSteps
-                ? numberMashSteps(props.beerFormState.fermentationSteps)
-                : defaultState.fermentationSteps,
+            fermentationSteps,
+            validationErrors: {
+                ...(props.beerFormState?.validationErrors || {}),
+                ...getFermentationStepValidationErrors(fermentationSteps),
+            },
             expandedSections: props.beerFormState?.expandedSections || defaultState.expandedSections,
         };
     }
@@ -171,6 +176,7 @@ export class BeerForm extends React.Component<BeerFormProps, BeerFormState> {
                 additionalIngredientsDTO: importedBeer.additionalIngredients ? importedBeer.additionalIngredients.map(aIngredient => this.normalizeAdditionalIngredient(aIngredient)) : [],
                 isSubmitSuccessful: undefined,
             }, () => {
+                this.updateFermentationStepValidationErrors(this.state.fermentationSteps);
                 this.props.saveBeerFormState(this.state);
             });
         }
@@ -213,6 +219,7 @@ export class BeerForm extends React.Component<BeerFormProps, BeerFormState> {
           }
           return { fermentationSteps };
        }, () => {
+            this.updateFermentationStepValidationErrors(this.state.fermentationSteps);
             // Nach jeder Statusänderung den aktuellen Formularstatus speichern
             this.props.saveBeerFormState(this.state);
        });
@@ -232,7 +239,17 @@ export class BeerForm extends React.Component<BeerFormProps, BeerFormState> {
             if (step.temperature === undefined || Number(step.temperature) <= 0) return false;
             if (mode === RestExecutionMode.TIMED && (step.time === undefined || Number(step.time) <= 0)) return false;
         }
-        return true;
+        return Object.keys(getFermentationStepValidationErrors(steps)).length === 0;
+    };
+
+    updateFermentationStepValidationErrors = (steps: FermentationSteps[]) => {
+        const stepErrors = getFermentationStepValidationErrors(steps);
+        this.setState((prevState) => {
+            const validationErrors = Object.fromEntries(
+                Object.entries(prevState.validationErrors).filter(([key]) => !key.startsWith('fermentationSteps.'))
+            );
+            return {validationErrors: {...validationErrors, ...stepErrors}};
+        });
     };
 
     handleMaltChange = (value: string, name: string, index: number) => {
@@ -446,7 +463,14 @@ export class BeerForm extends React.Component<BeerFormProps, BeerFormState> {
             return;
         }
         if (!this.validateFermentationSteps(fermentationSteps)) {
-            this.openValidationDialog('Bitte prüfe den Maischeplan: Zeitgesteuerte Rasten benötigen Zeit > 0, Halte-Rasten nur Temperatur.');
+            const orderErrors = getFermentationStepValidationErrors(fermentationSteps);
+            this.setState((prevState) => ({
+                validationErrors: {...prevState.validationErrors, ...orderErrors},
+                expandedSections: {...prevState.expandedSections, mash: true},
+            }));
+            this.openValidationDialog(Object.keys(orderErrors).length > 0
+                ? `Bitte prüfe den Maischeplan: ${decoctionRequiresPreviousRastError}`
+                : 'Bitte prüfe den Maischeplan: Zeitgesteuerte Rasten benötigen Zeit > 0, Halte-Rasten nur Temperatur.');
             return;
         }
         const normalizedFermentationSteps = fermentationSteps.map((step) => normalizeFermentationStep(step));
@@ -615,7 +639,7 @@ export class BeerForm extends React.Component<BeerFormProps, BeerFormState> {
             const fermentationSteps = [...prevState.fermentationSteps];
             fermentationSteps.splice(index, 1);
             return { fermentationSteps: numberMashSteps(fermentationSteps) };
-        });
+        }, () => this.updateFermentationStepValidationErrors(this.state.fermentationSteps));
     };
 
     removeMalts = (index: number) => {
@@ -683,6 +707,7 @@ export class BeerForm extends React.Component<BeerFormProps, BeerFormState> {
                 additionalIngredientsDTO: selectedBeer.additionalIngredients ? selectedBeer.additionalIngredients.map(aIngredient => this.normalizeAdditionalIngredient(aIngredient)) : [],
                 isSubmitSuccessful: undefined,
             }, () => {
+                this.updateFermentationStepValidationErrors(this.state.fermentationSteps);
                 this.props.saveBeerFormState(this.state);
             });
         }
@@ -714,6 +739,7 @@ export class BeerForm extends React.Component<BeerFormProps, BeerFormState> {
         if (section === 'hops') return errorKeys.some((key) => key.startsWith('hopsDTO.'));
         if (section === 'yeast') return errorKeys.some((key) => key.startsWith('yeastsDTO.'));
         if (section === 'additional') return errorKeys.some((key) => key.startsWith('additionalIngredientsDTO.'));
+        if (section === 'mash') return errorKeys.some((key) => key.startsWith('fermentationSteps.'));
         return false;
     };
 
@@ -787,8 +813,9 @@ export class BeerForm extends React.Component<BeerFormProps, BeerFormState> {
                             const isFixed = this.fixedTypes.includes(step.type);
                             const executionMode = this.getExecutionMode(step);
                             const procedureType = normalizeFermentationStep(step).procedureType;
-                            return <tr key={index}>
-                                <td>{isFixed ? <span className="readonly-table-value">{step.type}</span> : <select aria-label={`Typ ${index + 1}`} name="procedureType" value={procedureType} onChange={(e) => this.handleFermentationStepChange(e.target.value, e.target.name, index)}><option value={ProcedureType.RAST}>{step.type}</option><option value={ProcedureType.DECOCTION}>Dekoktion</option></select>}</td>
+                            const procedureTypeErrorKey = `fermentationSteps.${index}.procedureType`;
+                            return <tr key={index} className={this.state.validationErrors[procedureTypeErrorKey] ? 'validation-error-row' : ''}>
+                                <td>{isFixed ? <span className="readonly-table-value">{step.type}</span> : <><select aria-label={`Typ ${index + 1}`} aria-invalid={Boolean(this.state.validationErrors[procedureTypeErrorKey])} name="procedureType" value={procedureType} onChange={(e) => this.handleFermentationStepChange(e.target.value, e.target.name, index)}><option value={ProcedureType.RAST}>{step.type}</option><option value={ProcedureType.DECOCTION}>Dekoktion</option></select>{this.renderFieldError(procedureTypeErrorKey)}</>}</td>
                                 <td>{isFixed ? <span className="muted-table-value">–</span> : <select aria-label={`Modus ${index + 1}`} name="executionMode" value={executionMode} disabled={procedureType === ProcedureType.DECOCTION} onChange={(e) => this.handleFermentationStepChange(e.target.value, e.target.name, index)}><option value={RestExecutionMode.TIMED}>Zeitgesteuert</option><option value={RestExecutionMode.CONFIRMATION_HOLD}>Bis Bestätigung</option></select>}</td>
                                 <td>{procedureType === ProcedureType.DECOCTION ? <span className="muted-table-value">–</span> : <input type="number" name="temperature" value={step.temperature ?? ''} onChange={(e) => this.handleFermentationStepChange(e.target.value, e.target.name, index)} required={true} />}</td>
                                 <td>{procedureType !== ProcedureType.DECOCTION && executionMode === RestExecutionMode.TIMED ? <input type="number" name="time" min={isFixed ? 0 : 1} value={step.time ?? ''} onChange={(e) => this.handleFermentationStepChange(e.target.value, e.target.name, index)} required={!isFixed} /> : <span className="muted-table-value">–</span>}</td>

--- a/src/containers/DatabaseOverview/fermentationDefaults.test.ts
+++ b/src/containers/DatabaseOverview/fermentationDefaults.test.ts
@@ -1,5 +1,5 @@
 import { RestExecutionMode } from '../../enums/eRestExecutionMode';
-import { normalizeFermentationStep, isValidExecutionMode, numberMashSteps } from './fermentationDefaults';
+import { decoctionRequiresPreviousRastError, getFermentationStepValidationErrors, normalizeFermentationStep, isValidExecutionMode, numberMashSteps } from './fermentationDefaults';
 import {ProcedureType} from '../../enums/eProcedureType';
 
 describe('fermentationDefaults', () => {
@@ -54,5 +54,36 @@ describe('fermentationDefaults', () => {
             {type: 'd', procedureType: ProcedureType.DECOCTION},
             {type: 'e', temperature: 72, procedureType: ProcedureType.RAST},
         ]).map(step => step.type)).toEqual(['Rast 1', 'Dekoktion', 'Rast 2', 'Dekoktion', 'Rast 3']);
+    });
+});
+
+describe('getFermentationStepValidationErrors', () => {
+    const rast = (executionMode: RestExecutionMode = RestExecutionMode.TIMED) => ({
+        type: 'Rast', temperature: 65, time: executionMode === RestExecutionMode.TIMED ? 10 : undefined,
+        procedureType: ProcedureType.RAST, executionMode,
+    });
+    const decoction = () => ({type: 'Dekoktion', procedureType: ProcedureType.DECOCTION, executionMode: RestExecutionMode.CONFIRMATION_HOLD});
+
+    test.each([
+        ['decoction before a rast', [decoction(), rast()], 0],
+        ['fixed mash-in before decoction', [{type: 'Einmaischen', temperature: 55}, decoction(), rast()], 1],
+    ])('rejects %s', (_name, steps, invalidIndex) => {
+        expect(getFermentationStepValidationErrors(steps as any)).toEqual({
+            [`fermentationSteps.${invalidIndex}.procedureType`]: decoctionRequiresPreviousRastError,
+        });
+    });
+
+    test.each([
+        ['rast, decoction, rast', [rast(), decoction(), rast()]],
+        ['multiple decoctions after a rast', [rast(), decoction(), decoction(), rast()]],
+        ['confirmation-hold rast before decoction', [rast(RestExecutionMode.CONFIRMATION_HOLD), decoction()]],
+    ])('accepts %s', (_name, steps) => {
+        expect(getFermentationStepValidationErrors(steps as any)).toEqual({});
+    });
+
+    test('normalizes legacy confirmation-hold steps before checking their order', () => {
+        const legacyDecoction = {type: 'Kochmaische', executionMode: RestExecutionMode.CONFIRMATION_HOLD};
+        expect(getFermentationStepValidationErrors([legacyDecoction, rast()] as any)).toHaveProperty('fermentationSteps.0.procedureType');
+        expect(getFermentationStepValidationErrors([rast(), legacyDecoction] as any)).toEqual({});
     });
 });

--- a/src/containers/DatabaseOverview/fermentationDefaults.ts
+++ b/src/containers/DatabaseOverview/fermentationDefaults.ts
@@ -3,6 +3,9 @@ import { FermentationSteps } from '../../model/Beer';
 import { ProcedureType } from '../../enums/eProcedureType';
 
 const allowedExecutionModes = [RestExecutionMode.TIMED, RestExecutionMode.CONFIRMATION_HOLD];
+const fixedProcedureTypes = ['Einmaischen', 'Abmaischen', 'Kochen'];
+
+export const decoctionRequiresPreviousRastError = 'Dekoktion benötigt eine vorherige Rast.';
 
 export const normalizeFermentationStep = (step: Partial<FermentationSteps>): FermentationSteps => {
     // Altrezepte ohne executionMode bleiben kompatibel und werden als TIMED behandelt.
@@ -44,4 +47,25 @@ export const numberMashSteps = (steps: FermentationSteps[]): FermentationSteps[]
 
 export const isValidExecutionMode = (value: unknown): value is RestExecutionMode => {
     return allowedExecutionModes.includes(value as RestExecutionMode);
+};
+
+export const getFermentationStepValidationErrors = (steps: FermentationSteps[]): Record<string, string> => {
+    const errors: Record<string, string> = {};
+    let hasPreviousRast = false;
+
+    steps.forEach((step, index) => {
+        if (fixedProcedureTypes.includes(step.type)) return;
+
+        const normalized = normalizeFermentationStep(step);
+        if (normalized.procedureType === ProcedureType.DECOCTION) {
+            if (!hasPreviousRast) {
+                errors[`fermentationSteps.${index}.procedureType`] = decoctionRequiresPreviousRastError;
+            }
+            return;
+        }
+
+        hasPreviousRast = true;
+    });
+
+    return errors;
 };


### PR DESCRIPTION
### Motivation

- Ensure a `DECOCTION` step is only valid when there is at least one preceding normalized `RAST` because the control app will derive the decoction target from the last prior RAST. 
- Integrate the rule into the existing central mash-plan validation used for save-blocking and UI feedback without altering numbering or control contracts.

### Description

- Added `getFermentationStepValidationErrors` and the constant `decoctionRequiresPreviousRastError` to `src/containers/DatabaseOverview/fermentationDefaults.ts` to detect `DECOCTION` steps that have no earlier non-fixed `RAST` after normalization. 
- Integrated the ordering check into the existing `BeerForm` validation in `src/containers/DatabaseOverview/BeerForm.tsx`, so invalid decoctions mark the form, expand the mash section, show the validation dialog and prevent save. 
- The specific UI feedback marks the affected row with a validation class, sets `aria-invalid` on the `procedureType` select, renders the field error text `Dekoktion benötigt eine vorherige Rast.` and styles the row via updated `src/containers/DatabaseOverview/BeerForm.css`. 
- Legacy normalization is reused: steps without `procedureType` plus `executionMode === CONFIRMATION_HOLD` are treated as `DECOCTION` before validation, and `RAST` with `CONFIRMATION_HOLD` remains a valid `RAST`; the existing `numberMashSteps` logic (rast numbering) was not changed. 
- Tests added for the new rule and UI behavior in `src/containers/DatabaseOverview/fermentationDefaults.test.ts` and `src/containers/DatabaseOverview/BeerForm.test.tsx` covering invalid and valid sequences, legacy normalization, immediate validation after type-change, and save-blocking.

### Testing

- Ran `git diff --check`, which passed with no whitespace/errors. 
- Attempted unit tests with `CI=true npm test -- --runInBand --watchAll=false src/containers/DatabaseOverview/fermentationDefaults.test.ts src/containers/DatabaseOverview/BeerForm.test.tsx`, but tests could not be executed to completion because local frontend dependencies (`react-scripts` etc.) are not installed in the environment (test run exited non-zero). 
- Ran TypeScript typecheck with `npx --no-install tsc --noEmit`, which reported deprecation/configuration warnings from the globally available TypeScript and exited non-zero in this environment. 
- Ran ESLint via `npx --no-install eslint ...`, which failed in this environment due to the global ESLint expecting a different config format and exited non-zero. 
- `npm run build` could not complete here for the same missing-local-dependency reasons. 

Files changed: `src/containers/DatabaseOverview/fermentationDefaults.ts`, `src/containers/DatabaseOverview/BeerForm.tsx`, `src/containers/DatabaseOverview/BeerForm.css`, `src/containers/DatabaseOverview/fermentationDefaults.test.ts`, `src/containers/DatabaseOverview/BeerForm.test.tsx`, and documentation update `docs/codex/domain-model.md`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8c412ae1c4832f826675e3af4eb93c)