### PR TITLE
Feste Maischeschritte beim Reset erhalten und Zeiten für Einmaischen/Abmaischen entfernen

### DIFF
--- a/docs/codex/compatibility/cross-repo-contracts.md
+++ b/docs/codex/compatibility/cross-repo-contracts.md
@@ -60,6 +60,8 @@ Before changing any database/backend field or endpoint, check whether the UI use
 - `FinishedBrew.startDate`
 - `FinishedBrew.endDate`
 
+The recipe editor now omits `time` when serializing the fixed `Einmaischen` and `Abmaischen` steps because those phases have no recipe duration. The TypeScript contract already permits this field to be absent, but database/backend persistence tolerance is **Needs verification**; the UI does not synthesize a compatibility value.
+
 ## UI ↔ PI control
 
 The PI control app produces runtime/control data that the UI displays and uses for workflow behavior.

--- a/docs/codex/domain-model.md
+++ b/docs/codex/domain-model.md
@@ -7,6 +7,7 @@ Visible/used fields include:
 - Identity/display: `id`, `name`, `type`, `color`, `description`, `rating`.
 - Metrics: `alcohol`, `originalwort`, `bitterness`, `mashVolume`, `spargeVolume`, `cookingTime`, `cookingTemperatur`.
 - Production steps: `fermentation: FermentationSteps[]` where `procedureType` classifies mash steps as `RAST` or `DECOCTION`; legacy `CONFIRMATION_HOLD` steps without it normalize to `DECOCTION`. Step `type` remains the display name.
+- Recipe-editor mash plans defensively contain exactly one each of the fixed `Einmaischen`, `Abmaischen`, and `Kochen` steps. `Einmaischen` and `Abmaischen` carry temperature but no UI-generated `time`; whether the database/backend accepts an omitted `time` for these persisted fixed steps is **Needs verification**.
 - Recipe-editor validation requires every normalized `DECOCTION` to have an earlier non-fixed `RAST` in the mash-step order. Fixed steps such as `Einmaischen` do not satisfy this requirement; consecutive decoctions reuse the latest earlier RAST and remain valid.
 - Ingredients: `malts`, `wortBoiling.hops`, `fermentationMaturation.yeast`, optional `additionalIngredients`.
 

--- a/src/containers/DatabaseOverview/BeerForm.test.tsx
+++ b/src/containers/DatabaseOverview/BeerForm.test.tsx
@@ -52,6 +52,10 @@ const fillValidRecipe = () => {
     fireEvent.change(screen.getByLabelText(/Kochzeit/), {target: {value: '60'}});
     fireEvent.change(screen.getByLabelText(/Kochtemperatur/), {target: {value: '99'}});
 
+    fireEvent.click(screen.getByRole('button', {name: /Maischeplan/}));
+    fireEvent.change(within(screen.getByText('Einmaischen').closest('tr')!).getByRole('spinbutton'), {target: {value: '57'}});
+    fireEvent.change(within(screen.getByText('Abmaischen').closest('tr')!).getByRole('spinbutton'), {target: {value: '78'}});
+
     fireEvent.click(screen.getByRole('button', {name: /Malze/}));
     fireEvent.change(screen.getByDisplayValue('Malz'), {target: {value: 'Pilsner Malz'}});
     fireEvent.change(screen.getAllByRole('spinbutton').find((input) => input.getAttribute('name') === 'quantity')!, {target: {value: '4000'}});
@@ -82,6 +86,34 @@ const expectProcedureTypeOptions = (select: HTMLElement) => {
 };
 
 describe('BeerForm accordions', () => {
+    it('always renders fixed steps and no time inputs for mash-in and mash-out', () => {
+        renderBeerForm({beerFormState: {fermentationSteps: []}});
+        fireEvent.click(screen.getByRole('button', {name: /Maischeplan/}));
+
+        for (const type of ['Einmaischen', 'Abmaischen', 'Kochen']) {
+            expect(screen.getByText(type)).toBeInTheDocument();
+        }
+        const mashInRow = screen.getByText('Einmaischen').closest('tr')!;
+        const mashOutRow = screen.getByText('Abmaischen').closest('tr')!;
+        expect(within(mashInRow).getAllByText('–')).toHaveLength(2);
+        expect(within(mashOutRow).getAllByText('–')).toHaveLength(2);
+        expect(within(mashInRow).getAllByRole('spinbutton')).toHaveLength(1);
+        expect(within(mashOutRow).getAllByRole('spinbutton')).toHaveLength(1);
+    });
+
+    it('reset keeps one copy of every fixed step after configurable mash steps were added', () => {
+        renderBeerForm();
+        fireEvent.click(screen.getByRole('button', {name: /Maischeplan/}));
+        fireEvent.click(screen.getByRole('button', {name: /Rast hinzufügen/}));
+        fireEvent.click(screen.getByRole('button', {name: /Abbrechen \/ Zurücksetzen/}));
+        fireEvent.click(screen.getByRole('button', {name: /Abbrechen \/ Zurücksetzen/}));
+
+        expect(screen.getAllByText('Einmaischen')).toHaveLength(1);
+        expect(screen.getAllByText('Abmaischen')).toHaveLength(1);
+        expect(screen.getAllByText('Kochen')).toHaveLength(1);
+        expect(screen.queryByLabelText(/Typ/)).not.toBeInTheDocument();
+    });
+
     it('opens basic and brewing data initially while keeping table sections collapsed', () => {
         renderBeerForm();
 
@@ -159,6 +191,27 @@ describe('BeerForm accordions', () => {
 
         expect(props.onSubmitBeer).toHaveBeenCalledTimes(1);
         expect(props.onSubmitBeer).toHaveBeenCalledWith(expect.objectContaining({id: 'beer-1', name: 'Altbier'}));
+    });
+
+    it('restores saved fixed steps when cancelling edits to an existing recipe', () => {
+        const existingBeer: React.ComponentProps<typeof BeerForm>['beers'][number] = {
+            id: 'beer-1', name: 'Alt', type: 'Ale', color: 'amber', alcohol: 5, originalwort: 12, bitterness: 30, description: '', rating: 3,
+            mashVolume: 18, spargeVolume: 8, cookingTime: 60, cookingTemperatur: 99,
+            fermentation: [{type: 'Einmaischen', temperature: 57}, {type: 'Abmaischen', temperature: 78}, {type: 'Kochen', temperature: 99, time: 60}],
+            malts: [], wortBoiling: {totalTime: 60, hops: []},
+            fermentationMaturation: {fermentationTemperature: 18, carbonation: 5, yeast: []},
+        };
+        renderBeerForm({beers: [existingBeer]});
+        fireEvent.change(screen.getByLabelText(/Bier auswählen/), {target: {value: 'beer-1'}});
+        fireEvent.click(screen.getByRole('button', {name: /Maischeplan/}));
+        fireEvent.change(within(screen.getByText('Einmaischen').closest('tr')!).getByRole('spinbutton'), {target: {value: '65'}});
+
+        fireEvent.click(screen.getByRole('button', {name: /Abbrechen \/ Zurücksetzen/}));
+
+        expect(within(screen.getByText('Einmaischen').closest('tr')!).getByRole('spinbutton')).toHaveValue(57);
+        expect(screen.getAllByText('Einmaischen')).toHaveLength(1);
+        expect(screen.getAllByText('Abmaischen')).toHaveLength(1);
+        expect(screen.getAllByText('Kochen')).toHaveLength(1);
     });
 
     it('keeps the submit button disabled while saving to prevent duplicate submits', () => {

--- a/src/containers/DatabaseOverview/BeerForm.tsx
+++ b/src/containers/DatabaseOverview/BeerForm.tsx
@@ -4,7 +4,7 @@ import {AdditionalIngredientDTO, BeerDTO, HopDTO, MaltDTO, YeastDTO} from "../..
 import { HopUsage } from "../../enums/eHopUsage";
 import { HopTimeUnit } from "../../enums/eHopTimeUnit";
 import { normalizeHopDto, updateHopUsage, validateHopDto } from "./hopDefaults";
-import { decoctionRequiresPreviousRastError, getFermentationStepValidationErrors, isValidExecutionMode, normalizeFermentationStep, numberMashSteps } from "./fermentationDefaults";
+import { createDefaultFermentationSteps, decoctionRequiresPreviousRastError, fixedProcedureTypes, getFermentationStepValidationErrors, isValidExecutionMode, normalizeFermentationStep, numberMashSteps } from "./fermentationDefaults";
 import { ProcedureType } from "../../enums/eProcedureType";
 import {isEqual} from "lodash";
 
@@ -73,7 +73,7 @@ interface BeerFormState {
 
 export class BeerForm extends React.Component<BeerFormProps, BeerFormState> {
     private fileInput: HTMLInputElement | null | undefined;
-    private fixedTypes = ['Einmaischen', 'Abmaischen', 'Kochen'];
+    private fixedTypes: readonly string[] = fixedProcedureTypes;
     constructor(props: BeerFormProps) {
 
         super(props);
@@ -93,11 +93,7 @@ export class BeerForm extends React.Component<BeerFormProps, BeerFormState> {
             spargeVolume: 0,
             cookingTime: 0,
             cookingTemperatur: 0,
-            fermentationSteps: [
-                { type: 'Einmaischen', temperature: 0, time: 0 },
-                { type: 'Abmaischen', temperature: 0, time: 0 },
-                { type: 'Kochen', temperature: 0, time: 0 }
-            ],
+            fermentationSteps: createDefaultFermentationSteps(),
             maltsDTO: [{ id: '', name: '', quantity: undefined as any }],
             hopsDTO: [{ id: '', name: '', quantity: undefined as any, time: 0, usage: HopUsage.BOIL, timeUnit: HopTimeUnit.MINUTES }],
             yeastsDTO: [{ id: '', name: '', quantity: undefined as any }],
@@ -172,7 +168,7 @@ export class BeerForm extends React.Component<BeerFormProps, BeerFormState> {
                 cookingTime: importedBeer.cookingTime || 0,
                 cookingTemperatur: importedBeer.cookingTemperatur || 0,
                 // Importierte Rasten werden defensiv normalisiert (Altformat ohne executionMode => TIMED).
-                fermentationSteps: importedBeer.fermentation ? numberMashSteps(importedBeer.fermentation) : [],
+                fermentationSteps: numberMashSteps(importedBeer.fermentation || []),
                 maltsDTO: importedBeer.malts ? importedBeer.malts.map(m => ({ id: m.id, name: m.name, quantity: m.quantity })) : [],
                 // Altrezepte ohne usage/timeUnit bleiben kompatibel und werden auf BOIL/MINUTES normiert.
                 hopsDTO: importedBeer.wortBoiling && importedBeer.wortBoiling.hops ? importedBeer.wortBoiling.hops.map(aHop => normalizeHopDto(aHop)) : [],
@@ -235,6 +231,10 @@ export class BeerForm extends React.Component<BeerFormProps, BeerFormState> {
     validateFermentationSteps = (steps: FermentationSteps[]) => {
         for (const step of steps) {
             const isFixed = this.fixedTypes.includes(step.type);
+            if (step.type === 'Einmaischen' || step.type === 'Abmaischen') {
+                if (step.temperature === undefined || Number(step.temperature) <= 0) return false;
+                continue;
+            }
             if (isFixed) continue;
             const mode = this.getExecutionMode(step);
             const procedureType = normalizeFermentationStep(step).procedureType;
@@ -478,7 +478,9 @@ export class BeerForm extends React.Component<BeerFormProps, BeerFormState> {
                 : 'Bitte prüfe den Maischeplan: Zeitgesteuerte Rasten benötigen Zeit > 0, Halte-Rasten nur Temperatur.');
             return;
         }
-        const normalizedFermentationSteps = fermentationSteps.map((step) => normalizeFermentationStep(step));
+        const normalizedFermentationSteps = numberMashSteps(fermentationSteps).map((step) =>
+            this.fixedTypes.includes(step.type) ? step : normalizeFermentationStep(step)
+        );
 
         const malts_DTO = maltsDTO
             .map((aMalt) => {
@@ -575,7 +577,7 @@ export class BeerForm extends React.Component<BeerFormProps, BeerFormState> {
             spargeVolume: 0,
             cookingTime: 0,
             cookingTemperatur: 0,
-            fermentationSteps: [],
+            fermentationSteps: createDefaultFermentationSteps(),
             maltsDTO: [],
             hopsDTO: [],
             yeastsDTO: [],
@@ -592,6 +594,39 @@ export class BeerForm extends React.Component<BeerFormProps, BeerFormState> {
             },
         }, () => {
             // Nach dem Zurücksetzen des Formulars aktualisieren wir den gespeicherten Status
+            this.props.saveBeerFormState(this.state);
+        });
+    };
+
+    cancelOrResetForm = () => {
+        const selectedBeer = this.props.beers.find((beer) => String(beer.id) === String(this.state.id));
+        if (!selectedBeer) {
+            this.resetForm();
+            return;
+        }
+
+        this.setState({
+            id: selectedBeer.id || '',
+            name: selectedBeer.name || '',
+            type: selectedBeer.type || '',
+            color: selectedBeer.color || '',
+            alcohol: selectedBeer.alcohol || 0,
+            originalwort: selectedBeer.originalwort || 0,
+            bitterness: selectedBeer.bitterness || 0,
+            description: selectedBeer.description || '',
+            rating: selectedBeer.rating || 0,
+            mashVolume: selectedBeer.mashVolume || 0,
+            spargeVolume: selectedBeer.spargeVolume || 0,
+            cookingTime: selectedBeer.cookingTime || 0,
+            cookingTemperatur: selectedBeer.cookingTemperatur || 0,
+            fermentationSteps: numberMashSteps(selectedBeer.fermentation || []),
+            maltsDTO: selectedBeer.malts.map((malt) => ({id: malt.id, name: malt.name, quantity: malt.quantity})),
+            hopsDTO: selectedBeer.wortBoiling?.hops.map((hop) => normalizeHopDto(hop)) || [],
+            yeastsDTO: selectedBeer.fermentationMaturation?.yeast.map((yeast) => ({id: yeast.id, name: yeast.name, quantity: yeast.quantity})) || [],
+            additionalIngredientsDTO: selectedBeer.additionalIngredients?.map((ingredient) => this.normalizeAdditionalIngredient(ingredient)) || [],
+            validationErrors: {},
+        }, () => {
+            this.updateFermentationStepValidationErrors(this.state.fermentationSteps);
             this.props.saveBeerFormState(this.state);
         });
     };
@@ -703,7 +738,7 @@ export class BeerForm extends React.Component<BeerFormProps, BeerFormState> {
                 spargeVolume: selectedBeer.spargeVolume || 0,
                 cookingTime: selectedBeer.cookingTime || 0,
                 cookingTemperatur: selectedBeer.cookingTemperatur || 0,
-                fermentationSteps: selectedBeer.fermentation ? numberMashSteps(selectedBeer.fermentation) : [],
+                fermentationSteps: numberMashSteps(selectedBeer.fermentation || []),
                 maltsDTO: selectedBeer.malts ? selectedBeer.malts.map(m => ({ id: m.id, name: m.name, quantity: m.quantity })) : [],
                 // Bestehende Rezepte ohne neue Felder werden im UI als Kochhopfen in Minuten dargestellt.
                 hopsDTO: selectedBeer.wortBoiling && selectedBeer.wortBoiling.hops ? selectedBeer.wortBoiling.hops.map(aHop => normalizeHopDto(aHop)) : [],
@@ -819,11 +854,12 @@ export class BeerForm extends React.Component<BeerFormProps, BeerFormState> {
                             const executionMode = this.getExecutionMode(step);
                             const procedureType = normalizeFermentationStep(step).procedureType;
                             const procedureTypeErrorKey = `fermentationSteps.${index}.procedureType`;
+                            const hasEditableTime = step.type === 'Kochen' || !isFixed;
                             return <tr key={index} className={this.state.validationErrors[procedureTypeErrorKey] ? 'validation-error-row' : ''}>
                                 <td>{isFixed ? <span className="readonly-table-value">{step.type}</span> : <><select aria-label={`Typ ${index + 1}`} aria-invalid={Boolean(this.state.validationErrors[procedureTypeErrorKey])} name="procedureType" value={procedureType} onChange={(e) => this.handleFermentationStepChange(e.target.value, e.target.name, index)}><option value={ProcedureType.RAST}>{step.type}</option><option value={ProcedureType.DECOCTION}>Dekoktion</option></select>{this.renderFieldError(procedureTypeErrorKey)}</>}</td>
                                 <td>{isFixed ? <span className="muted-table-value">–</span> : <select aria-label={`Modus ${index + 1}`} name="executionMode" value={executionMode} disabled={procedureType === ProcedureType.DECOCTION} onChange={(e) => this.handleFermentationStepChange(e.target.value, e.target.name, index)}><option value={RestExecutionMode.TIMED}>Zeitgesteuert</option><option value={RestExecutionMode.CONFIRMATION_HOLD}>Bis Bestätigung</option></select>}</td>
                                 <td>{procedureType === ProcedureType.DECOCTION ? <span className="muted-table-value">–</span> : <input type="number" name="temperature" value={step.temperature ?? ''} onChange={(e) => this.handleFermentationStepChange(e.target.value, e.target.name, index)} required={true} />}</td>
-                                <td>{procedureType !== ProcedureType.DECOCTION && executionMode === RestExecutionMode.TIMED ? <input type="number" name="time" min={isFixed ? 0 : 1} value={step.time ?? ''} onChange={(e) => this.handleFermentationStepChange(e.target.value, e.target.name, index)} required={!isFixed} /> : <span className="muted-table-value">–</span>}</td>
+                                <td>{hasEditableTime && procedureType !== ProcedureType.DECOCTION && executionMode === RestExecutionMode.TIMED ? <input type="number" name="time" min={isFixed ? 0 : 1} value={step.time ?? ''} onChange={(e) => this.handleFermentationStepChange(e.target.value, e.target.name, index)} required={!isFixed} /> : <span className="muted-table-value">–</span>}</td>
                                 <td className="action-column">{index > 0 && !isFixed && <button type="button" className="cancel-btn brauhaus-button brauhaus-button-danger brauhaus-icon-button" onClick={() => this.removeFermentationStep(index)} title="Rast löschen" aria-label="Rast löschen">🗑️</button>}</td>
                             </tr>;
                         })}</tbody>
@@ -920,7 +956,7 @@ export class BeerForm extends React.Component<BeerFormProps, BeerFormState> {
                     <div className="beer-form-panel-header">
                         <span>Bier</span>
                         <div className="beer-form-panel-actions">
-                            <button type="button" className="add-button brauhaus-button brauhaus-button-secondary secondary-action" onClick={this.resetForm}>Abbrechen / Zurücksetzen</button>
+                            <button type="button" className="add-button brauhaus-button brauhaus-button-secondary secondary-action" onClick={this.cancelOrResetForm}>Abbrechen / Zurücksetzen</button>
                             <button className="finish-btn brauhaus-button brauhaus-button-primary submit-button primary-action" type="submit" form="beer-recipe-form" disabled={this.props.isSavingBeer}>{this.props.isSavingBeer ? '⏳ Speichern...' : '💾 Rezept speichern'}</button>
                         </div>
                     </div>

--- a/src/containers/DatabaseOverview/fermentationDefaults.test.ts
+++ b/src/containers/DatabaseOverview/fermentationDefaults.test.ts
@@ -1,5 +1,5 @@
 import { RestExecutionMode } from '../../enums/eRestExecutionMode';
-import { decoctionRequiresPreviousRastError, getFermentationStepValidationErrors, normalizeFermentationStep, isValidExecutionMode, numberMashSteps } from './fermentationDefaults';
+import { createDefaultFermentationSteps, decoctionRequiresPreviousRastError, getFermentationStepValidationErrors, normalizeFermentationStep, isValidExecutionMode, numberMashSteps } from './fermentationDefaults';
 import {ProcedureType} from '../../enums/eProcedureType';
 
 describe('fermentationDefaults', () => {
@@ -53,7 +53,36 @@ describe('fermentationDefaults', () => {
             {type: 'c', temperature: 68, procedureType: ProcedureType.RAST},
             {type: 'd', procedureType: ProcedureType.DECOCTION},
             {type: 'e', temperature: 72, procedureType: ProcedureType.RAST},
-        ]).map(step => step.type)).toEqual(['Rast 1', 'Dekoktion', 'Rast 2', 'Dekoktion', 'Rast 3']);
+        ]).map(step => step.type)).toEqual(['Einmaischen', 'Rast 1', 'Dekoktion', 'Rast 2', 'Dekoktion', 'Rast 3', 'Abmaischen', 'Kochen']);
+    });
+
+    test('default mash plan contains each fixed process step once and no fake mash-in/out time', () => {
+        expect(createDefaultFermentationSteps()).toEqual([
+            {type: 'Einmaischen', temperature: 0},
+            {type: 'Abmaischen', temperature: 0},
+            {type: 'Kochen', temperature: 0, time: 0},
+        ]);
+    });
+
+    test('normalization restores missing fixed steps, removes duplicates and preserves saved values', () => {
+        const normalized = numberMashSteps([
+            {type: 'Einmaischen', temperature: 57, time: 12},
+            {type: 'Einmaischen', temperature: 60},
+            {type: 'Rast', temperature: 63, time: 30},
+            {type: 'Abmaischen', temperature: 78, time: 5},
+        ]);
+
+        expect(normalized.map((step) => step.type)).toEqual(['Einmaischen', 'Rast 1', 'Abmaischen', 'Kochen']);
+        expect(normalized[0]).toEqual({type: 'Einmaischen', temperature: 57});
+        expect(normalized[2]).toEqual({type: 'Abmaischen', temperature: 78});
+    });
+
+    test('repeated normalization never duplicates fixed steps', () => {
+        const once = numberMashSteps([]);
+        const twice = numberMashSteps(once);
+        expect(twice.filter((step) => step.type === 'Einmaischen')).toHaveLength(1);
+        expect(twice.filter((step) => step.type === 'Abmaischen')).toHaveLength(1);
+        expect(twice.filter((step) => step.type === 'Kochen')).toHaveLength(1);
     });
 });
 

--- a/src/containers/DatabaseOverview/fermentationDefaults.ts
+++ b/src/containers/DatabaseOverview/fermentationDefaults.ts
@@ -3,7 +3,20 @@ import { FermentationSteps } from '../../model/Beer';
 import { ProcedureType } from '../../enums/eProcedureType';
 
 const allowedExecutionModes = [RestExecutionMode.TIMED, RestExecutionMode.CONFIRMATION_HOLD];
-const fixedProcedureTypes = ['Einmaischen', 'Abmaischen', 'Kochen'];
+export const fixedProcedureTypes = ['Einmaischen', 'Abmaischen', 'Kochen'] as const;
+
+export const createDefaultFermentationSteps = (): FermentationSteps[] => [
+    {type: 'Einmaischen', temperature: 0},
+    {type: 'Abmaischen', temperature: 0},
+    {type: 'Kochen', temperature: 0, time: 0},
+];
+
+const normalizeFixedStep = (step: FermentationSteps): FermentationSteps => {
+    if (step.type === 'Einmaischen' || step.type === 'Abmaischen') {
+        return {type: step.type, temperature: step.temperature};
+    }
+    return {...step};
+};
 
 export const decoctionRequiresPreviousRastError = 'Dekoktion benötigt eine vorherige Rast.';
 
@@ -34,15 +47,30 @@ export const normalizeFermentationStep = (step: Partial<FermentationSteps>): Fer
 
 export const numberMashSteps = (steps: FermentationSteps[]): FermentationSteps[] => {
     let rastNumber = 0;
-    return steps.map((step) => {
-        if (["Einmaischen", "Abmaischen", "Kochen"].includes(step.type)) return step;
+    const fixedSteps = new Map<string, FermentationSteps>();
+    const mashSteps = steps.flatMap((step) => {
+        if (fixedProcedureTypes.some((type) => type === step.type)) {
+            if (!fixedSteps.has(step.type)) fixedSteps.set(step.type, normalizeFixedStep(step));
+            return [];
+        }
         const normalized = normalizeFermentationStep(step);
         if (normalized.procedureType === ProcedureType.DECOCTION) {
-            return {...normalized, type: 'Dekoktion'};
+            return [{...normalized, type: 'Dekoktion'}];
         }
         rastNumber += 1;
-        return {...normalized, type: `Rast ${rastNumber}`};
+        return [{...normalized, type: `Rast ${rastNumber}`}];
     });
+
+    createDefaultFermentationSteps().forEach((step) => {
+        if (!fixedSteps.has(step.type)) fixedSteps.set(step.type, step);
+    });
+
+    return [
+        fixedSteps.get('Einmaischen')!,
+        ...mashSteps,
+        fixedSteps.get('Abmaischen')!,
+        fixedSteps.get('Kochen')!,
+    ];
 };
 
 export const isValidExecutionMode = (value: unknown): value is RestExecutionMode => {
@@ -54,7 +82,7 @@ export const getFermentationStepValidationErrors = (steps: FermentationSteps[]):
     let hasPreviousRast = false;
 
     steps.forEach((step, index) => {
-        if (fixedProcedureTypes.includes(step.type)) return;
+        if (fixedProcedureTypes.some((type) => type === step.type)) return;
 
         const normalized = normalizeFermentationStep(step);
         if (normalized.procedureType === ProcedureType.DECOCTION) {


### PR DESCRIPTION
### Motivation

- Fix: Beim Zurücksetzen/Zufügen des Maischeplans verschwanden die festen Prozessschritte `Einmaischen`, `Abmaischen` und `Kochen` oder wurden dupliziert; das darf nicht passieren. 
- Fachlich: `Einmaischen` und `Abmaischen` besitzen keine editierbare Zeit im Rezepteditor und dürfen nicht durch die UI mit künstlichen/Default-Zeiten versehen werden. 

### Description

- Einführung einer zentralen Quelle für fixe/default-Maische-Schritte: `createDefaultFermentationSteps()` und Export von `fixedProcedureTypes` in `src/containers/DatabaseOverview/fermentationDefaults.ts`, plus `normalizeFixedStep()` zur defensiven Behandlung gespeicherter Werte.  
- Normalisierung/Nummerierung (`numberMashSteps`) wurde so geändert, dass die drei festen Schritte genau einmal vorkommen, fehlende fixe Schritte ergänzt und Duplikate eliminiert werden, während RAST/DECOCTION-Logik unverändert bleibt. 
- Formular/Reset-Logik in `src/containers/DatabaseOverview/BeerForm.tsx` angepasst: Initialzustand, `resetForm()` und neues `cancelOrResetForm()` verwenden die zentrale Default-/Normalisierungsfunktion; beim Abbrechen eines bestehenden Rezepts werden gespeicherte fixe Schritte wiederhergestellt. 
- UI/Validierung: Zeit-Eingabefeld und Modus für `Einmaischen`/`Abmaischen` werden als nicht-anwendbar (`–`) angezeigt, nur `temperature` ist editierbar; Validation verlangt Temperatur, aber keine Zeit für diese beiden festen Schritte. 
- Serialisierung: Bei Normalisierung/Erzeugung von `fermentationSteps` werden für Einmaischen/Abmaischen keine künstlichen `time`-Werte mehr erzeugt; Kochen-Handling bleibt unverändert. 
- Docs: Hinweise in `docs/codex/domain-model.md` und `docs/codex/compatibility/cross-repo-contracts.md` ergänzt, dass `time` für Einmaischen/Abmaischen weggelassen wird (Backend-Toleranz ist "Needs verification"). 
- Tests: Neue/erweiterte Unit-Tests hinzugefügt in `src/containers/DatabaseOverview/fermentationDefaults.test.ts` und `src/containers/DatabaseOverview/BeerForm.test.tsx` zur Regression (Default-Schritte, Reset/Cancel, keine Duplikate, UI-Darstellung, Validierung). 

### Testing

- Hinzugefügte Tests: `src/containers/DatabaseOverview/fermentationDefaults.test.ts` und `src/containers/DatabaseOverview/BeerForm.test.tsx` (neue Fälle für Default-Schritte, Normalisierung, Reset/Cancel, Einmaischen/Abmaischen-Verhalten). 
- Lokale Prüfungen: `git diff --check` und `git status --short` liefen erfolgreich und Änderungen wurden als Commit `Fix fixed mash steps on recipe reset` erstellt. 
- Testausführung: Versuche, die Jest/CRA-Tests lokal zu starten (`CI=true npm test ...`, `react-scripts test`) schlugen fehl, weil die Projektabhängigkeiten in der Umgebung nicht installiert bzw. die Registry-Zugriffe fehlschlugen (`npm ci` endete mit HTTP 403); deshalb konnten die neuen Unit-Tests nicht vollständig ausgeführt verifiziert werden. 
- Empfehlung: Nach erfolgreicher `npm ci` (oder in CI) bitte die neuen Tests ausführen, TypeScript-Typecheck, ESLint und einen Frontend-Build prüfen.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8c4a63b8fc832f8a7ea84f0937f877)