### PR TITLE
Add explicit DECOCTION→RAST relationships with stable `stepId`, UI selector and validation

### DIFF
--- a/docs/codex/compatibility/cross-repo-contracts.md
+++ b/docs/codex/compatibility/cross-repo-contracts.md
@@ -50,6 +50,8 @@ Before changing any database/backend field or endpoint, check whether the UI use
 - `Beer.fermentation[].time`
 - `Beer.fermentation[].executionMode`
 - `Beer.fermentation[].procedureType` (`RAST` or `DECOCTION`); missing plus `CONFIRMATION_HOLD` remains a supported legacy decoction
+- `Beer.fermentation[].stepId` (stable UI-generated UUID for configurable mash steps)
+- `Beer.fermentation[].relatedRastId` (DECOCTION reference to a RAST `stepId`)
 - `Beer.wortBoiling.hops[].name`
 - `Beer.wortBoiling.hops[].time`
 - `FinishedBrew.id`
@@ -62,11 +64,15 @@ Before changing any database/backend field or endpoint, check whether the UI use
 
 The recipe editor now omits `time` when serializing the fixed `Einmaischen` and `Abmaischen` steps because those phases have no recipe duration. The TypeScript contract already permits this field to be absent, but database/backend persistence tolerance is **Needs verification**; the UI does not synthesize a compatibility value.
 
+The UI now persists `stepId` and `relatedRastId` in recipe mash steps. Database/backend DTO validation, storage, and read-back of both fields **Needs cross-repository update**; dropping either field would break stable decoction relationships.
+
 ## UI ↔ PI control
 
 The PI control app produces runtime/control data that the UI displays and uses for workflow behavior.
 
 The UI accepts `currentStep.phase: DECOCTION` as a public sequential mash phase and sends new decoction recipe steps with `procedureType: DECOCTION` plus `executionMode: CONFIRMATION_HOLD`. Database persistence of the new optional field is **Needs verification** in the database/backend repository.
+
+Production `Rasten` now retain `stepId`, and decoctions retain `relatedRastId` without copying the referenced temperature. PI/control lookup of `relatedRastId -> RAST.stepId -> temperature` **Needs cross-repository update**.
 
 An explicit `procedureType: RAST` with `executionMode: CONFIRMATION_HOLD` remains a RAST and is not routed to `Confirm/Decoction`. A general confirmation endpoint/status for this combination is not documented by the current control contract and is **Needs verification** in the PI/control repository.
 

--- a/docs/codex/domain-model.md
+++ b/docs/codex/domain-model.md
@@ -6,9 +6,9 @@ Visible/used fields include:
 
 - Identity/display: `id`, `name`, `type`, `color`, `description`, `rating`.
 - Metrics: `alcohol`, `originalwort`, `bitterness`, `mashVolume`, `spargeVolume`, `cookingTime`, `cookingTemperatur`.
-- Production steps: `fermentation: FermentationSteps[]` where `procedureType` classifies mash steps as `RAST` or `DECOCTION`; legacy `CONFIRMATION_HOLD` steps without it normalize to `DECOCTION`. Step `type` remains the display name.
+- Production steps: `fermentation: FermentationSteps[]` where `procedureType` classifies mash steps as `RAST` or `DECOCTION`; freely configurable steps have a UI-generated stable UUID `stepId`, and every decoction references exactly one normal rest through `relatedRastId`. Legacy `CONFIRMATION_HOLD` steps without a procedure type normalize to `DECOCTION`; missing legacy IDs are generated in the UI model and a missing decoction reference is migrated only to the last preceding RAST. Step `type` remains the display name.
 - Recipe-editor mash plans defensively contain exactly one each of the fixed `Einmaischen`, `Abmaischen`, and `Kochen` steps. `Einmaischen` and `Abmaischen` carry temperature but no UI-generated `time`; whether the database/backend accepts an omitted `time` for these persisted fixed steps is **Needs verification**.
-- Recipe-editor validation requires every normalized `DECOCTION` to have an earlier non-fixed `RAST` in the mash-step order. Fixed steps such as `Einmaischen` do not satisfy this requirement; consecutive decoctions reuse the latest earlier RAST and remain valid.
+- Recipe-editor validation requires every normalized `DECOCTION` to have a `relatedRastId` that resolves to the `stepId` of an existing non-fixed `RAST`. Choosing the relationship repositions the decoction directly after its rest (after already-associated decoctions), while retaining stable IDs and relative decoction order.
 - Ingredients: `malts`, `wortBoiling.hops`, `fermentationMaturation.yeast`, optional `additionalIngredients`.
 
 `BeerDTO` differs from `Beer` for submission: `fermentationSteps` instead of `fermentation`, ingredient DTOs, and nullable `wortBoiling`/`fermentationMaturation`.
@@ -21,7 +21,7 @@ The PI/control payload is:
 - `MashupTemperature`: from recipe step `Einmaischen.temperature`.
 - `CookingTemperature`: from `beer.cookingTemperatur`, with UI fallback `99` °C only when the stored cooking temperature is missing or invalid.
 - `CookingTime`: from `beer.cookingTime`.
-- `Rasten`: normalized fermentation steps excluding fixed process step types `Einmaischen`, `Abmaischen`, and `Kochen`. Normal rests are sent with `procedureType: RAST`; decoctions use `procedureType: DECOCTION` and `executionMode: CONFIRMATION_HOLD` and omit both `temperature` and `time`. The control app derives the main-mash target during decoction.
+- `Rasten`: normalized fermentation steps excluding fixed process step types `Einmaischen`, `Abmaischen`, and `Kochen`. Normal rests are sent with `stepId` and `procedureType: RAST`; decoctions use `stepId`, `relatedRastId`, `procedureType: DECOCTION`, and `executionMode: CONFIRMATION_HOLD` and omit both `temperature` and `time`. Control-side resolution of `relatedRastId` to the referenced RAST temperature **Needs cross-repository update**.
 
 Validation rejects missing/non-positive mash-in, mash-out, and rest temperatures and timed rests without `time > 0`; missing/invalid top-level cooking temperature is not rejected and maps to the UI fallback `99` °C.
 

--- a/src/containers/DatabaseOverview/BeerForm.test.tsx
+++ b/src/containers/DatabaseOverview/BeerForm.test.tsx
@@ -237,23 +237,23 @@ describe('BeerForm accordions', () => {
         expect(screen.getAllByRole('button', {name: /Malz löschen/})).toHaveLength(1);
     });
 
-    it('shows and clears the decoction order error immediately after procedure type changes', () => {
+    it('shows and clears the decoction assignment error immediately after procedure type changes', () => {
         renderBeerForm({beerFormState: {fermentationSteps: [
             {type: 'Rast 1', temperature: 65, time: 10, procedureType: ProcedureType.RAST, executionMode: RestExecutionMode.TIMED},
             {type: 'Rast 2', temperature: 68, time: 10, procedureType: ProcedureType.RAST, executionMode: RestExecutionMode.TIMED},
         ]}});
         fireEvent.click(screen.getByRole('button', {name: /Maischeplan/}));
 
-        fireEvent.change(screen.getByLabelText('Typ 1'), {target: {value: ProcedureType.DECOCTION}});
-        expect(screen.getByText('Dekoktion benötigt eine vorherige Rast.')).toBeInTheDocument();
-        expect(screen.getByLabelText('Typ 1')).toHaveAttribute('aria-invalid', 'true');
+        fireEvent.change(screen.getByLabelText('Typ 2'), {target: {value: ProcedureType.DECOCTION}});
+        expect(screen.getByText('Bitte ordne der Dekoktion eine Rast zu.')).toBeInTheDocument();
+        expect(screen.getByLabelText('Zugehörige Rast 2')).toHaveAttribute('aria-invalid', 'true');
 
-        fireEvent.change(screen.getByLabelText('Typ 1'), {target: {value: ProcedureType.RAST}});
-        expect(screen.queryByText('Dekoktion benötigt eine vorherige Rast.')).not.toBeInTheDocument();
-        expect(screen.getByLabelText('Typ 1')).toHaveAttribute('aria-invalid', 'false');
+        fireEvent.change(screen.getByLabelText('Typ 2'), {target: {value: ProcedureType.RAST}});
+        expect(screen.queryByText('Bitte ordne der Dekoktion eine Rast zu.')).not.toBeInTheDocument();
+        expect(screen.getByLabelText('Typ 2')).toHaveAttribute('aria-invalid', 'false');
     });
 
-    it('blocks saving when a decoction has no previous rast', () => {
+    it('blocks saving when a decoction has no assigned rast', () => {
         const {props} = renderBeerForm({beerFormState: {fermentationSteps: [
             {type: 'Dekoktion', procedureType: ProcedureType.DECOCTION, executionMode: RestExecutionMode.CONFIRMATION_HOLD},
             {type: 'Rast 1', temperature: 65, time: 10, procedureType: ProcedureType.RAST, executionMode: RestExecutionMode.TIMED},
@@ -262,7 +262,7 @@ describe('BeerForm accordions', () => {
 
         fireEvent.click(screen.getByRole('button', {name: /Rezept speichern/}));
 
-        expect(screen.getByText(/Bitte prüfe den Maischeplan: Dekoktion benötigt eine vorherige Rast/)).toBeInTheDocument();
+        expect(screen.getByText(/Bitte prüfe den Maischeplan: Bitte ordne der Dekoktion eine Rast zu/)).toBeInTheDocument();
         expect(props.onSubmitBeer).not.toHaveBeenCalled();
     });
 });

--- a/src/containers/DatabaseOverview/BeerForm.tsx
+++ b/src/containers/DatabaseOverview/BeerForm.tsx
@@ -4,7 +4,7 @@ import {AdditionalIngredientDTO, BeerDTO, HopDTO, MaltDTO, YeastDTO} from "../..
 import { HopUsage } from "../../enums/eHopUsage";
 import { HopTimeUnit } from "../../enums/eHopTimeUnit";
 import { normalizeHopDto, updateHopUsage, validateHopDto } from "./hopDefaults";
-import { createDefaultFermentationSteps, decoctionRequiresPreviousRastError, fixedProcedureTypes, getFermentationStepValidationErrors, isValidExecutionMode, normalizeFermentationStep, numberMashSteps } from "./fermentationDefaults";
+import { createDefaultFermentationSteps, createMashStepId, decoctionRequiresRastError, fixedProcedureTypes, getFermentationStepValidationErrors, isValidExecutionMode, normalizeFermentationStep, normalizeMashPlan, numberMashSteps, positionDecoctionAfterRast } from "./fermentationDefaults";
 import { ProcedureType } from "../../enums/eProcedureType";
 import {isEqual} from "lodash";
 
@@ -115,7 +115,7 @@ export class BeerForm extends React.Component<BeerFormProps, BeerFormState> {
 
         // Wenn ein gespeicherter Formularstatus existiert, verwenden wir diesen, ansonsten den Standardstatus.
         const fermentationSteps = props.beerFormState?.fermentationSteps
-            ? numberMashSteps(props.beerFormState.fermentationSteps)
+            ? normalizeMashPlan(props.beerFormState.fermentationSteps)
             : defaultState.fermentationSteps;
         this.state = {
             ...defaultState,
@@ -168,7 +168,7 @@ export class BeerForm extends React.Component<BeerFormProps, BeerFormState> {
                 cookingTime: importedBeer.cookingTime || 0,
                 cookingTemperatur: importedBeer.cookingTemperatur || 0,
                 // Importierte Rasten werden defensiv normalisiert (Altformat ohne executionMode => TIMED).
-                fermentationSteps: numberMashSteps(importedBeer.fermentation || []),
+                fermentationSteps: normalizeMashPlan(importedBeer.fermentation || []),
                 maltsDTO: importedBeer.malts ? importedBeer.malts.map(m => ({ id: m.id, name: m.name, quantity: m.quantity })) : [],
                 // Altrezepte ohne usage/timeUnit bleiben kompatibel und werden auf BOIL/MINUTES normiert.
                 hopsDTO: importedBeer.wortBoiling && importedBeer.wortBoiling.hops ? importedBeer.wortBoiling.hops.map(aHop => normalizeHopDto(aHop)) : [],
@@ -192,16 +192,26 @@ export class BeerForm extends React.Component<BeerFormProps, BeerFormState> {
     }
 
     handleFermentationStepChange = (value: string, name: string, index: number) => {
+       const currentStep = this.state.fermentationSteps[index];
+       if (name === 'procedureType' && value === ProcedureType.DECOCTION && currentStep.stepId
+           && this.state.fermentationSteps.some((step) => step.procedureType === ProcedureType.DECOCTION && step.relatedRastId === currentStep.stepId)) {
+           this.openValidationDialog('Dieser Rast sind noch Dekoktionen zugeordnet. Bitte ändere zuerst deren Zuordnung.');
+           return;
+       }
        this.setState((prevState) => {
           const fermentationSteps = [...prevState.fermentationSteps];
           const step = fermentationSteps[index];
           if (name === "procedureType") {
               if (value === ProcedureType.DECOCTION) {
-                  fermentationSteps[index] = {type: 'Dekoktion', procedureType: ProcedureType.DECOCTION, executionMode: RestExecutionMode.CONFIRMATION_HOLD};
+                  fermentationSteps[index] = {stepId: step.stepId || createMashStepId(), type: 'Dekoktion', procedureType: ProcedureType.DECOCTION, executionMode: RestExecutionMode.CONFIRMATION_HOLD};
               } else {
-                  fermentationSteps[index] = {type: step.type, procedureType: ProcedureType.RAST, executionMode: RestExecutionMode.TIMED, temperature: 1, time: 1};
+                  fermentationSteps[index] = {stepId: step.stepId || createMashStepId(), type: step.type, procedureType: ProcedureType.RAST, executionMode: RestExecutionMode.TIMED, temperature: 1, time: 1};
               }
               return {fermentationSteps: numberMashSteps(fermentationSteps)};
+          }
+          if (name === 'relatedRastId') {
+              step.relatedRastId = value || undefined;
+              return {fermentationSteps: positionDecoctionAfterRast(fermentationSteps, step.stepId!)};
           }
           if (name === "executionMode") {
               step.executionMode = value as RestExecutionMode;
@@ -474,7 +484,7 @@ export class BeerForm extends React.Component<BeerFormProps, BeerFormState> {
                 expandedSections: {...prevState.expandedSections, mash: true},
             }));
             this.openValidationDialog(Object.keys(orderErrors).length > 0
-                ? `Bitte prüfe den Maischeplan: ${decoctionRequiresPreviousRastError}`
+                ? `Bitte prüfe den Maischeplan: ${decoctionRequiresRastError}`
                 : 'Bitte prüfe den Maischeplan: Zeitgesteuerte Rasten benötigen Zeit > 0, Halte-Rasten nur Temperatur.');
             return;
         }
@@ -619,7 +629,7 @@ export class BeerForm extends React.Component<BeerFormProps, BeerFormState> {
             spargeVolume: selectedBeer.spargeVolume || 0,
             cookingTime: selectedBeer.cookingTime || 0,
             cookingTemperatur: selectedBeer.cookingTemperatur || 0,
-            fermentationSteps: numberMashSteps(selectedBeer.fermentation || []),
+            fermentationSteps: normalizeMashPlan(selectedBeer.fermentation || []),
             maltsDTO: selectedBeer.malts.map((malt) => ({id: malt.id, name: malt.name, quantity: malt.quantity})),
             hopsDTO: selectedBeer.wortBoiling?.hops.map((hop) => normalizeHopDto(hop)) || [],
             yeastsDTO: selectedBeer.fermentationMaturation?.yeast.map((yeast) => ({id: yeast.id, name: yeast.name, quantity: yeast.quantity})) || [],
@@ -637,7 +647,7 @@ export class BeerForm extends React.Component<BeerFormProps, BeerFormState> {
             return {
                 fermentationSteps: [
                     ...prevState.fermentationSteps,
-                    { type: `Rast ${rastCount}`, temperature: 0, time: 1, executionMode: RestExecutionMode.TIMED, procedureType: ProcedureType.RAST }
+                    { stepId: createMashStepId(), type: `Rast ${rastCount}`, temperature: 0, time: 1, executionMode: RestExecutionMode.TIMED, procedureType: ProcedureType.RAST }
                 ],
             };
         });
@@ -675,6 +685,12 @@ export class BeerForm extends React.Component<BeerFormProps, BeerFormState> {
     }
 
     removeFermentationStep = (index: number) => {
+        const step = this.state.fermentationSteps[index];
+        if (step.stepId && step.procedureType === ProcedureType.RAST
+            && this.state.fermentationSteps.some((candidate) => candidate.procedureType === ProcedureType.DECOCTION && candidate.relatedRastId === step.stepId)) {
+            this.openValidationDialog('Dieser Rast sind noch Dekoktionen zugeordnet. Bitte ordne diese zuerst einer anderen Rast zu oder lösche sie.');
+            return;
+        }
         this.setState((prevState) => {
             const fermentationSteps = [...prevState.fermentationSteps];
             fermentationSteps.splice(index, 1);
@@ -738,7 +754,7 @@ export class BeerForm extends React.Component<BeerFormProps, BeerFormState> {
                 spargeVolume: selectedBeer.spargeVolume || 0,
                 cookingTime: selectedBeer.cookingTime || 0,
                 cookingTemperatur: selectedBeer.cookingTemperatur || 0,
-                fermentationSteps: numberMashSteps(selectedBeer.fermentation || []),
+                fermentationSteps: normalizeMashPlan(selectedBeer.fermentation || []),
                 maltsDTO: selectedBeer.malts ? selectedBeer.malts.map(m => ({ id: m.id, name: m.name, quantity: m.quantity })) : [],
                 // Bestehende Rezepte ohne neue Felder werden im UI als Kochhopfen in Minuten dargestellt.
                 hopsDTO: selectedBeer.wortBoiling && selectedBeer.wortBoiling.hops ? selectedBeer.wortBoiling.hops.map(aHop => normalizeHopDto(aHop)) : [],
@@ -848,15 +864,18 @@ export class BeerForm extends React.Component<BeerFormProps, BeerFormState> {
             <>
                 <div className="table-wrapper">
                     <table className="ingredient-table">
-                        <thead><tr><th>Typ</th><th>Modus</th><th>Temp (°C)</th><th>Zeit (min)</th><th className="action-column">Aktion</th></tr></thead>
+                        <thead><tr><th>Typ</th><th>Zugehörige Rast</th><th>Modus</th><th>Temp (°C)</th><th>Zeit (min)</th><th className="action-column">Aktion</th></tr></thead>
                         <tbody>{fermentationSteps?.map((step, index) => {
                             const isFixed = this.fixedTypes.includes(step.type);
                             const executionMode = this.getExecutionMode(step);
                             const procedureType = normalizeFermentationStep(step).procedureType;
                             const procedureTypeErrorKey = `fermentationSteps.${index}.procedureType`;
+                            const relatedRastErrorKey = `fermentationSteps.${index}.relatedRastId`;
+                            const rastOptions = fermentationSteps.filter((candidate) => !this.fixedTypes.includes(candidate.type) && normalizeFermentationStep(candidate).procedureType === ProcedureType.RAST);
                             const hasEditableTime = step.type === 'Kochen' || !isFixed;
-                            return <tr key={index} className={this.state.validationErrors[procedureTypeErrorKey] ? 'validation-error-row' : ''}>
+                            return <tr key={step.stepId || step.type} className={this.state.validationErrors[procedureTypeErrorKey] || this.state.validationErrors[relatedRastErrorKey] ? 'validation-error-row' : ''}>
                                 <td>{isFixed ? <span className="readonly-table-value">{step.type}</span> : <><select aria-label={`Typ ${index + 1}`} aria-invalid={Boolean(this.state.validationErrors[procedureTypeErrorKey])} name="procedureType" value={procedureType} onChange={(e) => this.handleFermentationStepChange(e.target.value, e.target.name, index)}><option value={ProcedureType.RAST}>{step.type}</option><option value={ProcedureType.DECOCTION}>Dekoktion</option></select>{this.renderFieldError(procedureTypeErrorKey)}</>}</td>
+                                <td>{procedureType === ProcedureType.DECOCTION ? <><select aria-label={`Zugehörige Rast ${index + 1}`} aria-invalid={Boolean(this.state.validationErrors[relatedRastErrorKey])} name="relatedRastId" value={step.relatedRastId || ''} onChange={(e) => this.handleFermentationStepChange(e.target.value, e.target.name, index)}><option value="">Bitte Rast auswählen</option>{rastOptions.map((rast) => <option key={rast.stepId} value={rast.stepId}>{rast.type} – {rast.temperature} °C</option>)}</select>{this.renderFieldError(relatedRastErrorKey)}</> : <span className="muted-table-value">–</span>}</td>
                                 <td>{isFixed ? <span className="muted-table-value">–</span> : <select aria-label={`Modus ${index + 1}`} name="executionMode" value={executionMode} disabled={procedureType === ProcedureType.DECOCTION} onChange={(e) => this.handleFermentationStepChange(e.target.value, e.target.name, index)}><option value={RestExecutionMode.TIMED}>Zeitgesteuert</option><option value={RestExecutionMode.CONFIRMATION_HOLD}>Bis Bestätigung</option></select>}</td>
                                 <td>{procedureType === ProcedureType.DECOCTION ? <span className="muted-table-value">–</span> : <input type="number" name="temperature" value={step.temperature ?? ''} onChange={(e) => this.handleFermentationStepChange(e.target.value, e.target.name, index)} required={true} />}</td>
                                 <td>{hasEditableTime && procedureType !== ProcedureType.DECOCTION && executionMode === RestExecutionMode.TIMED ? <input type="number" name="time" min={isFixed ? 0 : 1} value={step.time ?? ''} onChange={(e) => this.handleFermentationStepChange(e.target.value, e.target.name, index)} required={!isFixed} /> : <span className="muted-table-value">–</span>}</td>

--- a/src/containers/DatabaseOverview/fermentationDefaults.test.ts
+++ b/src/containers/DatabaseOverview/fermentationDefaults.test.ts
@@ -1,5 +1,5 @@
 import { RestExecutionMode } from '../../enums/eRestExecutionMode';
-import { createDefaultFermentationSteps, decoctionRequiresPreviousRastError, getFermentationStepValidationErrors, normalizeFermentationStep, isValidExecutionMode, numberMashSteps } from './fermentationDefaults';
+import { createMashStepId, decoctionRequiresRastError, getFermentationStepValidationErrors, invalidDecoctionRastError, normalizeFermentationStep, isValidExecutionMode, normalizeMashPlan, numberMashSteps, positionDecoctionAfterRast, createDefaultFermentationSteps } from './fermentationDefaults';
 import {ProcedureType} from '../../enums/eProcedureType';
 
 describe('fermentationDefaults', () => {
@@ -43,7 +43,7 @@ describe('fermentationDefaults', () => {
 
     test('decoctions contain no fake recipe temperature or time', () => {
         const step = normalizeFermentationStep({type: 'Alt', temperature: 68, time: 10, procedureType: ProcedureType.DECOCTION});
-        expect(step).toEqual({type: 'Alt', procedureType: ProcedureType.DECOCTION, executionMode: RestExecutionMode.CONFIRMATION_HOLD});
+        expect(step).toEqual({stepId: undefined, relatedRastId: undefined, type: 'Alt', procedureType: ProcedureType.DECOCTION, executionMode: RestExecutionMode.CONFIRMATION_HOLD});
     });
 
     test('numbers only RAST steps', () => {
@@ -84,35 +84,69 @@ describe('fermentationDefaults', () => {
         expect(twice.filter((step) => step.type === 'Abmaischen')).toHaveLength(1);
         expect(twice.filter((step) => step.type === 'Kochen')).toHaveLength(1);
     });
+
+    test('creates stable UUIDs and migrates a legacy decoction to the preceding rast', () => {
+        const once = normalizeMashPlan([
+            {type: 'Rast', temperature: 63, time: 20},
+            {type: 'Dekoktion', executionMode: RestExecutionMode.CONFIRMATION_HOLD},
+        ]);
+        const configurable = once.filter((step) => step.stepId);
+        expect(configurable.every((step) => step.stepId).valueOf()).toBe(true);
+        expect(configurable[1].relatedRastId).toBe(configurable[0].stepId);
+        const twice = numberMashSteps(once);
+        expect(twice.filter((step) => step.stepId).map((step) => step.stepId)).toEqual(configurable.map((step) => step.stepId));
+        expect(createMashStepId()).toMatch(/^[0-9a-f-]{36}$/);
+    });
+
+    test('does not invent a legacy relationship when decoction precedes every rast', () => {
+        const normalized = normalizeMashPlan([
+            {type: 'Dekoktion', executionMode: RestExecutionMode.CONFIRMATION_HOLD},
+            {type: 'Rast', temperature: 63, time: 20},
+        ]);
+        expect(normalized.find((step) => step.procedureType === ProcedureType.DECOCTION)?.relatedRastId).toBeUndefined();
+    });
+
+    test('positions reassigned and multiple decoctions after their rast in stable order', () => {
+        const [a, b, c, decoctionA, decoctionB] = ['a', 'b', 'c', 'da', 'db'].map((stepId, index) => ({
+            stepId, type: index < 3 ? `Rast ${index + 1}` : 'Dekoktion', temperature: index < 3 ? 60 + index : undefined,
+            procedureType: index < 3 ? ProcedureType.RAST : ProcedureType.DECOCTION,
+            relatedRastId: index < 3 ? undefined : 'a',
+        } as any));
+        let positioned = positionDecoctionAfterRast([a, b, c, decoctionA, decoctionB], 'da');
+        positioned = positionDecoctionAfterRast(positioned, 'db');
+        expect(positioned.filter((step) => step.stepId).map((step) => step.stepId)).toEqual(['a', 'da', 'db', 'b', 'c']);
+        positioned = positioned.map((step) => step.stepId === 'da' ? {...step, relatedRastId: 'c'} : step);
+        expect(positionDecoctionAfterRast(positioned, 'da').filter((step) => step.stepId).map((step) => step.stepId)).toEqual(['a', 'db', 'b', 'c', 'da']);
+    });
 });
 
 describe('getFermentationStepValidationErrors', () => {
-    const rast = (executionMode: RestExecutionMode = RestExecutionMode.TIMED) => ({
+    const rast = (stepId = 'rast-id', executionMode: RestExecutionMode = RestExecutionMode.TIMED) => ({
         type: 'Rast', temperature: 65, time: executionMode === RestExecutionMode.TIMED ? 10 : undefined,
-        procedureType: ProcedureType.RAST, executionMode,
+        stepId, procedureType: ProcedureType.RAST, executionMode,
     });
-    const decoction = () => ({type: 'Dekoktion', procedureType: ProcedureType.DECOCTION, executionMode: RestExecutionMode.CONFIRMATION_HOLD});
+    const decoction = (relatedRastId?: string) => ({stepId: 'decoction-id', relatedRastId, type: 'Dekoktion', procedureType: ProcedureType.DECOCTION, executionMode: RestExecutionMode.CONFIRMATION_HOLD});
 
     test.each([
-        ['decoction before a rast', [decoction(), rast()], 0],
-        ['fixed mash-in before decoction', [{type: 'Einmaischen', temperature: 55}, decoction(), rast()], 1],
+        ['decoction without an assignment', [decoction(), rast()], 0],
+        ['fixed mash-in before unassigned decoction', [{type: 'Einmaischen', temperature: 55}, decoction(), rast()], 1],
     ])('rejects %s', (_name, steps, invalidIndex) => {
         expect(getFermentationStepValidationErrors(steps as any)).toEqual({
-            [`fermentationSteps.${invalidIndex}.procedureType`]: decoctionRequiresPreviousRastError,
+            [`fermentationSteps.${invalidIndex}.relatedRastId`]: decoctionRequiresRastError,
         });
     });
 
     test.each([
-        ['rast, decoction, rast', [rast(), decoction(), rast()]],
-        ['multiple decoctions after a rast', [rast(), decoction(), decoction(), rast()]],
-        ['confirmation-hold rast before decoction', [rast(RestExecutionMode.CONFIRMATION_HOLD), decoction()]],
+        ['rast, decoction, rast', [rast(), decoction('rast-id'), rast('other')]],
+        ['multiple decoctions after a rast', [rast(), decoction('rast-id'), {...decoction('rast-id'), stepId: 'decoction-2'}, rast('other')]],
+        ['confirmation-hold rast before decoction', [rast('rast-id', RestExecutionMode.CONFIRMATION_HOLD), decoction('rast-id')]],
     ])('accepts %s', (_name, steps) => {
         expect(getFermentationStepValidationErrors(steps as any)).toEqual({});
     });
 
-    test('normalizes legacy confirmation-hold steps before checking their order', () => {
-        const legacyDecoction = {type: 'Kochmaische', executionMode: RestExecutionMode.CONFIRMATION_HOLD};
-        expect(getFermentationStepValidationErrors([legacyDecoction, rast()] as any)).toHaveProperty('fermentationSteps.0.procedureType');
-        expect(getFermentationStepValidationErrors([rast(), legacyDecoction] as any)).toEqual({});
+    test('rejects a relationship that points to a decoction', () => {
+        expect(getFermentationStepValidationErrors([rast(), decoction('decoction-id')] as any)).toEqual({
+            'fermentationSteps.1.relatedRastId': invalidDecoctionRastError,
+        });
     });
 });

--- a/src/containers/DatabaseOverview/fermentationDefaults.ts
+++ b/src/containers/DatabaseOverview/fermentationDefaults.ts
@@ -18,7 +18,16 @@ const normalizeFixedStep = (step: FermentationSteps): FermentationSteps => {
     return {...step};
 };
 
-export const decoctionRequiresPreviousRastError = 'Dekoktion benötigt eine vorherige Rast.';
+export const decoctionRequiresRastError = 'Bitte ordne der Dekoktion eine Rast zu.';
+export const invalidDecoctionRastError = 'Bitte ordne der Dekoktion eine gültige Rast zu.';
+
+export const createMashStepId = (): string => {
+    if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') return crypto.randomUUID();
+    return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (character) => {
+        const random = Math.floor(Math.random() * 16);
+        return (character === 'x' ? random : (random & 0x3) | 0x8).toString(16);
+    });
+};
 
 export const normalizeFermentationStep = (step: Partial<FermentationSteps>): FermentationSteps => {
     // Altrezepte ohne executionMode bleiben kompatibel und werden als TIMED behandelt.
@@ -30,6 +39,8 @@ export const normalizeFermentationStep = (step: Partial<FermentationSteps>): Fer
 
     if (procedureType === ProcedureType.DECOCTION) {
         return {
+            stepId: step.stepId,
+            relatedRastId: step.relatedRastId,
             type: step.type || 'Dekoktion',
             executionMode: RestExecutionMode.CONFIRMATION_HOLD,
             procedureType,
@@ -37,6 +48,7 @@ export const normalizeFermentationStep = (step: Partial<FermentationSteps>): Fer
     }
 
     return {
+        stepId: step.stepId,
         type: step.type ?? '',
         temperature: step.temperature === undefined || step.temperature === null ? undefined : Number(step.temperature),
         time: step.time,
@@ -54,6 +66,7 @@ export const numberMashSteps = (steps: FermentationSteps[]): FermentationSteps[]
             return [];
         }
         const normalized = normalizeFermentationStep(step);
+        normalized.stepId = normalized.stepId || createMashStepId();
         if (normalized.procedureType === ProcedureType.DECOCTION) {
             return [{...normalized, type: 'Dekoktion'}];
         }
@@ -73,26 +86,57 @@ export const numberMashSteps = (steps: FermentationSteps[]): FermentationSteps[]
     ];
 };
 
+/** Adds stable IDs and migrates only legacy decoctions to the last preceding RAST. */
+export const normalizeMashPlan = (steps: FermentationSteps[]): FermentationSteps[] => {
+    let previousRastId: string | undefined;
+    const normalized = numberMashSteps(steps);
+    return normalized.map((step) => {
+        if (fixedProcedureTypes.some((type) => type === step.type)) return step;
+        if (step.procedureType === ProcedureType.RAST) {
+            previousRastId = step.stepId;
+            return step;
+        }
+        if (step.relatedRastId) return step;
+        return previousRastId ? {...step, relatedRastId: previousRastId} : step;
+    });
+};
+
+export const positionDecoctionAfterRast = (steps: FermentationSteps[], decoctionId: string): FermentationSteps[] => {
+    const movingIndex = steps.findIndex((step) => step.stepId === decoctionId);
+    if (movingIndex < 0) return steps;
+    const moving = steps[movingIndex];
+    if (moving.procedureType !== ProcedureType.DECOCTION || !moving.relatedRastId) return steps;
+    const withoutMoving = steps.filter((_, index) => index !== movingIndex);
+    const rastIndex = withoutMoving.findIndex((step) => step.stepId === moving.relatedRastId && step.procedureType === ProcedureType.RAST);
+    if (rastIndex < 0) return steps;
+    let insertionIndex = rastIndex + 1;
+    while (insertionIndex < withoutMoving.length
+        && withoutMoving[insertionIndex].procedureType === ProcedureType.DECOCTION
+        && withoutMoving[insertionIndex].relatedRastId === moving.relatedRastId) insertionIndex += 1;
+    withoutMoving.splice(insertionIndex, 0, moving);
+    return numberMashSteps(withoutMoving);
+};
+
 export const isValidExecutionMode = (value: unknown): value is RestExecutionMode => {
     return allowedExecutionModes.includes(value as RestExecutionMode);
 };
 
 export const getFermentationStepValidationErrors = (steps: FermentationSteps[]): Record<string, string> => {
     const errors: Record<string, string> = {};
-    let hasPreviousRast = false;
+    const rastIds = new Set(steps
+        .filter((step) => !fixedProcedureTypes.some((type) => type === step.type) && normalizeFermentationStep(step).procedureType === ProcedureType.RAST)
+        .map((step) => step.stepId)
+        .filter((id): id is string => Boolean(id)));
 
     steps.forEach((step, index) => {
         if (fixedProcedureTypes.some((type) => type === step.type)) return;
 
         const normalized = normalizeFermentationStep(step);
         if (normalized.procedureType === ProcedureType.DECOCTION) {
-            if (!hasPreviousRast) {
-                errors[`fermentationSteps.${index}.procedureType`] = decoctionRequiresPreviousRastError;
-            }
+            if (!normalized.relatedRastId) errors[`fermentationSteps.${index}.relatedRastId`] = decoctionRequiresRastError;
+            else if (!rastIds.has(normalized.relatedRastId)) errors[`fermentationSteps.${index}.relatedRastId`] = invalidDecoctionRastError;
             return;
         }
-
-        hasPreviousRast = true;
     });
 
     return errors;

--- a/src/model/Beer.ts
+++ b/src/model/Beer.ts
@@ -3,6 +3,8 @@ import { HopTimeUnit } from '../enums/eHopTimeUnit';
 import { HopUsage } from '../enums/eHopUsage';
 import { ProcedureType } from '../enums/eProcedureType';
 export interface FermentationSteps {
+    stepId?: string;
+    relatedRastId?: string;
     type: string;
     temperature?: number;
     time?: number;

--- a/src/model/BeerDTO.ts
+++ b/src/model/BeerDTO.ts
@@ -5,6 +5,8 @@ import { HopUsage } from '../enums/eHopUsage';
 import {AdditionalIngredientPhase, AdditionalIngredientTimeUnit} from "./Beer";
 import { ProcedureType } from '../enums/eProcedureType';
 export interface FermentationStepsDTO {
+    stepId?: string;
+    relatedRastId?: string;
     type: string;
     temperature?: number;
     time?: number;

--- a/src/utils/productionRecipe.test.ts
+++ b/src/utils/productionRecipe.test.ts
@@ -78,16 +78,18 @@ describe('productionRecipe mapping', () => {
   it('keeps CONFIRMATION_HOLD steps in Rasten without requiring time', () => {
     const result = mapBeerToBrewingData(makeBeer({ fermentation: [
       { type: 'Einmaischen', temperature: 52, time: 0 },
+      { type: 'Rast 1', temperature: 64, time: 10 },
       { type: 'Dickmaische führen', temperature: 66, executionMode: RestExecutionMode.CONFIRMATION_HOLD },
       { type: 'Abmaischen', temperature: 78, time: 0 }
     ] }));
 
     expect(result.ok).toBe(true);
     expect(result.brewingData?.Rasten).toEqual([
+      expect.objectContaining({ type: 'Rast 1', procedureType: ProcedureType.RAST }),
       expect.objectContaining({ type: 'Dickmaische führen', executionMode: RestExecutionMode.CONFIRMATION_HOLD })
     ]);
-    expect(result.brewingData?.Rasten[0]).not.toHaveProperty('time');
-    expect(result.brewingData?.Rasten[0]).toMatchObject({
+    expect(result.brewingData?.Rasten[1]).not.toHaveProperty('time');
+    expect(result.brewingData?.Rasten[1]).toMatchObject({
       procedureType: ProcedureType.DECOCTION,
       executionMode: RestExecutionMode.CONFIRMATION_HOLD
     });
@@ -105,14 +107,13 @@ describe('productionRecipe mapping', () => {
 
   it('enforces confirmation hold for a newly classified decoction', () => {
     const result = normalizeFermentationStepsForProduction([
-      {type: '1. Dekoktion', temperature: 67, procedureType: ProcedureType.DECOCTION}
+      {stepId: 'rast-id', type: 'Rast 1', temperature: 64, time: 10, procedureType: ProcedureType.RAST},
+      {stepId: 'decoction-id', relatedRastId: 'rast-id', type: '1. Dekoktion', temperature: 67, procedureType: ProcedureType.DECOCTION}
     ]);
 
-    expect(result.fermentationSteps).toEqual([
-      expect.objectContaining({procedureType: ProcedureType.DECOCTION, executionMode: RestExecutionMode.CONFIRMATION_HOLD})
-    ]);
-    expect(result.fermentationSteps?.[0]).not.toHaveProperty('time');
-    expect(result.fermentationSteps?.[0]).not.toHaveProperty('temperature');
+    expect(result.fermentationSteps?.[1]).toEqual(expect.objectContaining({stepId: 'decoction-id', relatedRastId: 'rast-id', procedureType: ProcedureType.DECOCTION, executionMode: RestExecutionMode.CONFIRMATION_HOLD}));
+    expect(result.fermentationSteps?.[1]).not.toHaveProperty('time');
+    expect(result.fermentationSteps?.[1]).not.toHaveProperty('temperature');
   });
 
   it('does not infer DECOCTION from an explicit confirmation-hold RAST', () => {
@@ -150,15 +151,17 @@ describe('productionRecipe mapping', () => {
     }));
 
     expect(result.ok).toBe(true);
-    expect(result.brewingData).toEqual({
+    expect(result.brewingData).toMatchObject({
       MashupTemperature: 48,
       MashdownTemperature: 78,
       CookingTime: 70,
       CookingTemperature: 100,
       Rasten: [
-        { type: 'Rast1', temperature: 63, time: 40, procedureType: ProcedureType.RAST, executionMode: RestExecutionMode.TIMED },
-        { type: 'Dickmaische', procedureType: ProcedureType.DECOCTION, executionMode: RestExecutionMode.CONFIRMATION_HOLD }
+        expect.objectContaining({ type: 'Rast1', temperature: 63, time: 40, procedureType: ProcedureType.RAST, executionMode: RestExecutionMode.TIMED }),
+        expect.objectContaining({ type: 'Dickmaische', procedureType: ProcedureType.DECOCTION, executionMode: RestExecutionMode.CONFIRMATION_HOLD })
       ]
     });
+    expect(result.brewingData?.Rasten[0].stepId).toBeTruthy();
+    expect(result.brewingData?.Rasten[1].relatedRastId).toBe(result.brewingData?.Rasten[0].stepId);
   });
 });

--- a/src/utils/productionRecipe.ts
+++ b/src/utils/productionRecipe.ts
@@ -2,6 +2,7 @@ import { Beer, FermentationSteps } from '../model/Beer';
 import { BrewingData } from '../model/BrewingData';
 import { RestExecutionMode } from '../enums/eRestExecutionMode';
 import { ProcedureType } from '../enums/eProcedureType';
+import { normalizeMashPlan } from '../containers/DatabaseOverview/fermentationDefaults';
 
 const isValidTemperature = (value: unknown): value is number => typeof value === 'number' && Number.isFinite(value) && value > 0;
 const isValidTimedDuration = (value: unknown): value is number => typeof value === 'number' && Number.isFinite(value) && value > 0;
@@ -17,8 +18,12 @@ export interface ProductionRecipeNormalizationResult {
 export function normalizeFermentationStepsForProduction(steps: FermentationSteps[]): ProductionRecipeNormalizationResult {
   const normalized: FermentationSteps[] = [];
   const fixedProcessStepTypes = new Set(['Einmaischen', 'Abmaischen', 'Kochen']);
+  const mashPlan = normalizeMashPlan(steps ?? []);
+  const rastIds = new Set(mashPlan
+    .filter((step) => !fixedProcessStepTypes.has(step.type) && step.procedureType === ProcedureType.RAST)
+    .map((step) => step.stepId));
 
-  for (const step of steps ?? []) {
+  for (const step of mashPlan) {
     const procedureType = step.procedureType
       ?? (step.executionMode === RestExecutionMode.CONFIRMATION_HOLD ? ProcedureType.DECOCTION : ProcedureType.RAST);
     const executionMode = procedureType === ProcedureType.DECOCTION
@@ -28,6 +33,9 @@ export function normalizeFermentationStepsForProduction(steps: FermentationSteps
     if (fixedProcessStepTypes.has(step.type)) continue;
 
     if (procedureType === ProcedureType.DECOCTION) {
+      if (!step.relatedRastId || !rastIds.has(step.relatedRastId)) {
+        return {ok: false, error: `Dekoktion "${step.type}" benötigt eine gültige zugehörige Rast.`};
+      }
       const {time, temperature, ...decoction} = step;
       normalized.push({...decoction, procedureType, executionMode: RestExecutionMode.CONFIRMATION_HOLD});
       continue;


### PR DESCRIPTION
### Motivation

- Make DECOCTION ownership explicit by referencing a stable RAST identifier instead of relying on list position or temperature. 
- Preserve existing RAST/DECOCTION model and editor UX while adding stable IDs and explicit relationships for correctness and cross-repo contracts. 

### Description

- Added optional `stepId?: string` and `relatedRastId?: string` to `FermentationSteps` and DTOs and generate stable UUIDs in the UI model via `createMashStepId()` (uses `crypto.randomUUID()` when available, otherwise a UUID fallback). 
- Implemented `normalizeMashPlan` and extended `numberMashSteps` to assign stable `stepId`s, migrate legacy DECOCTIONs to the last preceding RAST when possible, and keep legacy-unassignable DECOCTIONs unassigned (invalid). 
- Added `relatedRastId` dropdown in the mash plan UI labelled `Zugehörige Rast` that lists only `procedureType = RAST` steps and stores the selected `rast.stepId` while keeping DECOCTION `temperature`/`time` unavailable. 
- Enforced validation rules: every `DECOCTION` must have a `relatedRastId` that resolves to an existing `RAST.stepId`, otherwise a row-level error is shown and saving is blocked. 
- Implemented automatic repositioning via `positionDecoctionAfterRast(...)` so a DECOCTION is placed directly after its referenced RAST (preserving relative order among multiple DECOCTIONs for the same RAST). 
- Block deletion or `RAST -> DECOCTION` type-change when other DECOCTIONs reference that RAST, with a user-facing message asking to reassign or remove dependent DECOCTIONs first. 
- Preserved behavior on `DECOCTION -> RAST` conversions by removing `relatedRastId`, restoring RAST execution defaults, and retaining the existing `stepId`. 
- Updated production mapping (`mapBeerToBrewingData` / `normalizeFermentationStepsForProduction`) to include `stepId` and `relatedRastId` in `Rasten` and to reject invalid DECOCTION references rather than inventing data. 
- Tests updated/added to exercise stable IDs, legacy migration, validation, automatic repositioning, reassignment logic, multiple DECOCTION ordering, and serialization contract. 
- Files changed (high level): `src/model/Beer.ts`, `src/model/BeerDTO.ts`, `src/containers/DatabaseOverview/fermentationDefaults.ts`, `src/containers/DatabaseOverview/BeerForm.tsx`, `src/utils/productionRecipe.ts`, tests under `src/containers/DatabaseOverview` and `src/utils`. Documentation updated in `docs/codex/domain-model.md` and `docs/codex/compatibility/cross-repo-contracts.md` to mark cross-repo work required. 

### Testing

- `git diff --check` completed successfully with no whitespace errors. 
- Unit tests were updated to cover ID generation, legacy migration, assignment validation, automatic positioning, reassignment, and serialization, but running the test suite in this environment failed due to dependency installation being blocked by the environment (registry HTTP 403), so the new/modified tests could not be executed here. 
- TypeScript typecheck and `npm run build` / `eslint` were attempted but could not be completed because project dependencies were not installed in the environment and registry access was blocked, causing tool failures; therefore typecheck and lint/build results are `Needs local verification` after dependencies are available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8c7ec51844832fbb3ccbcc34b3d7d5)