### PR TITLE
Settings: add manual sound tests (UI, API client, docs, tests)

### DIFF
--- a/docs/codex/compatibility/cross-repo-contracts.md
+++ b/docs/codex/compatibility/cross-repo-contracts.md
@@ -70,6 +70,8 @@ The UI now persists `stepId` and `relatedRastId` in recipe mash steps. Database/
 
 The PI control app produces runtime/control data that the UI displays and uses for workflow behavior.
 
+The Settings UI also consumes the existing `POST /api/audio/test` contract. Its `sound` request field is restricted to the logical values `ALARM`, `WARNING`, `CONFIRMATION`, `REST_FINISHED`, `BREW_FINISHED`, and `SUCCESS`; UI labels do not alter these values and the UI never sends WAV filenames. The routed `/api/audio` ownership and deployment mapping are **Needs verification** outside this repository.
+
 The UI accepts `currentStep.phase: DECOCTION` as a public sequential mash phase and sends new decoction recipe steps with `procedureType: DECOCTION` plus `executionMode: CONFIRMATION_HOLD`. Database persistence of the new optional field is **Needs verification** in the database/backend repository.
 
 Production `Rasten` now retain `stepId`, and decoctions retain `relatedRastId` without copying the referenced temperature. PI/control lookup of `relatedRastId -> RAST.stepId -> temperature` **Needs cross-repository update**.

--- a/docs/codex/interfaces.md
+++ b/docs/codex/interfaces.md
@@ -49,6 +49,10 @@ Base URL: `BaseURL` (`/api/controller`), `CommandsURL` (`/api/controller/Command
 | POST | `next` | Advance process step | `200` |
 | POST | `Confirm/{confirmState}` | Confirm concrete waiting state only (`Iodine`, `Mashup`, `Cooking`, `Boiling`, `Decoction`) | `200`; UI must not send `Confirm/Wait`; PI rejects `Confirm/Wait` with a controlled error |
 
+## Audio REST endpoint
+
+The Settings UI tests the control system's existing logical sounds through `POST /api/audio/test` with JSON `{ "sound": SoundType }`. Supported values are exactly `ALARM`, `WARNING`, `CONFIRMATION`, `REST_FINISHED`, `BREW_FINISHED`, and `SUCCESS`. HTTP 200 returns `{ "success": true, "sound": SoundType }`; invalid input returns HTTP 400 and playback errors return HTTP 500 with `{ "success": false, "error": string }`.
+
 ## Socket.io
 
 - URL is derived from `BaseURL` by replacing leading `http` with `ws`.

--- a/src/containers/Settings/SettingsPage.css
+++ b/src/containers/Settings/SettingsPage.css
@@ -280,6 +280,29 @@
   cursor: pointer;
 }
 
+.sound-list {
+  display: flex;
+  flex-direction: column;
+}
+
+.sound-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.6rem 0;
+  border-top: 1px solid var(--color-input-border);
+}
+
+.sound-label {
+  font-weight: 700;
+}
+
+.sound-test-button {
+  min-width: 9.5rem;
+  padding: 0.5rem 0.75rem;
+}
+
 .settings-primary:disabled,
 .settings-secondary:disabled {
   cursor: not-allowed;

--- a/src/containers/Settings/SettingsPage.test.tsx
+++ b/src/containers/Settings/SettingsPage.test.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { SettingsPage } from './SettingsPage';
+import { AudioRepository } from '../../repositorys/AudioRepository';
+import { SoundType } from '../../enums/eSoundType';
+
+jest.mock('../../repositorys/AudioRepository');
+
+const mockedTestSound = AudioRepository.testSound as jest.MockedFunction<typeof AudioRepository.testSound>;
+
+const renderSettings = () => render(<SettingsPage theme="default" setTheme={jest.fn()} />);
+
+describe('Settings sound tests', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockedTestSound.mockResolvedValue();
+    });
+
+    it('renders all six user-friendly sound labels', () => {
+        renderSettings();
+
+        ['Alarm', 'Warnung', 'Bestätigung', 'Rast beendet', 'Brauvorgang beendet', 'Erfolgreich']
+            .forEach((label) => expect(screen.getByText(label)).toBeInTheDocument());
+    });
+
+    it('passes the selected logical sound values to the repository', async () => {
+        renderSettings();
+
+        fireEvent.click(screen.getByRole('button', { name: 'Alarm testen' }));
+        await waitFor(() => expect(mockedTestSound).toHaveBeenCalledWith(SoundType.ALARM));
+
+        fireEvent.click(screen.getByRole('button', { name: 'Brauvorgang beendet testen' }));
+        await waitFor(() => expect(mockedTestSound).toHaveBeenCalledWith(SoundType.BREW_FINISHED));
+    });
+
+    it('disables every sound button and prevents parallel requests while playing', async () => {
+        let resolveRequest!: () => void;
+        mockedTestSound.mockImplementationOnce(() => new Promise<void>((resolve) => {
+            resolveRequest = resolve;
+        }));
+        renderSettings();
+
+        const alarmButton = screen.getByRole('button', { name: 'Alarm testen' });
+        fireEvent.click(alarmButton);
+        fireEvent.click(screen.getByRole('button', { name: 'Warnung testen' }));
+
+        expect(screen.getAllByRole('button', { name: /testen$/i })).toHaveLength(6);
+        screen.getAllByRole('button', { name: /testen$/i }).forEach((button) => expect(button).toBeDisabled());
+        expect(alarmButton).toHaveTextContent('Wird abgespielt…');
+        expect(mockedTestSound).toHaveBeenCalledTimes(1);
+
+        resolveRequest();
+        await waitFor(() => expect(alarmButton).toBeEnabled());
+    });
+
+    it('shows an error, clears loading, and allows retrying', async () => {
+        mockedTestSound.mockRejectedValueOnce(new Error('playback failed')).mockResolvedValueOnce();
+        renderSettings();
+
+        const warningButton = screen.getByRole('button', { name: 'Warnung testen' });
+        fireEvent.click(warningButton);
+
+        expect(await screen.findByRole('alert')).toHaveTextContent('Sound konnte nicht abgespielt werden.');
+        await waitFor(() => expect(warningButton).toBeEnabled());
+
+        fireEvent.click(warningButton);
+        await waitFor(() => expect(mockedTestSound).toHaveBeenCalledTimes(2));
+    });
+});

--- a/src/containers/Settings/SettingsPage.tsx
+++ b/src/containers/Settings/SettingsPage.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import './SettingsPage.css';
 import { ThemeName } from '../../utils/theme';
 import { PushService, getPermissionState, isPushSupported } from '../../utils/pushService';
+import { AudioRepository } from '../../repositorys/AudioRepository';
+import { SOUND_LABELS, SOUND_TYPES, SoundType } from '../../enums/eSoundType';
 
 interface SettingsPageProps {
     theme: ThemeName;
@@ -18,6 +20,8 @@ interface SettingsPageState {
     pushSubscribed: boolean;
     pushLoading: boolean;
     pushError: string | null;
+    soundPlaying: SoundType | null;
+    soundError: string | null;
 }
 
 export class SettingsPage extends React.Component<SettingsPageProps, SettingsPageState> {
@@ -34,8 +38,12 @@ export class SettingsPage extends React.Component<SettingsPageProps, SettingsPag
             pushSubscribed: false,
             pushLoading: false,
             pushError: null,
+            soundPlaying: null,
+            soundError: null,
         };
     }
+
+    private soundRequestActive = false;
 
     get activeThemeLabel() {
         return this.props.theme === 'dark-alt' ? 'Dunkles Theme' : 'Helles Theme';
@@ -132,6 +140,23 @@ export class SettingsPage extends React.Component<SettingsPageProps, SettingsPag
         });
     };
 
+    handleSoundTest = async (sound: SoundType) => {
+        if (this.soundRequestActive) {
+            return;
+        }
+
+        this.soundRequestActive = true;
+        this.setState({ soundPlaying: sound, soundError: null });
+        try {
+            await AudioRepository.testSound(sound);
+        } catch (error) {
+            this.setState({ soundError: 'Sound konnte nicht abgespielt werden.' });
+        } finally {
+            this.soundRequestActive = false;
+            this.setState({ soundPlaying: null });
+        }
+    };
+
     handleSave = () => {
         this.setState({ statusMessage: 'Einstellungen gespeichert.' });
     };
@@ -150,7 +175,7 @@ export class SettingsPage extends React.Component<SettingsPageProps, SettingsPag
 
     render() {
         const { theme } = this.props;
-        const { autoConnect, notificationsEnabled, temperatureUnit, statusMessage, pushSupported, pushSubscribed, pushLoading, pushError, pushPermission } = this.state;
+        const { autoConnect, notificationsEnabled, temperatureUnit, statusMessage, pushSupported, pushSubscribed, pushLoading, pushError, pushPermission, soundPlaying, soundError } = this.state;
 
         return (
             <div className="settings-page">
@@ -223,6 +248,32 @@ export class SettingsPage extends React.Component<SettingsPageProps, SettingsPag
                                 />
                                 <label htmlFor="notifications">{notificationsEnabled ? 'Aktiviert' : 'Deaktiviert'}</label>
                             </div>
+                        </div>
+                    </section>
+
+                    <section className="settings-card">
+                        <div className="settings-card-header">
+                            <h3>Sounds</h3>
+                            <p>Hier können die Signaltöne der Brausteuerung getestet werden.</p>
+                        </div>
+                        {soundError && (
+                            <p className="settings-error" role="alert">{soundError}</p>
+                        )}
+                        <div className="sound-list">
+                            {SOUND_TYPES.map((sound) => (
+                                <div className="sound-row" key={sound}>
+                                    <span className="sound-label">{SOUND_LABELS[sound]}</span>
+                                    <button
+                                        className="settings-secondary sound-test-button"
+                                        type="button"
+                                        onClick={() => this.handleSoundTest(sound)}
+                                        disabled={soundPlaying !== null}
+                                        aria-label={`${SOUND_LABELS[sound]} testen`}
+                                    >
+                                        {soundPlaying === sound ? 'Wird abgespielt…' : '▶ Testen'}
+                                    </button>
+                                </div>
+                            ))}
                         </div>
                     </section>
 

--- a/src/enums/eSoundType.ts
+++ b/src/enums/eSoundType.ts
@@ -1,0 +1,19 @@
+export enum SoundType {
+    ALARM = 'ALARM',
+    WARNING = 'WARNING',
+    CONFIRMATION = 'CONFIRMATION',
+    REST_FINISHED = 'REST_FINISHED',
+    BREW_FINISHED = 'BREW_FINISHED',
+    SUCCESS = 'SUCCESS',
+}
+
+export const SOUND_LABELS: Record<SoundType, string> = {
+    [SoundType.ALARM]: 'Alarm',
+    [SoundType.WARNING]: 'Warnung',
+    [SoundType.CONFIRMATION]: 'Bestätigung',
+    [SoundType.REST_FINISHED]: 'Rast beendet',
+    [SoundType.BREW_FINISHED]: 'Brauvorgang beendet',
+    [SoundType.SUCCESS]: 'Erfolgreich',
+};
+
+export const SOUND_TYPES: SoundType[] = Object.values(SoundType);

--- a/src/global.ts
+++ b/src/global.ts
@@ -2,3 +2,4 @@ export const DatabaseURL = "/api/database";
 export const BaseURL = "/api/controller";
 export const CommandsURL = `${BaseURL}/Command/`;
 export const ConfirmURL = `${BaseURL}/Confirm/`;
+export const AudioURL = "/api/audio";

--- a/src/repositorys/AudioRepository.test.ts
+++ b/src/repositorys/AudioRepository.test.ts
@@ -1,0 +1,34 @@
+import axios from 'axios';
+import { AudioRepository } from './AudioRepository';
+import { SoundType } from '../enums/eSoundType';
+
+jest.mock('axios');
+
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+describe('AudioRepository', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockedAxios.post.mockResolvedValue({ data: { success: true, sound: SoundType.ALARM } } as any);
+    });
+
+    it.each([
+        [SoundType.ALARM, 'ALARM'],
+        [SoundType.BREW_FINISHED, 'BREW_FINISHED'],
+    ])('posts %s as a logical sound value', async (sound, expectedSound) => {
+        await AudioRepository.testSound(sound);
+
+        expect(mockedAxios.post).toHaveBeenCalledWith(
+            '/api/audio/test',
+            { sound: expectedSound },
+        );
+    });
+
+    it('rejects an unsuccessful response', async () => {
+        mockedAxios.post.mockResolvedValueOnce({
+            data: { success: false, error: 'Sound playback failed' },
+        } as any);
+
+        await expect(AudioRepository.testSound(SoundType.WARNING)).rejects.toThrow('Sound playback failed');
+    });
+});

--- a/src/repositorys/AudioRepository.ts
+++ b/src/repositorys/AudioRepository.ts
@@ -1,0 +1,18 @@
+import axios from 'axios';
+import { AudioURL } from '../global';
+import { SoundType } from '../enums/eSoundType';
+
+interface SoundTestResponse {
+    success: boolean;
+    sound?: SoundType;
+    error?: string;
+}
+
+export class AudioRepository {
+    static async testSound(sound: SoundType): Promise<void> {
+        const response = await axios.post<SoundTestResponse>(`${AudioURL}/test`, { sound });
+        if (!response.data.success) {
+            throw new Error(response.data.error || 'Sound playback failed');
+        }
+    }
+}


### PR DESCRIPTION
### Motivation

- Provide a simple way to manually test the six logical controller sounds from the existing Settings page using the already documented `POST /api/audio/test` contract. 
- Reuse the project's API/repository pattern and existing Settings layout and error UI instead of introducing new architectures or notification systems.

### Description

- Added a central `SoundType` enum and German labels in `src/enums/eSoundType.ts` and a `SOUND_TYPES` list to drive the UI. 
- Implemented `AudioRepository.testSound(sound: SoundType)` in `src/repositorys/AudioRepository.ts` and added `AudioURL` to `src/global.ts` to centralize the API call to `POST /api/audio/test`.
- Extended the Settings page UI (`src/containers/Settings/SettingsPage.tsx` and CSS) with a new `Sounds` card showing the six user-friendly labels and a per-sound `▶ Testen` button, including a simple global request lock so no parallel sound tests can be started and the active button shows a loading label `Wird abgespielt…`.
- Reused existing inline error styling: on API failure the UI shows the message `Sound konnte nicht abgespielt werden.` and the state is reset to allow retry.
- Added unit tests: repository tests in `src/repositorys/AudioRepository.test.ts` (payload and error handling) and component tests in `src/containers/Settings/SettingsPage.test.tsx` (rendering of all labels, API call payloads, loading/disable behavior, and error/retry flow).
- Updated documentation to record the UI usage of the audio endpoint in `docs/codex/interfaces.md` and `docs/codex/compatibility/cross-repo-contracts.md` and to mark routing/ownership as `Needs verification`.

### Testing

- Added Jest/React Testing Library tests in `src/containers/Settings/SettingsPage.test.tsx` and `src/repositorys/AudioRepository.test.ts` that mock the API and verify rendering, request payloads (`{ sound: "ALARM" }` and `{ sound: "BREW_FINISHED" }`), loading/disable behavior, and failure handling. 
- Attempted to run the tests with `CI=true npx react-scripts test --watchAll=false --runInBand src/containers/Settings/SettingsPage.test.tsx src/repositorys/AudioRepository.test.ts`, but test execution failed because the environment could not resolve/install `react-scripts` (npm registry/permission returned HTTP 403), so the new tests were not executed here.
- Created and committed the changes locally; repository state is clean and the new test files are present so CI or a developer environment with node dependencies installed can run the tests (`npm test` / `npx react-scripts test`) successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8c9c7873b4832f9dfa1164919369c7)