### PR TITLE
Render control confirmations inline and add InlineProcessNotice with central confirmation view model

### DIFF
--- a/docs/codex/data-flow.md
+++ b/docs/codex/data-flow.md
@@ -50,7 +50,7 @@ Needs verification: backend ordering of `GET beers`, because the UI treats the l
 
 ## Confirm/waiting flow
 
-- Normalized status fields `process.state`, `currentStep.mode`, `waiting.waitingFor`, and `waiting.canConfirm` determine whether a modal appears.
+- Normalized status fields `process.state`, `currentStep.mode`, `waiting.waitingFor`, and `waiting.canConfirm` feed a central confirmation view model. On desktop it is rendered inline in `Aktueller Schritt`; on mobile the same model provides the inline action and confirm button. Regular control confirmations no longer open a modal.
 - UI maps only concrete waiting reasons to confirm endpoints:
   - `IODINE_TEST` -> `Confirm/Iodine`
   - `MASHING_IN_CONFIRMATION` -> `Confirm/Mashup`
@@ -59,11 +59,12 @@ Needs verification: backend ordering of `GET beers`, because the UI treats the l
   - `COOKING_CONFIRMATION` -> `Confirm/Cooking`
   - `DECOCTION_CONFIRMATION` -> `Confirm/Decoction`
   - `USER_CONFIRMATION`, `NONE`, or unknown waiting reasons do not send a confirm command. `Wait` may be displayed as a status, but the UI must not call `Confirm/Wait`.
+- `USER_CONFIRMATION` and unknown waiting reasons remain visibly marked as waiting inline but do not render a confirmation button.
 
 ## Hop reminder flow
 
 - Production view computes reminder times from selected recipe hops as `(selectedBeer.cookingTime - hop.time) * 60`.
-- During `COOKING`, it compares `brewingStatus.currentStep.elapsedTime` to those second offsets and shows a modal with the hop name once per offset.
+- During `COOKING`, it compares `brewingStatus.currentStep.elapsedTime` to those second offsets and shows a non-blocking inline reminder with the hop name once per offset. Control waiting confirmations have priority over this reminder.
 - This means `hop.time` is assumed to be minutes before the end of boil, and `currentStep.elapsedTime` is assumed to be seconds elapsed in the cooking phase. Needs verification.
 
 ## Finished-brew completion flow

--- a/docs/codex/domain-model.md
+++ b/docs/codex/domain-model.md
@@ -40,7 +40,7 @@ Runtime status is normalized into process state, current step, temperature, hard
 - `currentStep.duration`, `currentStep.elapsedTime`, and `currentStep.remainingTime`: duration/progress/countdown values in seconds. `currentTime` is preserved in collected status data but must not be used as a duration/countdown unless the PI control contract changes.
 - `temperature.current`/`target`: gauges and mobile display.
 - `hardware.heater`/`agitator`: flames, water-control agitator visual, mobile agitator display.
-- `waiting.waitingFor`/`canConfirm`: modal content and confirm endpoint mapping. `MASHING_OUT_CONFIRMATION` uses the existing `Confirm/Mashup` control confirmation value.
+- `waiting.waitingFor`/`canConfirm`: central inline confirmation content and confirm endpoint mapping for desktop and mobile. `MASHING_OUT_CONFIRMATION` uses the existing `Confirm/Mashup` control confirmation value. Generic or unknown waiting values are displayed without an action button.
 
 ## Finished brew (`FinishedBrew`)
 

--- a/docs/codex/known-risks.md
+++ b/docs/codex/known-risks.md
@@ -17,6 +17,7 @@
 ## PI control confirmation and timing contracts
 
 - `Wait` is a control status, not a confirmation command. The UI must not call `POST /Confirm/Wait`; only concrete confirmation endpoints (`Iodine`, `Mashup`, `Cooking`, `Boiling`, `Decoction`) are valid.
+- Regular process confirmations are inline and therefore cannot be triggered by closing a modal. The shared `ModalDialog` still treats backdrop/Escape `onClose` as `onConfirm` when no cancel button is configured; this remains relevant to the finish workflow and other non-process-confirmation dialogs and must not be changed globally without auditing every consumer.
 - `currentTime` is not a UI duration/countdown/progress field. UI progress should use explicit seconds-based fields such as `elapsedTime`, `currentStep.duration`, and `currentStep.remainingTime`.
 - `WaterStatus` is expected as an object `{ filledLiters, targetLiters, openClose }`; keep defensive defaults for null, undefined, or failed HTTP responses to avoid broken rendering.
 

--- a/src/containers/Mobile/MobileStatusView/MobileProductionView.connect.ts
+++ b/src/containers/Mobile/MobileStatusView/MobileProductionView.connect.ts
@@ -1,6 +1,7 @@
 import { connect } from 'react-redux';
 import { ProductionActions } from '../../../actions/actions';
 import {MobileProductionView} from './MobileProductionView';
+import {ConfirmStates} from '../../../enums/eConfirmStates';
 
 const mapStateToProps = (state: any) => ({
     temperature: state.productionReducer.temperature,
@@ -10,7 +11,8 @@ const mapStateToProps = (state: any) => ({
 
 const mapDispatchToProps = (dispatch: any) => ({
     startPolling: () => dispatch(ProductionActions.startPolling()),
-    stopPolling: () => dispatch(ProductionActions.stopPolling())
+    stopPolling: () => dispatch(ProductionActions.stopPolling()),
+    confirm: (confirmState: ConfirmStates) => dispatch(ProductionActions.confirm(confirmState))
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(MobileProductionView);

--- a/src/containers/Mobile/MobileStatusView/MobileProductionView.css
+++ b/src/containers/Mobile/MobileStatusView/MobileProductionView.css
@@ -142,6 +142,17 @@
   line-height: 1.5;
 }
 
+.mobile-confirmation-wrapper {
+  width: 100%;
+}
+
+.mobile-confirmation-wrapper .inline-process-notice {
+  background: var(--color-white);
+  color: var(--color-dark-bg);
+  box-shadow: 0 2px 10px var(--shadow-card-soft);
+  margin: 0 0 16px;
+}
+
 .mobile-tabs {
   display: flex;
   justify-content: flex-start;

--- a/src/containers/Mobile/MobileStatusView/MobileProductionView.test.tsx
+++ b/src/containers/Mobile/MobileStatusView/MobileProductionView.test.tsx
@@ -6,6 +6,7 @@ import {MobileProductionView} from './MobileProductionView';
 import {BrewingStatus, ProcessMode, ProcessPhase, ProcessState, WaitingFor} from '../../../model/brewingStatus.types';
 import {rootReducer} from '../../../reducers/rootReducer';
 import * as pushService from '../../../utils/pushService';
+import {ConfirmStates} from '../../../enums/eConfirmStates';
 
 jest.mock('../MobileBrewingCalculationsView/MobileBrewingCalculationsView', () => () => <div>Berechnungen Mock</div>);
 
@@ -38,6 +39,7 @@ const renderMobileView = (overrides: Partial<React.ComponentProps<typeof MobileP
         startPolling: jest.fn(),
         stopPolling: jest.fn(),
         isPollingRunning: false,
+        confirm: jest.fn(),
         ...overrides,
     };
     return {props, ...render(
@@ -80,6 +82,22 @@ describe('MobileProductionView navigation', () => {
         fireEvent.click(screen.getByRole('button', {name: 'Status'}));
 
         expect(screen.queryByRole('heading', {name: 'Brauhaus Mobile'})).not.toBeInTheDocument();
+    });
+});
+
+describe('MobileProductionView confirmations', () => {
+    it('confirms a valid waiting state through the shared mapping and prevents repeated clicks', () => {
+        const status = makeStatus();
+        status.currentStep.mode = ProcessMode.WAITING;
+        status.waiting = {waitingFor: WaitingFor.IODINE_TEST, canConfirm: true};
+        const confirm = jest.fn();
+        renderMobileView({brewingStatus: status, confirm});
+
+        fireEvent.click(screen.getByRole('button', {name: 'Jodprobe abgeschlossen'}));
+        expect(confirm).toHaveBeenCalledWith(ConfirmStates.IODINE);
+        expect(screen.getByRole('button', {name: 'Wird verarbeitet …'})).toBeDisabled();
+        expect(screen.getByText('24 °C')).toBeInTheDocument();
+        expect(screen.getByText('65 °C')).toBeInTheDocument();
     });
 });
 

--- a/src/containers/Mobile/MobileStatusView/MobileProductionView.tsx
+++ b/src/containers/Mobile/MobileStatusView/MobileProductionView.tsx
@@ -3,8 +3,10 @@ import './MobileProductionView.css';
 import { BrewingStatus } from '../../../model/brewingStatus.types';
 import { TimeFormatter } from "../../../utils/TimeFormatter";
 import MobileBrewingCalculationsView from '../MobileBrewingCalculationsView/MobileBrewingCalculationsView';
-import {getBrewingStatusLabel, getStatusChangeKey, isStepWaiting} from '../../../utils/brewingStatus/selectors';
+import {getBrewingStatusLabel, getConfirmationRequestViewModel, getStatusChangeKey, isStepWaiting} from '../../../utils/brewingStatus/selectors';
 import SettingsPage from '../../Settings/SettingsPage.connect';
+import {ConfirmStates} from '../../../enums/eConfirmStates';
+import {ControlConfirmationNotice} from '../../Production/components/InlineProcessNotice';
 
 interface MobileProductionViewProps {
     temperature: number;
@@ -12,10 +14,12 @@ interface MobileProductionViewProps {
     startPolling: () => void;
     stopPolling: () => void;
     isPollingRunning: boolean;
+    confirm: (confirmState: ConfirmStates) => void;
 }
 
 interface MobileProductionViewState {
     activeTab: MobileTab;
+    confirmationPendingFor?: string;
 }
 
 type MobileTab = 'status' | 'finishedBrew' | 'calculations' | 'settings';
@@ -23,7 +27,7 @@ type MobileTab = 'status' | 'finishedBrew' | 'calculations' | 'settings';
 export class MobileProductionView extends React.Component<MobileProductionViewProps, MobileProductionViewState> {
     constructor(props: MobileProductionViewProps) {
         super(props);
-        this.state = { activeTab: 'status' };
+        this.state = { activeTab: 'status', confirmationPendingFor: undefined };
     }
 
     handleTabChange = (tab: MobileTab) => {
@@ -49,7 +53,18 @@ export class MobileProductionView extends React.Component<MobileProductionViewPr
                 navigator.vibrate(200); // 200ms Vibration
             }
         }
+        if (this.state.confirmationPendingFor && (prevProps.brewingStatus?.waiting?.waitingFor !== this.props.brewingStatus?.waiting?.waitingFor
+            || prevProps.brewingStatus?.currentStep?.mode !== this.props.brewingStatus?.currentStep?.mode)) {
+            this.setState({confirmationPendingFor: undefined});
+        }
     }
+
+    confirmCurrentWaitingState = () => {
+        const request = getConfirmationRequestViewModel(this.props.brewingStatus);
+        if (!request?.canConfirm || !request.confirmState || this.state.confirmationPendingFor) return;
+        this.setState({confirmationPendingFor: String(request.waitingFor)});
+        this.props.confirm(request.confirmState);
+    };
 
     touchStartX: number | null = null;
     touchEndX: number | null = null;
@@ -83,6 +98,7 @@ export class MobileProductionView extends React.Component<MobileProductionViewPr
         const { brewingStatus, startPolling, isPollingRunning } = this.props;
         const { activeTab } = this.state;
         const statusText = getBrewingStatusLabel(brewingStatus);
+        const confirmationRequest = getConfirmationRequestViewModel(brewingStatus);
         return (
             <div
                 className="mobile-production-container"
@@ -138,6 +154,11 @@ export class MobileProductionView extends React.Component<MobileProductionViewPr
                             <span className="mobile-label">Status:</span>
                             <div className="mobile-status-value">{statusText || '-'}</div>
                         </div>
+                        {confirmationRequest && (
+                            <div className="mobile-confirmation-wrapper">
+                                <ControlConfirmationNotice request={confirmationRequest} pending={Boolean(this.state.confirmationPendingFor)} onConfirm={this.confirmCurrentWaitingState} />
+                            </div>
+                        )}
                         <button className="mobile-polling-btn" onClick={startPolling} disabled={isPollingRunning}>
                             {isPollingRunning ? 'Aktualisierung läuft...' : 'Aktualisieren'}
                         </button>

--- a/src/containers/Production/ProcessList/ProcessList.css
+++ b/src/containers/Production/ProcessList/ProcessList.css
@@ -103,9 +103,24 @@
 }
 
 .current-step-temperature {
+    display: flex;
+    flex-direction: column;
     font-size: 1.2rem;
     font-weight: 700;
     color: var(--color-light-text);
+}
+
+.current-step-temperature small {
+    color: var(--color-accent);
+    font-size: 0.7rem;
+    font-weight: 700;
+    line-height: 1.25;
+    max-width: 15rem;
+}
+
+.current-process-step--action-required {
+    border-color: var(--color-accent);
+    box-shadow: 0 0 0 1px color-mix(in srgb, var(--color-accent) 18%, transparent);
 }
 
 .current-step-time {

--- a/src/containers/Production/ProcessList/ProcessList.tsx
+++ b/src/containers/Production/ProcessList/ProcessList.tsx
@@ -5,6 +5,8 @@ import {RestExecutionMode} from "../../../enums/eRestExecutionMode";
 import {BrewingStatus, ProcessMode, ProcessPhase, ProcessState, WaitingFor} from "../../../model/brewingStatus.types";
 import {ProcedureType} from "../../../enums/eProcedureType";
 import {TimeFormatter} from "../../../utils/TimeFormatter";
+import {getConfirmationRequestViewModel} from "../../../utils/brewingStatus/selectors";
+import {ControlConfirmationNotice, HopReminderNotice} from "../components/InlineProcessNotice";
 
 export enum ProcessListEntryType {
     HEATING = "HEATING",
@@ -54,6 +56,10 @@ export interface ProcessListProps {
     brewingStatus?: BrewingStatus;
     remainingSeconds?: number;
     displayMode?: 'combined' | 'overview' | 'current';
+    confirmationPending?: boolean;
+    onConfirmWaiting?: () => void;
+    hopReminderName?: string;
+    onCompleteHopReminder?: () => void;
 }
 
 interface ProcessListState {
@@ -142,7 +148,7 @@ export class ProcessList extends React.Component<ProcessListProps, ProcessListSt
 
     getCurrentStepMeta(activeStep: ProcessListStep | undefined, isProcessStarted: boolean): React.ReactNode {
         const {brewingStatus} = this.props;
-        const targetTemperature = brewingStatus?.temperature?.target ?? activeStep?.detail?.temperature;
+        const targetTemperature = brewingStatus?.temperature?.target ?? this.getRelatedRastTemperature(activeStep) ?? activeStep?.detail?.temperature;
         const metaItems: React.ReactNode[] = [];
 
         if (!isProcessStarted) {
@@ -151,10 +157,24 @@ export class ProcessList extends React.Component<ProcessListProps, ProcessListSt
         }
 
         if (typeof targetTemperature === 'number' && Number.isFinite(targetTemperature) && targetTemperature > 0) {
-            metaItems.push(<span key="temperature" className="current-step-temperature">{targetTemperature} °C</span>);
+            const isDecoction = brewingStatus?.currentStep?.phase === ProcessPhase.DECOCTION;
+            metaItems.push(
+                <span key="temperature" className="current-step-temperature">
+                    {isDecoction && <small>Hauptmaische · gehaltene Rasttemperatur</small>}
+                    {targetTemperature} °C
+                </span>
+            );
         }
 
         return <div className="current-step-meta">{metaItems}</div>;
+    }
+
+    getRelatedRastTemperature(activeStep: ProcessListStep | undefined): number | undefined {
+        if (this.props.brewingStatus?.currentStep?.phase !== ProcessPhase.DECOCTION) return undefined;
+        const decoctionName = this.props.brewingStatus.currentStep.name ?? activeStep?.name;
+        const decoction = this.props.selectedBeer.fermentation.find((step) => step.procedureType === ProcedureType.DECOCTION && step.type === decoctionName);
+        if (!decoction?.relatedRastId) return undefined;
+        return this.props.selectedBeer.fermentation.find((step) => step.stepId === decoction.relatedRastId && step.procedureType !== ProcedureType.DECOCTION)?.temperature;
     }
 
     isHeatingStatus(): boolean {
@@ -264,6 +284,17 @@ export class ProcessList extends React.Component<ProcessListProps, ProcessListSt
         );
     }
 
+    renderInlineNotice(): React.ReactNode {
+        const confirmationRequest = getConfirmationRequestViewModel(this.props.brewingStatus);
+        if (confirmationRequest) {
+            return <ControlConfirmationNotice request={confirmationRequest} pending={this.props.confirmationPending === true} onConfirm={this.props.onConfirmWaiting} />;
+        }
+        if (this.props.hopReminderName && this.props.onCompleteHopReminder) {
+            return <HopReminderNotice hopName={this.props.hopReminderName} onDone={this.props.onCompleteHopReminder} />;
+        }
+        return null;
+    }
+
 
     getStepProgressPercent(): number | undefined {
         const {brewingStatus, remainingSeconds} = this.props;
@@ -295,7 +326,7 @@ export class ProcessList extends React.Component<ProcessListProps, ProcessListSt
         const currentStepCard = hasRecipeProcess ? (
             <>
                 <div className="current-process-label">Aktueller Schritt</div>
-                <section className="current-process-step" aria-label="Aktueller Prozessschritt">
+                <section className={`current-process-step${getConfirmationRequestViewModel(brewingStatus) ? ' current-process-step--action-required' : ''}`} aria-label="Aktueller Prozessschritt">
                     <div className="current-step-heading">
                         <div>
                             <h4>{isProcessStarted ? this.getCurrentStepTitle(activeStep) : 'Noch kein Brauvorgang gestartet'}</h4>
@@ -304,6 +335,7 @@ export class ProcessList extends React.Component<ProcessListProps, ProcessListSt
                         {this.getCurrentStepMeta(activeStep, isProcessStarted)}
                     </div>
                     {this.renderStatusSection(isProcessStarted)}
+                    {this.renderInlineNotice()}
                 </section>
             </>
         ) : <div className="process-empty-state">Kein Bier für den Brauvorgang ausgewählt.</div>;

--- a/src/containers/Production/Production.connect.ts
+++ b/src/containers/Production/Production.connect.ts
@@ -6,6 +6,7 @@ import {BrewingData} from "../../model/BrewingData";
 import {FinishedBrew} from "../../model/FinishedBrew";
 import {RootState} from "../../reducers/rootReducer";
 import {Production} from './Production';
+import {ConfirmStates} from '../../enums/eConfirmStates';
 
 const mapDispatchToProps = (dispatch: Dispatch) => ({
     getTemperatures: () => {
@@ -35,6 +36,9 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
     },
     nextProcedureStep: () => {
         dispatch(ProductionActions.nextProcedureStep())
+    },
+    confirm: (confirmState: ConfirmStates) => {
+        dispatch(ProductionActions.confirm(confirmState))
     }
 });
 const mapStateToProps = (state: RootState) => (

--- a/src/containers/Production/Production.test.tsx
+++ b/src/containers/Production/Production.test.tsx
@@ -4,6 +4,7 @@ import {Production} from './Production';
 import {Beer} from '../../model/Beer';
 import {ToggleState} from '../../enums/eToggleState';
 import {AlarmType, BrewingStatus, ProcessMode, ProcessPhase, ProcessState, WaitingFor} from '../../model/brewingStatus.types';
+import {ConfirmStates} from '../../enums/eConfirmStates';
 
 const createBeer = (aMashVolume: number | undefined = 18, aSpargeVolume: number | undefined = 12, aId: string = '1'): Beer => ({
     id: aId,
@@ -72,6 +73,7 @@ const renderProduction = (aOverrides: Partial<React.ComponentProps<typeof Produc
         waterStatus: {filledLiters: 0, targetLiters: 0, openClose: false},
         addFinishedBrew: jest.fn(),
         nextProcedureStep: jest.fn(),
+        confirm: jest.fn(),
         ...aOverrides
     };
     return {props, ...render(<Production {...props} />)};
@@ -169,6 +171,81 @@ describe('Production start button', () => {
         expect(startPollingButton).toBeDisabled();
     });
 
+});
+
+describe('Production inline confirmations', () => {
+    const waitingStatus = (waitingFor: WaitingFor, phase: ProcessPhase): BrewingStatus => ({
+        ...createBrewingStatus(ProcessState.ACTIVE),
+        currentStep: {index: 1, phase, mode: ProcessMode.WAITING, name: phase},
+        temperature: {current: 64, target: 66},
+        waiting: {waitingFor, canConfirm: true},
+    });
+
+    it.each([
+        [WaitingFor.DECOCTION_CONFIRMATION, ProcessPhase.DECOCTION, 'Dekoktion abgeschlossen', ConfirmStates.DECOCTION],
+        [WaitingFor.IODINE_TEST, ProcessPhase.RAST, 'Jodprobe abgeschlossen', ConfirmStates.IODINE],
+        [WaitingFor.MASHING_IN_CONFIRMATION, ProcessPhase.MASHING_IN, 'Einmaischen abgeschlossen', ConfirmStates.MASHUP],
+        [WaitingFor.MASHING_OUT_CONFIRMATION, ProcessPhase.MASHING_OUT, 'Abmaischen abgeschlossen', ConfirmStates.MASHUP],
+        [WaitingFor.BOILING_CONFIRMATION, ProcessPhase.COOKING, 'Siedepunkt bestätigen', ConfirmStates.BOILING],
+        [WaitingFor.COOKING_CONFIRMATION, ProcessPhase.COOKING, 'Kochen bestätigen', ConfirmStates.COOKING],
+    ] as const)('renders %s inline and dispatches the existing confirm state', (waitingFor, phase, buttonLabel, confirmState) => {
+        const confirm = jest.fn();
+        const {container} = renderProduction({brewingStatus: waitingStatus(waitingFor, phase), confirm});
+
+        expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+        expect(screen.getByLabelText('Aktion erforderlich')).toBeInTheDocument();
+        expect(container.querySelector('.Temp')).toBeInTheDocument();
+        fireEvent.click(screen.getByRole('button', {name: buttonLabel}));
+        expect(confirm).toHaveBeenCalledWith(confirmState);
+        expect(screen.getByRole('button', {name: 'Wird verarbeitet …'})).toBeDisabled();
+    });
+
+    it('shows an unsupported user confirmation without inventing a button', () => {
+        renderProduction({brewingStatus: waitingStatus(WaitingFor.USER_CONFIRMATION, ProcessPhase.RAST)});
+        expect(screen.getByText('Wartet auf Benutzeraktion')).toBeInTheDocument();
+        expect(screen.getByLabelText('Aktion erforderlich').querySelector('button')).toBeNull();
+    });
+
+    it('labels the decoction target as the held main-mash rest temperature', () => {
+        renderProduction({brewingStatus: waitingStatus(WaitingFor.DECOCTION_CONFIRMATION, ProcessPhase.DECOCTION)});
+        expect(screen.getByText('Hauptmaische · gehaltene Rasttemperatur')).toBeInTheDocument();
+        expect(screen.getByText('66 °C')).toBeInTheDocument();
+    });
+
+    it('uses the related rest temperature when the controller has no target for a decoction', () => {
+        const beer = {
+            ...createBeer(),
+            fermentation: [
+                {type: 'Einmaischen', temperature: 60},
+                {stepId: 'rast-1', type: 'Rast 1', temperature: 67, procedureType: 'RAST'},
+                {stepId: 'decoction-1', relatedRastId: 'rast-1', type: 'Dekoktion 1', procedureType: 'DECOCTION'},
+                {type: 'Abmaischen', temperature: 78},
+            ],
+        } as Beer;
+        const status = waitingStatus(WaitingFor.DECOCTION_CONFIRMATION, ProcessPhase.DECOCTION);
+        status.currentStep.name = 'Dekoktion 1';
+        status.temperature = {current: 64};
+        renderProduction({selectedBeer: beer, brewingStatus: status});
+
+        expect(screen.getByText('Hauptmaische · gehaltene Rasttemperatur')).toBeInTheDocument();
+        expect(screen.getByText('67 °C')).toBeInTheDocument();
+    });
+
+    it('renders hop additions as a non-blocking reminder and dismisses only the reminder', () => {
+        const beer = {...createBeer(), wortBoiling: {totalTime: 60, hops: [{id: 'h1', name: 'Cascade', description: '', alpha: 5, quantity: 10, time: 60}]}};
+        const beforeCooking = createBrewingStatus(ProcessState.ACTIVE);
+        const cooking = createBrewingStatus(ProcessState.ACTIVE);
+        cooking.currentStep = {index: 3, phase: ProcessPhase.COOKING, mode: ProcessMode.TIMER_RUNNING, elapsedTime: 1, duration: 3600};
+        const {rerender, props} = renderProduction({selectedBeer: beer, brewingStatus: beforeCooking});
+        rerender(<Production {...props} selectedBeer={beer} brewingStatus={cooking} />);
+
+        expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+        expect(screen.getByLabelText('Hopfengabe')).toHaveTextContent('Cascade zugeben');
+        expect(screen.getByLabelText('Hopfengabe')).toHaveTextContent('Der Kochprozess läuft weiter.');
+        fireEvent.click(screen.getByRole('button', {name: 'Erledigt'}));
+        expect(screen.queryByLabelText('Hopfengabe')).not.toBeInTheDocument();
+        expect(screen.getByText('Schritt wird ausgeführt')).toBeInTheDocument();
+    });
 });
 
 

--- a/src/containers/Production/Production.tsx
+++ b/src/containers/Production/Production.tsx
@@ -39,6 +39,8 @@ import {ProductionDialogs} from "./components/ProductionDialogs";
 import {ProductionTemperatureTimeline} from "./TemperatureTimeline/ProductionTemperatureTimeline";
 import {getDisplayedWaterLiters as selectDisplayedWaterLiters, getWaterLabel, getWaterTargetLiters, isRecipeWaterButtonDisabled as selectRecipeWaterButtonDisabled, isWaterFillingActive as selectWaterFillingActive, shouldIncludeSpargeAfterMashingOut as selectShouldIncludeSpargeAfterMashingOut, sanitizeLiters} from "./waterFill/recipeWaterFillSelectors";
 import {equipmentAlarmDisplay, isEquipmentAlarmActive} from '../../utils/brewingStatus/alarmDisplay';
+import {getConfirmationRequestViewModel} from '../../utils/brewingStatus/selectors';
+import {ConfirmStates} from '../../enums/eConfirmStates';
 
 export interface ProductionProps {
     selectedBeer?: Beer;
@@ -62,6 +64,7 @@ export interface ProductionProps {
     addFinishedBrew: (finishedBrew: FinishedBrew) => void;
     nextProcedureStep: () => void;
     isPollingRunning: boolean;
+    confirm: (confirmState: ConfirmStates) => void;
 }
 
 interface ProductionState {
@@ -89,6 +92,7 @@ interface ProductionState {
     recipeWaterFill: RecipeWaterFillStatus;
     displayedRemainingSeconds: number | undefined;
     equipmentAlarmDismissed: boolean;
+    confirmationPendingFor?: string;
 }
 
 export class Production extends React.Component<ProductionProps, ProductionState> {
@@ -127,7 +131,8 @@ export class Production extends React.Component<ProductionProps, ProductionState
             announcedHopTimes: [],
             recipeWaterFill: createInitialRecipeWaterFillStatus(),
             displayedRemainingSeconds: undefined,
-            equipmentAlarmDismissed: false
+            equipmentAlarmDismissed: false,
+            confirmationPendingFor: undefined
         }
     }
 
@@ -160,6 +165,12 @@ export class Production extends React.Component<ProductionProps, ProductionState
 
         if (prevProps.brewingStatus !== brewingStatus) {
             this.syncRemainingTimeFromStatus();
+        }
+
+        const previousWaitingFor = prevProps.brewingStatus?.waiting?.waitingFor;
+        const currentWaitingFor = brewingStatus?.waiting?.waitingFor;
+        if (this.state.confirmationPendingFor && (currentWaitingFor !== previousWaitingFor || brewingStatus?.currentStep?.mode !== prevProps.brewingStatus?.currentStep?.mode)) {
+            this.setState({confirmationPendingFor: undefined});
         }
 
         if (isEquipmentAlarmActive(prevProps.brewingStatus) && !isEquipmentAlarmActive(brewingStatus)) {
@@ -673,6 +684,13 @@ export class Production extends React.Component<ProductionProps, ProductionState
         this.setState({showHopsDialog: false});
     }
 
+    confirmCurrentWaitingState = () => {
+        const request = getConfirmationRequestViewModel(this.props.brewingStatus);
+        if (!request?.canConfirm || !request.confirmState || this.state.confirmationPendingFor) return;
+        this.setState({confirmationPendingFor: String(request.waitingFor)});
+        this.props.confirm(request.confirmState);
+    }
+
 
     confirmFinishDialog = async () => {
         const { stopPolling, selectedBeer, addFinishedBrew } = this.props;
@@ -714,20 +732,17 @@ export class Production extends React.Component<ProductionProps, ProductionState
         if (selectedBeer === undefined) {
             return null;
         }
-        return <ProcessList displayMode="current" selectedBeer={selectedBeer} currentStepIndex={brewingStatus?.currentStep?.index ?? 0} currentStep={brewingStatus?.currentStep} brewingStatus={brewingStatus} remainingSeconds={this.state.displayedRemainingSeconds} />;
+        return <ProcessList displayMode="current" selectedBeer={selectedBeer} currentStepIndex={brewingStatus?.currentStep?.index ?? 0} currentStep={brewingStatus?.currentStep} brewingStatus={brewingStatus} remainingSeconds={this.state.displayedRemainingSeconds} confirmationPending={Boolean(this.state.confirmationPendingFor)} onConfirmWaiting={this.confirmCurrentWaitingState} hopReminderName={this.state.showHopsDialog ? this.state.hopName : undefined} onCompleteHopReminder={this.confirmHopDialog} />;
     }
 
 
     render() {
-        const {showHopsDialog, showFinishDialog} = this.state;
+        const {showFinishDialog} = this.state;
         const equipmentAlarmActive = isEquipmentAlarmActive(this.props.brewingStatus);
         return (
             <div className="containerProduction ">
                 <ProductionDialogs
-                    showHopsDialog={showHopsDialog}
-                    hopName={this.state.hopName}
                     showFinishDialog={showFinishDialog}
-                    onConfirmHop={this.confirmHopDialog}
                     onConfirmFinish={this.confirmFinishDialog}
                     showEquipmentAlarmDialog={equipmentAlarmActive && !this.state.equipmentAlarmDismissed}
                     equipmentAlarmTitle={equipmentAlarmDisplay.title}

--- a/src/containers/Production/components/InlineProcessNotice.css
+++ b/src/containers/Production/components/InlineProcessNotice.css
@@ -1,0 +1,60 @@
+.inline-process-notice {
+    border: 1px solid color-mix(in srgb, var(--color-accent) 72%, transparent);
+    border-left: 0.35rem solid var(--color-accent);
+    border-radius: 0.7rem;
+    margin-top: 0.65rem;
+    padding: 0.7rem 0.8rem;
+    background: color-mix(in srgb, var(--color-accent) 10%, var(--color-surface-2));
+    color: var(--color-light-text);
+}
+
+.inline-process-notice--action {
+    box-shadow: 0 0 0 1px color-mix(in srgb, var(--color-accent) 16%, transparent);
+}
+
+.inline-process-notice--reminder {
+    background: color-mix(in srgb, var(--color-accent) 6%, var(--color-surface-2));
+}
+
+.inline-process-notice__eyebrow {
+    color: var(--color-accent);
+    display: block;
+    font-size: 0.76rem;
+    font-weight: 800;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+}
+
+.inline-process-notice h5 {
+    color: inherit;
+    font-size: 1.02rem;
+    margin: 0.2rem 0 0;
+}
+
+.inline-process-notice p {
+    line-height: 1.35;
+    margin: 0.35rem 0 0;
+}
+
+.inline-process-notice__button {
+    background: var(--color-accent);
+    border: 1px solid var(--color-accent);
+    border-radius: 0.45rem;
+    color: var(--color-white);
+    cursor: pointer;
+    font-weight: 800;
+    margin-top: 0.65rem;
+    min-height: 2.6rem;
+    padding: 0.55rem 1rem;
+    width: 100%;
+}
+
+.inline-process-notice__button--secondary {
+    background: transparent;
+    color: var(--color-accent);
+}
+
+.inline-process-notice__button:disabled {
+    cursor: wait;
+    opacity: 0.65;
+}

--- a/src/containers/Production/components/InlineProcessNotice.tsx
+++ b/src/containers/Production/components/InlineProcessNotice.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import {ConfirmationRequestViewModel} from '../../../utils/brewingStatus/selectors';
+import './InlineProcessNotice.css';
+
+interface ControlConfirmationNoticeProps {
+    request: ConfirmationRequestViewModel;
+    pending: boolean;
+    onConfirm?: () => void;
+}
+
+export const ControlConfirmationNotice: React.FC<ControlConfirmationNoticeProps> = ({request, pending, onConfirm}) => (
+    <section className="inline-process-notice inline-process-notice--action" aria-label="Aktion erforderlich" aria-live="polite">
+        <span className="inline-process-notice__eyebrow">Aktion erforderlich</span>
+        <h5>{request.title}</h5>
+        <p>{pending ? 'Bestätigung wird verarbeitet …' : request.message}</p>
+        {request.canConfirm && request.confirmState && onConfirm && (
+            <button type="button" className="inline-process-notice__button" disabled={pending} onClick={onConfirm}>
+                {pending ? 'Wird verarbeitet …' : request.buttonLabel}
+            </button>
+        )}
+    </section>
+);
+
+interface HopReminderNoticeProps {
+    hopName: string;
+    onDone: () => void;
+}
+
+export const HopReminderNotice: React.FC<HopReminderNoticeProps> = ({hopName, onDone}) => (
+    <section className="inline-process-notice inline-process-notice--reminder" aria-label="Hopfengabe" aria-live="polite">
+        <span className="inline-process-notice__eyebrow">Hopfengabe</span>
+        <h5>{hopName} zugeben</h5>
+        <p>Der Kochprozess läuft weiter.</p>
+        <button type="button" className="inline-process-notice__button inline-process-notice__button--secondary" onClick={onDone}>Erledigt</button>
+    </section>
+);

--- a/src/containers/Production/components/ProductionDialogs.tsx
+++ b/src/containers/Production/components/ProductionDialogs.tsx
@@ -2,10 +2,7 @@ import React from 'react';
 import ModalDialog, {DialogType} from '../../../components/ModalDialog/ModalDialog';
 
 export interface ProductionDialogsProps {
-    showHopsDialog: boolean;
-    hopName: string;
     showFinishDialog: boolean;
-    onConfirmHop: () => void;
     onConfirmFinish: () => void;
     showEquipmentAlarmDialog: boolean;
     equipmentAlarmTitle: string;
@@ -15,11 +12,10 @@ export interface ProductionDialogsProps {
 
 export class ProductionDialogs extends React.Component<ProductionDialogsProps> {
     render(): React.ReactNode {
-        const {showHopsDialog, hopName, showFinishDialog, onConfirmHop, onConfirmFinish,
+        const {showFinishDialog, onConfirmFinish,
             showEquipmentAlarmDialog, equipmentAlarmTitle, equipmentAlarmMessage, onDismissEquipmentAlarm} = this.props;
         return (
             <>
-                <ModalDialog onConfirm={onConfirmHop} type={DialogType.CONFIRM} open={showHopsDialog} content={'Bitte den ' + hopName + ' Hopfen zufügen!'} header="Hopfen Zufügen" />
                 <ModalDialog onConfirm={onConfirmFinish} type={DialogType.INFO} open={showFinishDialog} content="Das Bier ist fertig!" header="Fertig!" />
                 <ModalDialog
                     onConfirm={onDismissEquipmentAlarm}

--- a/src/containers/index.connect.ts
+++ b/src/containers/index.connect.ts
@@ -1,7 +1,6 @@
 import {connect} from "react-redux";
 import {Views} from '../enums/eViews';
 import {ProductionActions} from "../actions/actions";
-import {ConfirmStates} from "../enums/eConfirmStates";
 import {Index} from './index';
 
 const mapStateToProps = (state: any) => ({
@@ -10,10 +9,6 @@ const mapStateToProps = (state: any) => ({
 });
 
 const mapDispatchToProps = (dispatch: any) => ({
-    confirm: (confirmState: ConfirmStates) => {
-        dispatch(ProductionActions.confirm(confirmState))
-    },
-
     checkIsBackenAvailable: () => {
         dispatch(ProductionActions.checkIsBackenAvailable())
     },

--- a/src/containers/index.test.tsx
+++ b/src/containers/index.test.tsx
@@ -1,9 +1,8 @@
 import React from 'react';
-import {fireEvent, render, screen} from '@testing-library/react';
+import {render, screen} from '@testing-library/react';
 import {Index} from './index';
 import {Views} from '../enums/eViews';
 import {BrewingStatus, ProcessMode, ProcessPhase, ProcessState, WaitingFor} from '../model/brewingStatus.types';
-import {ConfirmStates} from '../enums/eConfirmStates';
 
 jest.mock('./Dashboard/DashboardPage.connect', () => () => <div><h1>Dashboard</h1></div>);
 
@@ -29,22 +28,21 @@ const makeStatus = (overrides: Partial<BrewingStatus> = {}): BrewingStatus => ({
     ...overrides,
 });
 
-const renderIndex = (brewingStatus: BrewingStatus, confirm = jest.fn(), viewState = Views.VERSION) => {
+const renderIndex = (brewingStatus: BrewingStatus, viewState = Views.VERSION) => {
     const result = render(
         <Index
             viewState={viewState}
             brewingStatus={brewingStatus}
-            confirm={confirm}
             checkIsBackenAvailable={jest.fn()}
             webSocketConnect={jest.fn()}
         />
     );
-    return {confirm, ...result};
+    return result;
 };
 
 describe('Index view routing', () => {
     it('points the dashboard view to the dashboard page', (): void => {
-        renderIndex(makeStatus({process: {state: ProcessState.IDLE}, currentStep: {phase: ProcessPhase.NONE, mode: ProcessMode.NONE}, waiting: {waitingFor: WaitingFor.NONE, canConfirm: false}}), jest.fn(), Views.DASHBOARD);
+        renderIndex(makeStatus({process: {state: ProcessState.IDLE}, currentStep: {phase: ProcessPhase.NONE, mode: ProcessMode.NONE}, waiting: {waitingFor: WaitingFor.NONE, canConfirm: false}}), Views.DASHBOARD);
 
         expect(screen.getByRole('heading', {name: 'Dashboard'})).toBeInTheDocument();
     });
@@ -57,65 +55,8 @@ describe('Index view routing', () => {
 });
 
 describe('Index waiting confirmation dialog', () => {
-    it('shows the Abmaischen dialog for MASHING_OUT_CONFIRMATION when the active step is waiting and confirmable', () => {
+    it('does not render the removed global waiting modal', () => {
         renderIndex(makeStatus());
-
-        expect(screen.getByRole('dialog')).toBeInTheDocument();
-        expect(screen.getByText('Abmaischen und Nachguss abgeschlossen?')).toBeInTheDocument();
-    });
-
-    it('sends exactly one Mashup confirmation when the Abmaischen dialog is confirmed', () => {
-        const {confirm} = renderIndex(makeStatus());
-
-        fireEvent.click(screen.getByRole('button', {name: 'Ok'}));
-
-        expect(confirm).toHaveBeenCalledTimes(1);
-        expect(confirm).toHaveBeenCalledWith(ConfirmStates.MASHUP);
-    });
-
-    it('does not show a dialog when canConfirm is false', () => {
-        renderIndex(makeStatus({waiting: {waitingFor: WaitingFor.MASHING_OUT_CONFIRMATION, canConfirm: false}}));
-
-        expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
-    });
-
-    it('does not show a dialog when the current step is not WAITING', () => {
-        renderIndex(makeStatus({currentStep: {...makeStatus().currentStep, mode: ProcessMode.HEATING}}));
-
-        expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
-    });
-
-    it('does not show or send a false confirmation for unknown waitingFor values', () => {
-        const consoleWarn = jest.spyOn(console, 'warn').mockImplementation(() => {});
-        const {confirm} = renderIndex(makeStatus({waiting: {waitingFor: 'UNKNOWN_CONFIRMATION', canConfirm: true}}));
-
-        expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
-        expect(confirm).not.toHaveBeenCalled();
-        expect(consoleWarn).toHaveBeenCalledWith(expect.stringContaining('UNKNOWN_CONFIRMATION'));
-        consoleWarn.mockRestore();
-    });
-
-    it('shows the dialog when the initially loaded status is already waiting', () => {
-        renderIndex(makeStatus());
-
-        expect(screen.getByRole('dialog')).toBeInTheDocument();
-    });
-
-    it('keeps a single dialog instance when the same waiting status is received repeatedly through polling', () => {
-        const status = makeStatus();
-        const {rerender} = renderIndex(status);
-
-        rerender(<Index viewState={Views.VERSION} brewingStatus={{...status}} confirm={jest.fn()} checkIsBackenAvailable={jest.fn()} webSocketConnect={jest.fn()} />);
-
-        expect(screen.getAllByRole('dialog')).toHaveLength(1);
-    });
-
-    it('closes the dialog after the waiting state disappears after successful confirmation', () => {
-        const {rerender} = renderIndex(makeStatus());
-
-        expect(screen.getByRole('dialog')).toBeInTheDocument();
-        rerender(<Index viewState={Views.VERSION} brewingStatus={makeStatus({currentStep: {...makeStatus().currentStep, mode: ProcessMode.HEATING}, waiting: {waitingFor: WaitingFor.NONE, canConfirm: false}})} confirm={jest.fn()} checkIsBackenAvailable={jest.fn()} webSocketConnect={jest.fn()} />);
-
         expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
     });
 });

--- a/src/containers/index.tsx
+++ b/src/containers/index.tsx
@@ -4,21 +4,17 @@ import Main from "./MainView/Main.connect";
 import Production from "./Production/Production.connect";
 import DatabaseOverview from "./DatabaseOverview/BeerForm.connect";
 import SimpleBar from "simplebar-react";
-import ModalDialog, {DialogType} from "../components/ModalDialog/ModalDialog";
 import {BrewingStatus} from "../model/brewingStatus.types";
-import {ConfirmStates} from "../enums/eConfirmStates";
 import FinishedBrewsTable from "./MainView/FinishBrewsBeers/FinishedBrewsTable.connect";
 import BrewingCalculations from "./BrewingCalculations/BrewingCalculations";
 import IngredientsFormPage from "./DatabaseOverview/IngredientsFormPage.connect";
 import SettingsPage from "./Settings/SettingsPage.connect";
 import VersionPage from "./Version/VersionPage";
 import DashboardPage from "./Dashboard/DashboardPage.connect";
-import {getBrewingStatusLabel, getConfirmationType, shouldShowConfirmButton, shouldShowWaitingDialog} from "../utils/brewingStatus/selectors";
 
 interface indexMainProps {
     viewState: Views;
     brewingStatus: BrewingStatus;
-    confirm: (confirmState: ConfirmStates) => void;
     checkIsBackenAvailable : () => void;
     webSocketConnect: () => void;
 }
@@ -37,46 +33,12 @@ export class Index extends React.Component<indexMainProps> {
         }
     }
 
-    getConfirmStateForWaiting = (): ConfirmStates | undefined => getConfirmationType(this.props.brewingStatus);
-
-    confirmDialog = () => {
-        const {confirm} = this.props;
-        const confirmState = this.getConfirmStateForWaiting();
-        if (confirmState === undefined) {
-            console.warn('Waiting state has no concrete confirmation command; no Confirm endpoint will be called.');
-            return;
-        }
-        confirm(confirmState);
-    }
-
-    getDialogMessage() {
-        return getBrewingStatusLabel(this.props.brewingStatus);
-    }
-
-    showDialog() {
-        const {brewingStatus} = this.props;
-        const message = this.getDialogMessage();
-        return (
-            <div>
-                <ModalDialog
-                    type={DialogType.CONFIRM}
-                    open={shouldShowWaitingDialog(brewingStatus)}
-                    content={message}
-                    header={"Confirm"}
-                    onConfirm={shouldShowConfirmButton(brewingStatus) ? this.confirmDialog : () => {}}
-                />
-            </div>
-        );
-    }
-
-
     render() {
         const {viewState} = this.props;
 
         return (
 
             <div className="IndexContent">
-                {this.showDialog()}
                 <SimpleBar style={{maxHeight: '100%', overflowY: 'auto'}}>
                     {viewState === Views.DASHBOARD && <DashboardPage />}
                     {viewState === Views.MAIN && <Main/>}

--- a/src/utils/brewingStatus/selectors.test.ts
+++ b/src/utils/brewingStatus/selectors.test.ts
@@ -1,4 +1,4 @@
-import {getBrewingStatusLabel, getConfirmButtonLabel, getConfirmationType, getCountdownValue, isBrewingProcessActive, shouldShowConfirmButton, shouldShowCountdown, shouldShowWaitingDialog} from './selectors';
+import {getBrewingStatusLabel, getConfirmButtonLabel, getConfirmationRequestViewModel, getConfirmationType, getCountdownValue, isBrewingProcessActive, shouldShowConfirmButton, shouldShowCountdown, shouldShowWaitingDialog} from './selectors';
 import {AlarmType, BrewingStatus, ProcessMode, ProcessPhase, ProcessState, WaitingFor} from '../../model/brewingStatus.types';
 import {ConfirmStates} from '../../enums/eConfirmStates';
 import {isEquipmentAlarmActive} from './alarmDisplay';
@@ -60,6 +60,24 @@ describe('brewing selectors', () => {
   it('requires canConfirm to show the confirmation dialog', () => {
     const s = makeStatus({currentStep:{phase:ProcessPhase.MASHING_OUT, mode:ProcessMode.WAITING}, waiting:{waitingFor:WaitingFor.MASHING_OUT_CONFIRMATION, canConfirm:false}});
     expect(shouldShowWaitingDialog(s)).toBe(false);
+  });
+
+  it.each([
+    [WaitingFor.MASHING_IN_CONFIRMATION, ConfirmStates.MASHUP, 'Einmaischen bestätigen'],
+    [WaitingFor.IODINE_TEST, ConfirmStates.IODINE, 'Jodprobe durchführen'],
+    [WaitingFor.DECOCTION_CONFIRMATION, ConfirmStates.DECOCTION, 'Dekoktion'],
+    [WaitingFor.MASHING_OUT_CONFIRMATION, ConfirmStates.MASHUP, 'Abmaischen bestätigen'],
+    [WaitingFor.COOKING_CONFIRMATION, ConfirmStates.COOKING, 'Kochen bestätigen'],
+    [WaitingFor.BOILING_CONFIRMATION, ConfirmStates.BOILING, 'Siedepunkt bestätigen'],
+  ] as const)('builds one central view model for %s', (waitingFor, confirmState, title) => {
+    const status = makeStatus({currentStep:{phase:ProcessPhase.RAST, mode:ProcessMode.WAITING}, waiting:{waitingFor, canConfirm:true}});
+    expect(getConfirmationRequestViewModel(status)).toMatchObject({waitingFor, confirmState, title, canConfirm: true, requiresAction: true});
+  });
+
+  it('represents unsupported waiting states without a confirmation command', () => {
+    const status = makeStatus({currentStep:{phase:ProcessPhase.RAST, mode:ProcessMode.WAITING}, waiting:{waitingFor:WaitingFor.USER_CONFIRMATION, canConfirm:true}});
+    expect(getConfirmationRequestViewModel(status)).toMatchObject({title: 'Wartet auf Benutzeraktion', canConfirm: false, requiresAction: true});
+    expect(getConfirmationRequestViewModel(status)?.confirmState).toBeUndefined();
   });
 
   it('countdown shown only for timer running', () => {

--- a/src/utils/brewingStatus/selectors.ts
+++ b/src/utils/brewingStatus/selectors.ts
@@ -55,6 +55,69 @@ export const getConfirmButtonLabel = (aStatus?: BrewingStatus) => {
         default: return 'Bestätigen';
     }
 };
+
+export interface ConfirmationRequestViewModel {
+    waitingFor: WaitingState;
+    title: string;
+    message: string;
+    buttonLabel?: string;
+    confirmState?: ConfirmStates;
+    canConfirm: boolean;
+    requiresAction: boolean;
+}
+
+const confirmationCopyByWaitingState: Partial<Record<WaitingState, Pick<ConfirmationRequestViewModel, 'title' | 'message' | 'buttonLabel'>>> = {
+    [WaitingFor.MASHING_IN_CONFIRMATION]: {
+        title: 'Einmaischen bestätigen',
+        message: 'Bitte das Einmaischen abschließen und anschließend bestätigen.',
+        buttonLabel: 'Einmaischen abgeschlossen',
+    },
+    [WaitingFor.IODINE_TEST]: {
+        title: 'Jodprobe durchführen',
+        message: 'Bitte die Jodprobe durchführen und das Ergebnis anschließend bestätigen.',
+        buttonLabel: 'Jodprobe abgeschlossen',
+    },
+    [WaitingFor.DECOCTION_CONFIRMATION]: {
+        title: 'Dekoktion',
+        message: 'Die Dekoktion läuft. Die Hauptmaische wird weiterhin auf der Temperatur der zugehörigen Rast gehalten.',
+        buttonLabel: 'Dekoktion abgeschlossen',
+    },
+    [WaitingFor.MASHING_OUT_CONFIRMATION]: {
+        title: 'Abmaischen bestätigen',
+        message: 'Bitte Abmaischen und Nachguss abschließen und anschließend bestätigen.',
+        buttonLabel: 'Abmaischen abgeschlossen',
+    },
+    [WaitingFor.COOKING_CONFIRMATION]: {
+        title: 'Kochen bestätigen',
+        message: 'Bestätigung für den Kochvorgang erforderlich.',
+        buttonLabel: 'Kochen bestätigen',
+    },
+    [WaitingFor.BOILING_CONFIRMATION]: {
+        title: 'Siedepunkt bestätigen',
+        message: 'Bitte bestätigen, dass der Siedepunkt erreicht ist.',
+        buttonLabel: 'Siedepunkt bestätigen',
+    },
+};
+
+/** Zentrales, darstellungsfertiges Modell für blockierende und unbekannte Wartezustände. */
+export const getConfirmationRequestViewModel = (aStatus?: BrewingStatus): ConfirmationRequestViewModel | undefined => {
+    if (!aStatus || !isProcessActive(aStatus) || !isStepWaiting(aStatus)) return undefined;
+
+    const waitingFor = aStatus.waiting.waitingFor;
+    const confirmState = getConfirmationTypeForWaitingState(waitingFor);
+    const copy = confirmationCopyByWaitingState[waitingFor];
+    const canConfirm = aStatus.waiting.canConfirm === true && confirmState !== undefined;
+
+    return {
+        waitingFor,
+        title: copy?.title ?? 'Wartet auf Benutzeraktion',
+        message: copy?.message ?? 'Der Brauprozess wartet auf eine Benutzeraktion. Für diesen Zustand ist keine Bestätigung in der UI verfügbar.',
+        buttonLabel: canConfirm ? (copy?.buttonLabel ?? getConfirmButtonLabel(aStatus)) : undefined,
+        confirmState,
+        canConfirm,
+        requiresAction: true,
+    };
+};
 /** WAITING ist ein Prozess-Blocker. HOLDING ist dagegen nur Temperaturhalten und kein Blocker. */
 export const getBrewingStatusLabel = (aStatus?: BrewingStatus) => {
     if (!aStatus) return 'Bereit / kein Brauvorgang aktiv';
@@ -68,6 +131,7 @@ export const getBrewingStatusLabel = (aStatus?: BrewingStatus) => {
     if (aMode === ProcessMode.WAITING && aPhase === ProcessPhase.DECOCTION && aWaitingFor === WaitingFor.DECOCTION_CONFIRMATION) return 'Dekoktion: bitte bestätigen';
     if (aMode === ProcessMode.WAITING && aPhase === ProcessPhase.MASHING_OUT && aWaitingFor === WaitingFor.MASHING_OUT_CONFIRMATION) return 'Abmaischen und Nachguss abgeschlossen?';
     if (aMode === ProcessMode.WAITING && aPhase === ProcessPhase.COOKING && aWaitingFor === WaitingFor.BOILING_CONFIRMATION) return 'Warten auf Siedepunkt-Bestätigung';
+    if (aMode === ProcessMode.WAITING && aWaitingFor === WaitingFor.COOKING_CONFIRMATION) return 'Bestätigung für den Kochvorgang erforderlich';
     if (aPhase === ProcessPhase.MASHING_IN && aMode === ProcessMode.HEATING) return 'Einmaischen: Aufheizen läuft';
     if (aPhase === ProcessPhase.RAST && aMode === ProcessMode.HEATING) return 'Rast: Aufheizen auf Solltemperatur';
     if (aPhase === ProcessPhase.RAST && aMode === ProcessMode.HOLDING) return 'Rasttemperatur wird gehalten';


### PR DESCRIPTION
### Motivation

- Replace the previous global modal-based control confirmations with an inline, shared view model so process confirmations render inline in desktop and mobile and avoid a blocking global modal.
- Provide a single, testable source of copy/behavior for different `waitingFor` control states and avoid calling `Confirm/Wait` for unsupported reasons.

### Description

- Introduces a central `ConfirmationRequestViewModel` and `getConfirmationRequestViewModel` in `utils/brewingStatus/selectors.ts` that maps `waitingFor` states to presentation text, `ConfirmStates`, and `canConfirm` flags.
- Adds an inline UI component `InlineProcessNotice` (`ControlConfirmationNotice` and `HopReminderNotice`) with styles in `src/containers/Production/components/` and replaces modal confirmations with this inline notice in `Production`, `ProcessList`, and mobile `MobileProductionView`.
- Wires confirmation dispatching through containers by adding `confirm: (confirmState: ConfirmStates) => void` props to `Production.connect`, `MobileProductionView.connect`, and relevant consumers, and removes the old global waiting modal from `Index`/`index.connect`.
- UI/UX refinements: non-blocking hop reminders, decoction temperature label, and handling of pending confirmation state to disable repeated clicks until status updates.
- Tests and CSS: updates/adds tests to reflect inline confirmations and selector view model (`selectors.test.ts`, `Production.test.tsx`, `MobileProductionView.test.tsx`, `index.test.tsx`), and adds related CSS tweaks in several component style files.

### Testing

- Ran unit tests for brewing selectors (`src/utils/brewingStatus/selectors.test.ts`), production components (`src/containers/Production/Production.test.tsx`), mobile production view (`src/containers/Mobile/.../MobileProductionView.test.tsx`), and index routing (`src/containers/index.test.tsx`).
- All modified and new unit tests executed and passed locally in the change set.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8dd3361af0832f9ee2ac108e508627)