### PR TITLE
Rezepteditor: Brauwasser / Brauprozess trennen und Kochwerte konsolidieren

### DIFF
--- a/src/containers/DatabaseOverview/BeerForm.test.tsx
+++ b/src/containers/DatabaseOverview/BeerForm.test.tsx
@@ -99,20 +99,16 @@ describe('BeerForm accordions', () => {
         expect(within(mashOutRow).getAllByRole('spinbutton')).toHaveLength(1);
     });
 
-    it('uses one editable cooking temperature source for the brewing data and mash plan', () => {
+    it('shows cooking values only in the brew process and keeps temperature read-only', () => {
         renderBeerForm();
+        expect(screen.queryByLabelText(/Kochtemperatur:/)).not.toBeInTheDocument();
+        expect(screen.queryByLabelText(/Kochzeit \(min\):/)).not.toBeInTheDocument();
 
-        const brewingTemperature = screen.getByLabelText(/Kochtemperatur:/);
-        expect(brewingTemperature).toHaveValue(100);
-
-        fireEvent.click(screen.getByRole('button', {name: /Maischeplan/}));
+        fireEvent.click(screen.getByRole('button', {name: /Brauprozess/}));
         const cookingRow = screen.getByText('Kochen').closest('tr')!;
-        const mashPlanTemperature = within(cookingRow).getByLabelText('Kochtemperatur im Maischeplan');
-        expect(mashPlanTemperature).toHaveValue(100);
-        expect(mashPlanTemperature).toHaveAttribute('readonly');
-
-        fireEvent.change(brewingTemperature, {target: {value: '99'}});
-        expect(mashPlanTemperature).toHaveValue(99);
+        expect(within(cookingRow).getByLabelText('Kochtemperatur im Brauprozess')).toHaveValue(100);
+        expect(within(cookingRow).getByLabelText('Kochtemperatur im Brauprozess')).toHaveAttribute('readonly');
+        expect(within(cookingRow).getByLabelText('Kochzeit im Brauprozess')).not.toHaveAttribute('readonly');
     });
 
     it('preserves an existing cooking temperature while showing it read-only in the mash plan', () => {
@@ -126,10 +122,10 @@ describe('BeerForm accordions', () => {
         renderBeerForm({beers: [existingBeer]});
 
         fireEvent.change(screen.getByLabelText(/Bier auswählen/), {target: {value: 'beer-99'}});
-        fireEvent.click(screen.getByRole('button', {name: /Maischeplan/}));
+        fireEvent.click(screen.getByRole('button', {name: /Brauprozess/}));
 
-        expect(screen.getByLabelText(/Kochtemperatur:/)).toHaveValue(99);
-        expect(screen.getByLabelText('Kochtemperatur im Maischeplan')).toHaveValue(99);
+        expect(screen.queryByLabelText(/Kochtemperatur:/)).not.toBeInTheDocument();
+        expect(screen.getByLabelText('Kochtemperatur im Brauprozess')).toHaveValue(99);
     });
 
     it('reset keeps one copy of every fixed step after configurable mash steps were added', () => {

--- a/src/containers/DatabaseOverview/BeerForm.tsx
+++ b/src/containers/DatabaseOverview/BeerForm.tsx
@@ -42,6 +42,8 @@ const procedureTypeOptions = [
     {value: ProcedureType.DECOCTION, label: 'Dekoktion'},
 ];
 
+const DEFAULT_COOKING_TEMPERATURE = 100;
+
 interface BeerFormState {
     id: string;
     name: string;
@@ -92,7 +94,7 @@ export class BeerForm extends React.Component<BeerFormProps, BeerFormState> {
             mashVolume: 0,
             spargeVolume: 0,
             cookingTime: 0,
-            cookingTemperatur: 100,
+            cookingTemperatur: DEFAULT_COOKING_TEMPERATURE,
             fermentationSteps: createDefaultFermentationSteps(),
             maltsDTO: [{ id: '', name: '', quantity: undefined as any }],
             hopsDTO: [{ id: '', name: '', quantity: undefined as any, time: 0, usage: HopUsage.BOIL, timeUnit: HopTimeUnit.MINUTES }],
@@ -490,7 +492,7 @@ export class BeerForm extends React.Component<BeerFormProps, BeerFormState> {
             return;
         }
         const normalizedFermentationSteps = numberMashSteps(fermentationSteps).map((step) => {
-            if (step.type === 'Kochen') return {...step, temperature: Number(cookingTemperatur)};
+            if (step.type === 'Kochen') return {...step, temperature: Number(cookingTemperatur), time: Number(cookingTime)};
             return this.fixedTypes.includes(step.type) ? step : normalizeFermentationStep(step);
         });
 
@@ -588,7 +590,7 @@ export class BeerForm extends React.Component<BeerFormProps, BeerFormState> {
             mashVolume: 0,
             spargeVolume: 0,
             cookingTime: 0,
-            cookingTemperatur: 100,
+            cookingTemperatur: DEFAULT_COOKING_TEMPERATURE,
             fermentationSteps: createDefaultFermentationSteps(),
             maltsDTO: [],
             hopsDTO: [],
@@ -857,8 +859,6 @@ export class BeerForm extends React.Component<BeerFormProps, BeerFormState> {
             <div className="beer-form-grid brewing-data-grid">
                 <label>Hauptguss (l):<input type="number" name="mashVolume" className="field-number-small" min={0} value={mashVolume} step={0.1} onChange={this.handleChange} required={true} max={99} />{this.renderInputError('mashVolume')}</label>
                 <label>Nachguss (l):<input type="number" name="spargeVolume" className="field-number-small" min={0} step={0.1} value={spargeVolume} onChange={this.handleChange} required={true} max={99} />{this.renderInputError('spargeVolume')}</label>
-                <label>Kochzeit (min):<input type="number" name="cookingTime" className="field-number-medium" min={0} value={cookingTime} onChange={this.handleChange} required={true} max={999} />{this.renderInputError('cookingTime')}</label>
-                <label>Kochtemperatur:<input type="number" name="cookingTemperatur" className="field-number-small" min={1} value={cookingTemperatur} onChange={this.handleChange} required={true} max={100} />{this.renderInputError('cookingTemperatur')}</label>
             </div>
         );
 
@@ -887,8 +887,8 @@ export class BeerForm extends React.Component<BeerFormProps, BeerFormState> {
                                 <td>{isFixed ? <span className="readonly-table-value">{step.type}</span> : <><select aria-label={`Typ ${index + 1}`} aria-invalid={Boolean(this.state.validationErrors[procedureTypeErrorKey])} name="procedureType" value={procedureType} onChange={(e) => this.handleFermentationStepChange(e.target.value, e.target.name, index)}><option value={ProcedureType.RAST}>{step.type}</option><option value={ProcedureType.DECOCTION}>Dekoktion</option></select>{this.renderFieldError(procedureTypeErrorKey)}</>}</td>
                                 <td>{procedureType === ProcedureType.DECOCTION ? <><select aria-label={`Zugehörige Rast ${index + 1}`} aria-invalid={Boolean(this.state.validationErrors[relatedRastErrorKey])} name="relatedRastId" value={step.relatedRastId || ''} onChange={(e) => this.handleFermentationStepChange(e.target.value, e.target.name, index)}><option value="">Bitte Rast auswählen</option>{rastOptions.map((rast) => <option key={rast.stepId} value={rast.stepId}>{rast.type} – {rast.temperature} °C</option>)}</select>{this.renderFieldError(relatedRastErrorKey)}</> : <span className="muted-table-value">–</span>}</td>
                                 <td>{isFixed ? <span className="muted-table-value">–</span> : <select aria-label={`Modus ${index + 1}`} name="executionMode" value={executionMode} disabled={procedureType === ProcedureType.DECOCTION} onChange={(e) => this.handleFermentationStepChange(e.target.value, e.target.name, index)}><option value={RestExecutionMode.TIMED}>Zeitgesteuert</option><option value={RestExecutionMode.CONFIRMATION_HOLD}>Bis Bestätigung</option></select>}</td>
-                                <td>{procedureType === ProcedureType.DECOCTION ? <span className="muted-table-value">–</span> : step.type === 'Kochen' ? <input type="number" value={cookingTemperatur} readOnly={true} className="readonly-cooking-temperature" title="Rezeptwert – die Kochphase wird nicht temperaturgeregelt." aria-label="Kochtemperatur im Maischeplan" /> : <input type="number" name="temperature" value={step.temperature ?? ''} onChange={(e) => this.handleFermentationStepChange(e.target.value, e.target.name, index)} required={true} />}</td>
-                                <td>{hasEditableTime && procedureType !== ProcedureType.DECOCTION && executionMode === RestExecutionMode.TIMED ? <input type="number" name="time" min={isFixed ? 0 : 1} value={step.time ?? ''} onChange={(e) => this.handleFermentationStepChange(e.target.value, e.target.name, index)} required={!isFixed} /> : <span className="muted-table-value">–</span>}</td>
+                                <td>{procedureType === ProcedureType.DECOCTION ? <span className="muted-table-value">–</span> : step.type === 'Kochen' ? <input type="number" value={cookingTemperatur} readOnly={true} className="readonly-cooking-temperature" title="Rezeptwert – die Kochphase wird nicht temperaturgeregelt." aria-label="Kochtemperatur im Brauprozess" /> : <input type="number" name="temperature" value={step.temperature ?? ''} onChange={(e) => this.handleFermentationStepChange(e.target.value, e.target.name, index)} required={true} />}</td>
+                                <td>{step.type === 'Kochen' ? <><input type="number" name="cookingTime" min={0} max={999} value={cookingTime} onChange={this.handleChange} required={true} aria-label="Kochzeit im Brauprozess" />{this.renderInputError('cookingTime')}</> : hasEditableTime && procedureType !== ProcedureType.DECOCTION && executionMode === RestExecutionMode.TIMED ? <input type="number" name="time" min={isFixed ? 0 : 1} value={step.time ?? ''} onChange={(e) => this.handleFermentationStepChange(e.target.value, e.target.name, index)} required={!isFixed} /> : <span className="muted-table-value">–</span>}</td>
                                 <td className="action-column">{index > 0 && !isFixed && <button type="button" className="cancel-btn brauhaus-button brauhaus-button-danger brauhaus-icon-button" onClick={() => this.removeFermentationStep(index)} title="Rast löschen" aria-label="Rast löschen">🗑️</button>}</td>
                             </tr>;
                         })}</tbody>

--- a/src/containers/DatabaseOverview/fermentationDefaults.test.ts
+++ b/src/containers/DatabaseOverview/fermentationDefaults.test.ts
@@ -60,7 +60,7 @@ describe('fermentationDefaults', () => {
         expect(createDefaultFermentationSteps()).toEqual([
             {type: 'Einmaischen', temperature: 0},
             {type: 'Abmaischen', temperature: 0},
-            {type: 'Kochen', time: 0},
+            {type: 'Kochen'},
         ]);
     });
 

--- a/src/containers/DatabaseOverview/fermentationDefaults.ts
+++ b/src/containers/DatabaseOverview/fermentationDefaults.ts
@@ -8,16 +8,16 @@ export const fixedProcedureTypes = ['Einmaischen', 'Abmaischen', 'Kochen'] as co
 export const createDefaultFermentationSteps = (): FermentationSteps[] => [
     {type: 'Einmaischen', temperature: 0},
     {type: 'Abmaischen', temperature: 0},
-    {type: 'Kochen', time: 0},
+    {type: 'Kochen'},
 ];
 
 const normalizeFixedStep = (step: FermentationSteps): FermentationSteps => {
     if (step.type === 'Einmaischen' || step.type === 'Abmaischen') {
         return {type: step.type, temperature: step.temperature};
     }
-    const cookingStep = {...step};
-    delete cookingStep.temperature;
-    return cookingStep;
+    // Kochzeit und -temperatur liegen im Formular ausschließlich auf dem Rezept.
+    // Der feste Schritt wird erst beim Serialisieren daraus befüllt.
+    return {type: 'Kochen'};
 };
 
 export const decoctionRequiresRastError = 'Bitte ordne der Dekoktion eine Rast zu.';


### PR DESCRIPTION
### Motivation
- Der Rezepteditor soll klar zwischen Brauwasser und dem eigentlichen Brauprozess trennen und Doppelhaltung von Kochzeit/-temperatur vermeiden.
- Kochzeit soll nur im Brauprozess editierbar sein und Kochtemperatur dort nur lesbar angezeigt werden, während der Persistenz-/API-Vertrag unverändert bleibt.

### Description
- Benennung/Struktur: Die Akkordeonüberschriften wurden angepasst von `Braudaten` → `Brauwasser` und von `Maischeplan` → `Brauprozess`, wobei der `Brauwasser`-Abschnitt nur noch Hauptguss und Nachguss enthält (`src/containers/DatabaseOverview/BeerForm.tsx`).
- Darstellung/Editing: Eingabefelder für `Kochzeit` und `Kochtemperatur` wurden aus dem Brauwasser-Bereich entfernt; im `Brauprozess`-Tab zeigt die `Kochen`-Zeile die Rezept-Temperatur als `readOnly` und macht die `Kochzeit` dort editierbar (Verwendung bestehender Styling-Klassen für nicht-editierbare Felder).
- Single source of truth: Das Formular hält `cookingTime` und `cookingTemperatur` weiterhin einmalig im Formular-Zustand; beim Serialisieren werden diese Werte in den festen `Kochen`-Schritt übernommen (`src/containers/DatabaseOverview/fermentationDefaults.ts` und `BeerForm.tsx`).
- Defaultwert: Neues Rezeptmodell initialisiert `cookingTemperatur` zentral auf `100 °C` (`DEFAULT_COOKING_TEMPERATURE = 100`).
- Tests: Bestehende UI-Tests wurden angepasst, um die neue Struktur und das Verhalten zu prüfen (angepasste Assertions in `src/containers/DatabaseOverview/BeerForm.test.tsx` und `fermentationDefaults.test.ts`).

### Testing
- `git diff --check` wurde ausgeführt und zeigte keine whitespace-/diff-Fehler (erfolgreich).
- Testversuche mit `CI=true npm test -- --runInBand src/containers/DatabaseOverview/BeerForm.test.tsx src/containers/DatabaseOverview/fermentationDefaults.test.ts` und mit `CI=true npx react-scripts test --runInBand ...` schlugen fehl, da Projektabhängigkeiten nicht installiert werden konnten (Registry/Authentifizierungsfehler), sodass die Jest-Tests nicht vollständig lokal ausgeführt werden konnten.
- Die relevanten Unit-Tests wurden lokal angepasst; sie erwarten nun, dass `Kochzeit`/`Kochtemperatur` nur im `Brauprozess` vorhanden sind, Temperatur read-only ist, und der `100 °C`-Default für neue Rezepte verwendet wird.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8dd98eb29c832fb519df6f3dbacb72)