### PR TITLE
Kompakte Inline-Bestätigung für „Aktueller Schritt“ mit pulsendem Ausrufezeichen

### DIFF
--- a/src/containers/Production/ProcessList/ProcessList.test.tsx
+++ b/src/containers/Production/ProcessList/ProcessList.test.tsx
@@ -295,7 +295,8 @@ describe('ProcessList compact production overview', () => {
         const waitingStatus = activeStatus(3, ProcessMode.WAITING);
         waitingStatus.waiting = {waitingFor: WaitingFor.IODINE_TEST, canConfirm: true};
         const {rerender} = render(<ProcessList selectedBeer={selectedBeer} currentStepIndex={3} currentStep={{index: 3, phase: ProcessPhase.RAST, mode: ProcessMode.WAITING}} brewingStatus={waitingStatus} remainingSeconds={1176} />);
-        expect(screen.getByText('Wartet auf Bestätigung')).toBeInTheDocument();
+        expect(screen.getByLabelText('Aktion erforderlich')).toHaveTextContent('Jodprobe durchführen');
+        expect(screen.queryByText('Wartet auf Bestätigung')).not.toBeInTheDocument();
         expect(screen.queryByText('Fortschritt')).not.toBeInTheDocument();
         expect(screen.queryByText('Restzeit')).not.toBeInTheDocument();
 

--- a/src/containers/Production/ProcessList/ProcessList.tsx
+++ b/src/containers/Production/ProcessList/ProcessList.tsx
@@ -287,7 +287,10 @@ export class ProcessList extends React.Component<ProcessListProps, ProcessListSt
     renderInlineNotice(): React.ReactNode {
         const confirmationRequest = getConfirmationRequestViewModel(this.props.brewingStatus);
         if (confirmationRequest) {
-            return <ControlConfirmationNotice request={confirmationRequest} pending={this.props.confirmationPending === true} onConfirm={this.props.onConfirmWaiting} />;
+            const heldMashTemperature = this.props.brewingStatus?.currentStep?.phase === ProcessPhase.DECOCTION
+                ? this.props.brewingStatus?.temperature?.target ?? this.getRelatedRastTemperature(undefined)
+                : undefined;
+            return <ControlConfirmationNotice request={confirmationRequest} pending={this.props.confirmationPending === true} onConfirm={this.props.onConfirmWaiting} heldMashTemperature={heldMashTemperature} />;
         }
         if (this.props.hopReminderName && this.props.onCompleteHopReminder) {
             return <HopReminderNotice hopName={this.props.hopReminderName} onDone={this.props.onCompleteHopReminder} />;
@@ -322,11 +325,12 @@ export class ProcessList extends React.Component<ProcessListProps, ProcessListSt
         const activeStep = stepIndex >= 0 ? steps[stepIndex] : undefined;
         const upcomingSteps = stepIndex >= 0 ? steps.slice(stepIndex + 1) : steps;
         const progressLabel = stepIndex >= 0 ? `${stepIndex + 1} / ${steps.length}` : '';
+        const confirmationRequest = getConfirmationRequestViewModel(brewingStatus);
 
         const currentStepCard = hasRecipeProcess ? (
             <>
                 <div className="current-process-label">Aktueller Schritt</div>
-                <section className={`current-process-step${getConfirmationRequestViewModel(brewingStatus) ? ' current-process-step--action-required' : ''}`} aria-label="Aktueller Prozessschritt">
+                <section className={`current-process-step${confirmationRequest ? ' current-process-step--action-required' : ''}`} aria-label="Aktueller Prozessschritt">
                     <div className="current-step-heading">
                         <div>
                             <h4>{isProcessStarted ? this.getCurrentStepTitle(activeStep) : 'Noch kein Brauvorgang gestartet'}</h4>
@@ -334,7 +338,7 @@ export class ProcessList extends React.Component<ProcessListProps, ProcessListSt
                         </div>
                         {this.getCurrentStepMeta(activeStep, isProcessStarted)}
                     </div>
-                    {this.renderStatusSection(isProcessStarted)}
+                    {!confirmationRequest && this.renderStatusSection(isProcessStarted)}
                     {this.renderInlineNotice()}
                 </section>
             </>

--- a/src/containers/Production/Production.test.tsx
+++ b/src/containers/Production/Production.test.tsx
@@ -186,7 +186,7 @@ describe('Production inline confirmations', () => {
         [WaitingFor.IODINE_TEST, ProcessPhase.RAST, 'Jodprobe abgeschlossen', ConfirmStates.IODINE],
         [WaitingFor.MASHING_IN_CONFIRMATION, ProcessPhase.MASHING_IN, 'Einmaischen abgeschlossen', ConfirmStates.MASHUP],
         [WaitingFor.MASHING_OUT_CONFIRMATION, ProcessPhase.MASHING_OUT, 'Abmaischen abgeschlossen', ConfirmStates.MASHUP],
-        [WaitingFor.BOILING_CONFIRMATION, ProcessPhase.COOKING, 'Siedepunkt bestätigen', ConfirmStates.BOILING],
+        [WaitingFor.BOILING_CONFIRMATION, ProcessPhase.COOKING, 'Siedepunkt erreicht', ConfirmStates.BOILING],
         [WaitingFor.COOKING_CONFIRMATION, ProcessPhase.COOKING, 'Kochen bestätigen', ConfirmStates.COOKING],
     ] as const)('renders %s inline and dispatches the existing confirm state', (waitingFor, phase, buttonLabel, confirmState) => {
         const confirm = jest.fn();
@@ -210,6 +210,7 @@ describe('Production inline confirmations', () => {
         renderProduction({brewingStatus: waitingStatus(WaitingFor.DECOCTION_CONFIRMATION, ProcessPhase.DECOCTION)});
         expect(screen.getByText('Hauptmaische · gehaltene Rasttemperatur')).toBeInTheDocument();
         expect(screen.getByText('66 °C')).toBeInTheDocument();
+        expect(screen.getByText('Hauptmaische wird weiterhin auf 66 °C gehalten.')).toBeInTheDocument();
     });
 
     it('uses the related rest temperature when the controller has no target for a decoction', () => {

--- a/src/containers/Production/components/InlineProcessNotice.css
+++ b/src/containers/Production/components/InlineProcessNotice.css
@@ -1,20 +1,24 @@
 .inline-process-notice {
-    border: 1px solid color-mix(in srgb, var(--color-accent) 72%, transparent);
-    border-left: 0.35rem solid var(--color-accent);
-    border-radius: 0.7rem;
-    margin-top: 0.65rem;
-    padding: 0.7rem 0.8rem;
-    background: color-mix(in srgb, var(--color-accent) 10%, var(--color-surface-2));
+    border-top: 1px solid color-mix(in srgb, var(--color-accent) 55%, transparent);
+    margin-top: 0.5rem;
+    padding: 0.45rem 0 0;
     color: var(--color-light-text);
 }
 
 .inline-process-notice--action {
-    box-shadow: 0 0 0 1px color-mix(in srgb, var(--color-accent) 16%, transparent);
+    min-height: 3.75rem;
 }
 
 .inline-process-notice--reminder {
     background: color-mix(in srgb, var(--color-accent) 6%, var(--color-surface-2));
+    border: 1px solid color-mix(in srgb, var(--color-accent) 72%, transparent);
+    border-left: 0.35rem solid var(--color-accent);
+    border-radius: 0.7rem;
+    padding: 0.7rem 0.8rem;
 }
+
+.inline-process-notice--reminder .inline-process-notice__button { margin-top: 0.65rem; }
+.inline-process-notice--reminder p { line-height: 1.35; margin: 0.35rem 0 0; }
 
 .inline-process-notice__eyebrow {
     color: var(--color-accent);
@@ -25,15 +29,51 @@
     text-transform: uppercase;
 }
 
+.inline-process-notice__content {
+    flex: 1 1 auto;
+    min-width: 0;
+}
+
+.inline-process-notice__heading {
+    align-items: center;
+    display: flex;
+    gap: 0.4rem;
+}
+
+.inline-process-notice__alert {
+    align-items: center;
+    animation: confirmation-alert-pulse 1.3s ease-in-out infinite;
+    border: 2px solid var(--color-accent);
+    border-radius: 50%;
+    color: var(--color-accent);
+    display: inline-flex;
+    font-size: 0.78rem;
+    font-weight: 900;
+    height: 1.25rem;
+    justify-content: center;
+    line-height: 1;
+    width: 1.25rem;
+}
+
+.inline-process-notice__action-row {
+    align-items: center;
+    display: flex;
+    gap: 1rem;
+    justify-content: space-between;
+    margin-top: 0.2rem;
+}
+
 .inline-process-notice h5 {
     color: inherit;
     font-size: 1.02rem;
     margin: 0.2rem 0 0;
 }
 
-.inline-process-notice p {
+.inline-process-notice__detail {
+    color: rgba(255, 255, 255, 0.72);
+    font-size: 0.82rem;
     line-height: 1.35;
-    margin: 0.35rem 0 0;
+    margin: 0.25rem 0 0 1.65rem;
 }
 
 .inline-process-notice__button {
@@ -43,10 +83,24 @@
     color: var(--color-white);
     cursor: pointer;
     font-weight: 800;
-    margin-top: 0.65rem;
-    min-height: 2.6rem;
-    padding: 0.55rem 1rem;
-    width: 100%;
+    flex: 0 1 16rem;
+    min-height: 2.5rem;
+    padding: 0.45rem 0.9rem;
+    width: clamp(13.75rem, 22vw, 17.5rem);
+}
+
+@keyframes confirmation-alert-pulse {
+    0%, 100% { opacity: 0.55; transform: scale(0.94); }
+    50% { opacity: 1; transform: scale(1); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .inline-process-notice__alert { animation: none; }
+}
+
+@media (max-width: 700px) {
+    .inline-process-notice__action-row { align-items: stretch; flex-direction: column; gap: 0.4rem; }
+    .inline-process-notice__button { flex-basis: auto; max-width: 100%; width: 100%; }
 }
 
 .inline-process-notice__button--secondary {

--- a/src/containers/Production/components/InlineProcessNotice.tsx
+++ b/src/containers/Production/components/InlineProcessNotice.tsx
@@ -1,23 +1,44 @@
 import React from 'react';
 import {ConfirmationRequestViewModel} from '../../../utils/brewingStatus/selectors';
+import {WaitingFor} from '../../../model/brewingStatus.types';
 import './InlineProcessNotice.css';
 
 interface ControlConfirmationNoticeProps {
     request: ConfirmationRequestViewModel;
     pending: boolean;
     onConfirm?: () => void;
+    heldMashTemperature?: number;
 }
 
-export const ControlConfirmationNotice: React.FC<ControlConfirmationNoticeProps> = ({request, pending, onConfirm}) => (
+const compactCopyByWaitingState: Partial<Record<WaitingFor, {title: string; buttonLabel?: string}>> = {
+    [WaitingFor.MASHING_IN_CONFIRMATION]: {title: 'Einmaischen abschließen'},
+    [WaitingFor.IODINE_TEST]: {title: 'Jodprobe durchführen'},
+    [WaitingFor.DECOCTION_CONFIRMATION]: {title: 'Dekoktion abschließen'},
+    [WaitingFor.MASHING_OUT_CONFIRMATION]: {title: 'Abmaischen abschließen'},
+    [WaitingFor.COOKING_CONFIRMATION]: {title: 'Kochen bestätigen'},
+    [WaitingFor.BOILING_CONFIRMATION]: {title: 'Siedepunkt bestätigen', buttonLabel: 'Siedepunkt erreicht'},
+};
+
+export const ControlConfirmationNotice: React.FC<ControlConfirmationNoticeProps> = ({request, pending, onConfirm, heldMashTemperature}) => (
     <section className="inline-process-notice inline-process-notice--action" aria-label="Aktion erforderlich" aria-live="polite">
-        <span className="inline-process-notice__eyebrow">Aktion erforderlich</span>
-        <h5>{request.title}</h5>
-        <p>{pending ? 'Bestätigung wird verarbeitet …' : request.message}</p>
-        {request.canConfirm && request.confirmState && onConfirm && (
-            <button type="button" className="inline-process-notice__button" disabled={pending} onClick={onConfirm}>
-                {pending ? 'Wird verarbeitet …' : request.buttonLabel}
-            </button>
-        )}
+        <div className="inline-process-notice__content">
+            <div className="inline-process-notice__heading">
+                <span className="inline-process-notice__alert" aria-hidden="true">!</span>
+                <span className="inline-process-notice__eyebrow">Aktion erforderlich</span>
+            </div>
+            <div className="inline-process-notice__action-row">
+                <h5>{compactCopyByWaitingState[request.waitingFor as WaitingFor]?.title ?? request.title}</h5>
+                {request.canConfirm && request.confirmState && onConfirm && (
+                    <button type="button" className="inline-process-notice__button" disabled={pending} onClick={onConfirm}>
+                        {pending ? 'Wird verarbeitet …' : (compactCopyByWaitingState[request.waitingFor as WaitingFor]?.buttonLabel ?? request.buttonLabel)}
+                    </button>
+                )}
+            </div>
+            {request.waitingFor === WaitingFor.DECOCTION_CONFIRMATION && typeof heldMashTemperature === 'number' && (
+                <p className="inline-process-notice__detail">Hauptmaische wird weiterhin auf {heldMashTemperature.toLocaleString('de-DE', {maximumFractionDigits: 1})} °C gehalten.</p>
+            )}
+            {!request.canConfirm && <p className="inline-process-notice__detail">{request.message}</p>}
+        </div>
     </section>
 );
 


### PR DESCRIPTION
### Motivation

- Die bestehende Inline-Darstellung für bestätigungspflichtige Prozessschritte war zu hoch und verschob die Temperaturanzeige nach unten, enthielt redundante Statustexte und wirkte zu dominant.
- Ziel war ein deutlich kompakterer, sofort als Aktion erkennbarer Bereich ohne neue Prozess-/Confirm-Logik, mit dezent pulsendem Ausrufezeichen und besserem Responsive-Verhalten.

### Description

- Kompakte, horizontale Aktionsdarstellung implementiert und redundante Statusanzeige ausgeblendet während eine Bestätigung aktiv ist, indem die Status-Section nicht gerendert wird wenn ein Confirmation-Request vorliegt (`ProcessList`-Rendering angepasst). (Datei: `src/containers/Production/ProcessList/ProcessList.tsx`)
- Neues kompakteres Inline-Layout mit linkem Ausrufezeichen, kurzer Eyebrow „Aktion erforderlich“, Aktionslabel links und begrenztem Bestätigungsbutton rechts sowie responsivem Umbruch bei kleinen Viewports; Button-Breite per `clamp()` begrenzt (ca. 220–280 px Zielbereich). (Datei: `src/containers/Production/components/InlineProcessNotice.tsx`, `InlineProcessNotice.css`)
- Ruhiges, orangefarbenes pulsendes Ausrufezeichen nur am Symbol selbst mit einer ~1.3s Animationsdauer und `prefers-reduced-motion`-Fallback, Animation wird nur gezeigt solange eine Benutzeraktion erforderlich ist; sonst bleibt das Symbol statisch sichtbar. (Datei: `InlineProcessNotice.css`)
- Dekoktion-Sonderfall beibehalten und kompakt dargestellt: zusätzliche kleine Infozeile zeigt die gehaltene Hauptmaischetemperatur und nutzt weiterhin die vorhandenen `temperature.target` bzw. `relatedRastId`-Auflösung; es wurde keine Prozess- oder Confirm-Logik verändert. (Dateien: `ProcessList.tsx`, `InlineProcessNotice.tsx`)
- Längere Erklärtexte entfernt und kompakte Kopien für Standard-Confirm-Typen verwendet; vorhandene Confirm-Zuordnung und `ConfirmationRequestViewModel`-Selektoren wurden nicht geändert. (Dateien: `src/containers/Production/components/InlineProcessNotice.tsx`, `src/utils/brewingStatus/selectors.ts` unverändert)
- Änderungen an Test-Assertions vorgenommen, um die kompakte Darstellung und die neue Button-Beschriftung für Siedepunkt zu prüfen (Dateien: `src/containers/Production/ProcessList/ProcessList.test.tsx`, `src/containers/Production/Production.test.tsx`).

### Testing

- `git diff --check` wurde ausgeführt und beanstandet keine whitespace-/diff-Probleme (erfolgreich). 
- Arbeitsbaum/Status geprüft und die geänderten Dateien sind vorhanden (Arbeitsbaum sauber nach Änderungen).
- Die lokalen Jest-Tests konnten im Container nicht vollständig ausgeführt werden, weil `react-scripts` nicht verfügbar war und ein Versuch mit `npx react-scripts` am Registry-Zugriff scheiterte, weshalb UI-Tests nicht lokal durchgelaufen sind (Fehler: fehlendes `react-scripts` / Registry 403). 
- Die angepassten Unit-Testdateien wurden aktualisiert (`ProcessList.test.tsx`, `Production.test.tsx`) und sind auf die neue Darstellung ausgerichtet; automatisches Test-Running in dieser Umgebung konnte jedoch nicht abgeschlossen werden.

Geänderte Dateien (Kurz):
- `src/containers/Production/components/InlineProcessNotice.tsx` (neues kompaktes Layout, Dekoktion-Detail, Button-Label-Auswahl)
- `src/containers/Production/components/InlineProcessNotice.css` (kompakte Abstände, pulsendes Ausrufezeichen, responsive Regeln, `prefers-reduced-motion`)
- `src/containers/Production/ProcessList/ProcessList.tsx` (Status-Rendering ausgeblendet bei Confirmation, Übergabe der gehaltenen Rasttemperatur)
- `src/containers/Production/ProcessList/ProcessList.test.tsx` (Assertions für neue kompakte Darstellung)
- `src/containers/Production/Production.test.tsx` (Button-Label für Siedepunkt angepasst und Dekoktion-Info geprüft)

Hinweis: Die Implementierung ist rein visuell / CSS/JSX-basiert und ändert nicht die Confirm-Backendschnittstellen, Redux-Aktionen, Epics oder das `ConfirmationRequestViewModel`-Verhalten.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8ddd73b950832f8e29dbb362480152)