### PR TITLE
Switch recipe import to JSON {source, recipe}; add import dialog, model, epic and tests

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -30,7 +30,7 @@ Base route:
 | `POST` | `/beer` | Create a beer recipe |
 | `PUT` | `/beer/{id}` | Update a beer recipe |
 | `DELETE` | `/beer/{id}` | Delete a beer recipe |
-| `POST` | `/importbeer` | Import a recipe file |
+| `POST` | `/importbeer` | Import recipe JSON with `{ source, recipe }` |
 | `GET` | `/finishedbeers` | Load completed brews |
 | `POST` | `/finishedbeer` | Save a completed brew |
 | `DELETE` | `/finishedbeer/{id}` | Delete a completed brew |

--- a/docs/codex/compatibility/cross-repo-contracts.md
+++ b/docs/codex/compatibility/cross-repo-contracts.md
@@ -8,6 +8,16 @@ Codex must check this file before changing API-facing, UI-visible, database-faci
 
 ## UI ↔ Database/backend
 
+### Recipe import request
+
+The UI sends `POST /importbeer` with `Content-Type: application/json` and body
+`{ source, recipe }`. `source` is exactly `MAISCHE_MALZ_UND_MEHR`, `BRAUREKA`, or `BRAUHAUS`,
+and `recipe` is the syntactically parsed external JSON without conversion to the
+UI `Beer` or `BeerDTO` models. A successful response must remain a full `Beer`.
+BeerDatabase support for this request, including validation/error response shapes,
+is **Needs cross-repository update**; the old multipart `file` request is no longer
+sent by this UI.
+
 The React UI consumes database/backend data for:
 
 - beer recipes,

--- a/docs/codex/data-flow.md
+++ b/docs/codex/data-flow.md
@@ -1,5 +1,18 @@
 # Data flow
 
+## Recipe import
+
+The recipe editor opens a source/file dialog. After the user selects
+`MAISCHE_MALZ_UND_MEHR`, `BRAUREKA`, or `BRAUHAUS`, the UI reads the selected file as text and
+uses `JSON.parse` only for syntax checking. It sends the resulting value unchanged
+as `recipe` together with the selected `source` to `POST /api/database/importbeer`
+as JSON. The backend remains responsible for format-specific validation,
+normalization, mapping, and persistence. The successful `Beer` response continues
+through `ADD_IMPORTED_BEER` into the recipe list and editor.
+
+Needs cross-repository update: BeerDatabase must accept this JSON request contract;
+the previously documented backend contract accepts multipart field `file`.
+
 ## Startup flow
 
 - `src/index.tsx` dispatches `ApplicationActions.setTheme(resolveInitialTheme())` before rendering.

--- a/docs/codex/external/database-context.md
+++ b/docs/codex/external/database-context.md
@@ -55,6 +55,12 @@ Important compatibility assumptions:
 - `DELETE /beer/<beer_id>` -> success returns `{ "message": "Beer deleted successfully", "id": beer_id }`.
 - `POST /importbeer` -> multipart field `file`; success returns full created recipe object.
 
+UI compatibility note: the UI now expects to replace the multipart request with
+`POST /importbeer` JSON `{ source, recipe }`, where `source` is
+`MAISCHE_MALZ_UND_MEHR`, `BRAUREKA`, or `BRAUHAUS`. Backend implementation of that request is
+**Needs cross-repository update**; this section otherwise documents the last known
+backend behavior.
+
 Recipe object response shape:
 
 ```json

--- a/docs/codex/interfaces.md
+++ b/docs/codex/interfaces.md
@@ -10,7 +10,7 @@ Base URL: `DatabaseURL` (`/api/database`).
 | POST | `beer` | Create recipe | `BeerDTO` without `id`, returns `{ id, message, beer: { id } }` |
 | PUT | `beer/{id}` | Update recipe | `BeerDTO` with matching `id` or no body id, returns `{ id, message, beer: { id } }`; unknown id returns `404 BEER_NOT_FOUND` |
 | DELETE | `beer/{id}` | Delete recipe | no body |
-| POST | `importbeer` | Import recipe file | multipart `file`, response `any`/imported beer |
+| POST | `importbeer` | Import recipe JSON | `{ source: 'MAISCHE_MALZ_UND_MEHR' \| 'BRAUREKA' \| 'BRAUHAUS', recipe: unknown }`, returns imported `Beer` |
 | GET | `finishedbeers` | Load finished brews | `FinishedBrew[]` |
 | POST | `finishedbeer` | Create finished brew | `FinishedBrew`, returns `FinishedBrew` |
 | POST | `finishedbeer` | Update finished brew | `FinishedBrew`, returns `FinishedBrew`; create/update distinction is backend-owned |

--- a/docs/frontend-api-usage.md
+++ b/docs/frontend-api-usage.md
@@ -48,7 +48,7 @@ This document reflects the **current React frontend implementation** after align
 |---|---|---|---|---|---|---|
 | GET | `beers` (`DatabaseURL`) | Load beer recipes | Safe Read | `BeerRepository.getBeers` | none | No |
 | POST | `beer` (`DatabaseURL`) | Create/submit beer recipe | Workflow Prepare | `BeerRepository.submitBeer` | `BeerDTO` JSON | No |
-| POST | `importbeer` (`DatabaseURL`) | Import beer from file | Workflow Prepare | `BeerRepository.importBeer` | `FormData(file)` | Medium (response type `any`) |
+| POST | `importbeer` (`DatabaseURL`) | Import external recipe JSON | Workflow Prepare | `BeerRepository.importBeer` | `{ source, recipe }` JSON | Backend contract update required |
 | GET | `finishedbeers` (`DatabaseURL`) | Load finished brews | Safe Read | `FinishedBeerRepository.getFinishedBeers` | none | No |
 | POST | `finishedbeer` (`DatabaseURL`) | Add finished brew | Workflow Prepare | `FinishedBeerRepository.sendNewFinishedBeer` | `FinishedBrew` JSON | No |
 | POST | `finishedbeer` (`DatabaseURL`) | Update finished brew | Workflow Control | `FinishedBeerRepository.updateFinishedBeer` | `FinishedBrew` JSON | Medium (POST used for update) |
@@ -93,7 +93,7 @@ This document reflects the **current React frontend implementation** after align
 ### 2) Recipe/workflow preparation
 
 - POST `DatabaseURL + beer`
-- POST `DatabaseURL + importbeer` (multipart file)
+- POST `DatabaseURL + importbeer` (`{ source, recipe }` JSON)
 - POST `DatabaseURL + hop`
 - POST `DatabaseURL + malt`
 - POST `DatabaseURL + yeast`

--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -10,6 +10,7 @@ import {WaterStatus} from "../components/Controlls/WaterControll/WaterControl";
 import {FinishedBrew} from "../model/FinishedBrew";
 import {BackendAvailable} from "../reducers/productionReducer";
 import {scalingValues} from "../utils/BeerScaler/ScalingBeerRecipe";
+import {RecipeImportRequest} from '../model/RecipeImport';
 import { ThemeName, setTheme as applyAndStoreTheme } from "../utils/theme";
 import { pushViewPath } from "../utils/viewRoutes";
 
@@ -188,7 +189,7 @@ export namespace BeerActions {
     export interface ImportBeer {
         readonly type: ActionTypes.IMPORT_BEER;
         payload: {
-            file: File;
+            request: RecipeImportRequest;
         }
     }
 
@@ -394,11 +395,10 @@ export namespace BeerActions {
         }
     }
 
-    export function importBeer(file: File): ImportBeer {
-        console.log(file);
+    export function importBeer(request: RecipeImportRequest): ImportBeer {
         return {
             type: ActionTypes.IMPORT_BEER,
-            payload: {file}
+            payload: {request}
         };
     }
 

--- a/src/containers/DatabaseOverview/BeerForm.connect.ts
+++ b/src/containers/DatabaseOverview/BeerForm.connect.ts
@@ -6,6 +6,7 @@ import {HopsActions} from "../../actions/hops.actions";
 import {YeastActions} from "../../actions/yeast.actions";
 import {AdditionalIngredientsActions} from "../../actions/additionalIngredients.actions";
 import {BeerForm} from './BeerForm';
+import {RecipeImportRequest} from '../../model/RecipeImport';
 
 const mapStateToProps = (state: any) => ({
     malts: state.maltsReducer.malts,
@@ -28,7 +29,7 @@ const mapDispatchToProps = (dispatch: any) => ({
     getYeast: (isFetching: boolean) => dispatch(YeastActions.getYeasts(isFetching)),
     getAdditionalIngredients: (isFetching: boolean) => dispatch(AdditionalIngredientsActions.getAdditionalIngredients(isFetching)),
     saveBeerFormState: (formState: any) => dispatch(BeerActions.saveBeerFormState(formState)),
-    importBeer: (file: File) => dispatch(BeerActions.importBeer(file)),
+    importBeer: (request: RecipeImportRequest) => dispatch(BeerActions.importBeer(request)),
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(BeerForm);

--- a/src/containers/DatabaseOverview/BeerForm.tsx
+++ b/src/containers/DatabaseOverview/BeerForm.tsx
@@ -13,6 +13,8 @@ import './BeerForm.css'
 import {AdditionalIngredient} from "../../model/AdditionalIngredient";
 import ModalDialog, {DialogType} from "../../components/ModalDialog/ModalDialog";
 import { isRequiredPositiveQuantity } from "../../utils/beerSubmission";
+import {RecipeImportRequest} from '../../model/RecipeImport';
+import {RecipeImportDialog} from './RecipeImportDialog';
 
 interface BeerFormProps {
     onSubmitBeer: (beer: BeerDTO) => void;
@@ -30,7 +32,7 @@ interface BeerFormProps {
     message?: string;
     beerFormState?: any;
     beers: Beer[];
-    importBeer: (file: File) => void;
+    importBeer: (request: RecipeImportRequest) => void;
     importedBeer?: Beer;
     isSavingBeer?: boolean;
 }
@@ -71,10 +73,10 @@ interface BeerFormState {
     validationDialogMessage: string;
     validationErrors: Record<string, string>;
     expandedSections: Record<BeerFormSection, boolean>;
+    showImportDialog: boolean;
 }
 
 export class BeerForm extends React.Component<BeerFormProps, BeerFormState> {
-    private fileInput: HTMLInputElement | null | undefined;
     private fixedTypes: readonly string[] = fixedProcedureTypes;
     constructor(props: BeerFormProps) {
 
@@ -104,6 +106,7 @@ export class BeerForm extends React.Component<BeerFormProps, BeerFormState> {
             showValidationDialog: false,
             validationDialogMessage: '',
             validationErrors: {},
+            showImportDialog: false,
             expandedSections: {
                 basic: true,
                 brewing: true,
@@ -932,12 +935,11 @@ export class BeerForm extends React.Component<BeerFormProps, BeerFormState> {
 
         return (
             <form id="beer-recipe-form" className="beer-form" onSubmit={this.handleSubmit} noValidate>
-                <input type="file" accept="application/json" className="visually-hidden-file" ref={ref => this.fileInput = ref} onChange={this.handleImportBeerJson} />
                 <div className="beer-form-toolbar">
                     <div className="beer-form-toolbar-title">Rezept</div>
                     <label className="beer-select-label">Bier auswählen:<select onChange={this.handleBeerSelect} value={beers.find(b => b.name === name)?.id || ''}><option value="">Neues Bier anlegen</option>{beers.map(beer => <option key={beer.id} value={beer.id}>{beer.name}</option>)}</select></label>
                     <button type="button" className="add-button brauhaus-button brauhaus-button-secondary toolbar-button" onClick={this.resetForm}>Neues Bier</button>
-                    <button type="button" className="add-button brauhaus-button brauhaus-button-secondary toolbar-button" onClick={() => this.fileInput && this.fileInput.click()}>Importieren</button>
+                    <button type="button" className="add-button brauhaus-button brauhaus-button-secondary toolbar-button" onClick={() => this.setState({showImportDialog: true})}>Importieren</button>
                 </div>
                 <div className="beer-form-overview" aria-label="Rezeptübersicht">
                     <div className="beer-form-overview-item"><span>Name</span><strong>{name || 'Neues Bier'}</strong></div>
@@ -960,18 +962,8 @@ export class BeerForm extends React.Component<BeerFormProps, BeerFormState> {
         );
     }
 
-    handleImportBeerJson = (event: React.ChangeEvent<HTMLInputElement>) => {
-        const { importBeer } = this.props;
-        const file = event.target.files && event.target.files[0];
-        if (file) {
-            importBeer(file);
-        }
-        // Damit auch dieselbe Datei erneut ein onChange-Event auslöst.
-        event.target.value = '';
-    };
-
     render() {
-        const {showValidationDialog, validationDialogMessage} = this.state;
+        const {showValidationDialog, validationDialogMessage, showImportDialog} = this.state;
         return (
             <div className='containerBeerForm'>
                 <ModalDialog
@@ -980,6 +972,14 @@ export class BeerForm extends React.Component<BeerFormProps, BeerFormState> {
                     content={validationDialogMessage}
                     header={"Validierungsfehler"}
                     onConfirm={this.closeValidationDialog}
+                />
+                <RecipeImportDialog
+                    open={showImportDialog}
+                    onCancel={() => this.setState({showImportDialog: false})}
+                    onImport={(request) => {
+                        this.props.importBeer(request);
+                        this.setState({showImportDialog: false});
+                    }}
                 />
                 <div className="beer-form-panel">
                     <div className="beer-form-panel-header">

--- a/src/containers/DatabaseOverview/RecipeImportDialog.test.tsx
+++ b/src/containers/DatabaseOverview/RecipeImportDialog.test.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import {fireEvent, render, screen, waitFor} from '@testing-library/react';
+import {RecipeImportDialog} from './RecipeImportDialog';
+import {RecipeImportSource} from '../../model/RecipeImport';
+
+const jsonFile = (content: string) => ({
+    name: 'recipe.json',
+    text: jest.fn().mockResolvedValue(content),
+}) as unknown as File;
+
+const selectSource = (label: string) => {
+    fireEvent.mouseDown(screen.getByLabelText('Quelle'));
+    fireEvent.click(screen.getByRole('option', {name: label}));
+};
+
+const selectFile = (file: File) => {
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement;
+    fireEvent.change(input, {target: {files: [file]}});
+};
+
+describe('RecipeImportDialog', () => {
+    it.each([
+        ['MaischeMalzundMehr', RecipeImportSource.MAISCHE_MALZ_UND_MEHR],
+        ['BräuReKa / Müggelland', RecipeImportSource.BRAUREKA],
+        ['Brauhaus', RecipeImportSource.BRAUHAUS],
+    ])('sends valid JSON unchanged for source %s', async (label, source) => {
+        const onImport = jest.fn();
+        const recipe = {name: 'Extern', nested: {value: 7}, values: [1, '2', null]};
+        render(<RecipeImportDialog open onCancel={jest.fn()} onImport={onImport} />);
+
+        selectSource(label as string);
+        selectFile(jsonFile(JSON.stringify(recipe)));
+        fireEvent.click(screen.getByRole('button', {name: 'Import starten'}));
+
+        await waitFor(() => expect(onImport).toHaveBeenCalledWith({source, recipe}));
+    });
+
+    it('does not import without a source', async () => {
+        const onImport = jest.fn();
+        render(<RecipeImportDialog open onCancel={jest.fn()} onImport={onImport} />);
+        selectFile(jsonFile('{"name":"Extern"}'));
+
+        fireEvent.click(screen.getByRole('button', {name: 'Import starten'}));
+
+        expect(await screen.findByRole('alert')).toHaveTextContent('Bitte wählen Sie eine Rezeptquelle aus.');
+        expect(onImport).not.toHaveBeenCalled();
+    });
+
+    it('does not import without a file', async () => {
+        const onImport = jest.fn();
+        render(<RecipeImportDialog open onCancel={jest.fn()} onImport={onImport} />);
+        selectSource('MaischeMalzundMehr');
+
+        fireEvent.click(screen.getByRole('button', {name: 'Import starten'}));
+
+        expect(await screen.findByRole('alert')).toHaveTextContent('Bitte wählen Sie eine JSON-Datei aus.');
+        expect(onImport).not.toHaveBeenCalled();
+    });
+
+    it('rejects invalid JSON without importing', async () => {
+        const onImport = jest.fn();
+        render(<RecipeImportDialog open onCancel={jest.fn()} onImport={onImport} />);
+        selectSource('BräuReKa / Müggelland');
+        selectFile(jsonFile('{invalid'));
+
+        fireEvent.click(screen.getByRole('button', {name: 'Import starten'}));
+
+        expect(await screen.findByRole('alert')).toHaveTextContent('Die ausgewählte Datei enthält kein gültiges JSON.');
+        expect(onImport).not.toHaveBeenCalled();
+    });
+});

--- a/src/containers/DatabaseOverview/RecipeImportDialog.tsx
+++ b/src/containers/DatabaseOverview/RecipeImportDialog.tsx
@@ -1,0 +1,85 @@
+import React from 'react';
+import {Button, Dialog, DialogActions, DialogContent, DialogTitle, FormControl, InputLabel, MenuItem, Select, SelectChangeEvent} from '@mui/material';
+import {RecipeImportRequest, RecipeImportSource} from '../../model/RecipeImport';
+
+interface RecipeImportDialogProps {
+    open: boolean;
+    onCancel: () => void;
+    onImport: (request: RecipeImportRequest) => void;
+}
+
+export const RecipeImportDialog: React.FC<RecipeImportDialogProps> = ({open, onCancel, onImport}) => {
+    const [source, setSource] = React.useState<RecipeImportSource | ''>('');
+    const [file, setFile] = React.useState<File>();
+    const [error, setError] = React.useState('');
+
+    const resetAndCancel = () => {
+        setSource('');
+        setFile(undefined);
+        setError('');
+        onCancel();
+    };
+
+    const handleImport = async () => {
+        if (!source) {
+            setError('Bitte wählen Sie eine Rezeptquelle aus.');
+            return;
+        }
+        if (!file) {
+            setError('Bitte wählen Sie eine JSON-Datei aus.');
+            return;
+        }
+
+        try {
+            const recipe: unknown = JSON.parse(await file.text());
+            onImport({source, recipe});
+            setSource('');
+            setFile(undefined);
+            setError('');
+        } catch (_error) {
+            setError('Die ausgewählte Datei enthält kein gültiges JSON.');
+        }
+    };
+
+    return (
+        <Dialog open={open} onClose={resetAndCancel} maxWidth="sm" fullWidth>
+            <DialogTitle>Rezept importieren</DialogTitle>
+            <DialogContent>
+                <FormControl fullWidth margin="normal">
+                    <InputLabel id="recipe-import-source-label">Quelle</InputLabel>
+                    <Select
+                        labelId="recipe-import-source-label"
+                        label="Quelle"
+                        value={source}
+                        onChange={(event: SelectChangeEvent) => {
+                            setSource(event.target.value as RecipeImportSource);
+                            setError('');
+                        }}
+                    >
+                        <MenuItem value={RecipeImportSource.MAISCHE_MALZ_UND_MEHR}>MaischeMalzundMehr</MenuItem>
+                        <MenuItem value={RecipeImportSource.BRAUREKA}>BräuReKa / Müggelland</MenuItem>
+                        <MenuItem value={RecipeImportSource.BRAUHAUS}>Brauhaus</MenuItem>
+                    </Select>
+                </FormControl>
+                <Button component="label" variant="outlined" fullWidth>
+                    {file ? file.name : 'JSON-Datei auswählen'}
+                    <input
+                        hidden
+                        type="file"
+                        accept="application/json,.json"
+                        onChange={(event) => {
+                            setFile(event.target.files?.[0]);
+                            setError('');
+                            event.target.value = '';
+                        }}
+                    />
+                </Button>
+                {error && <p role="alert">{error}</p>}
+            </DialogContent>
+            <DialogActions>
+                <Button onClick={resetAndCancel}>Abbrechen</Button>
+                <Button onClick={handleImport} variant="contained">Import starten</Button>
+            </DialogActions>
+        </Dialog>
+    );
+};

--- a/src/epics/beerEpics.ts
+++ b/src/epics/beerEpics.ts
@@ -168,13 +168,13 @@ export const importBeerEpic = (aAction$: any) =>
     aAction$.pipe(
         ofType(BeerActions.ActionTypes.IMPORT_BEER),
         mergeMap((aAction: any) =>
-            from(BeerRepository.importBeer(aAction.payload.file)).pipe(
+            from(BeerRepository.importBeer(aAction.payload.request)).pipe(
                 map((aResponse) => BeerActions.addImportedBeer(aResponse)),
                 catchError((aError: Error) =>
                     of(ApplicationActions.openErrorDialog(
                         true,
                         "Import Fehler",
-                        aError.message
+                        (aError as any)?.response?.data?.message ?? (aError as any)?.response?.data?.error ?? aError.message
                     ))
                 )
             )

--- a/src/epics/beerImportEpic.test.ts
+++ b/src/epics/beerImportEpic.test.ts
@@ -1,0 +1,23 @@
+import {firstValueFrom, of} from 'rxjs';
+import {BeerActions} from '../actions/actions';
+import {importBeerEpic} from './beerEpics';
+import {BeerRepository} from '../repositorys/BeerRepository';
+import {RecipeImportSource} from '../model/RecipeImport';
+import {Beer} from '../model/Beer';
+
+jest.mock('../repositorys/BeerRepository', () => ({
+    BeerRepository: {importBeer: jest.fn()},
+}));
+
+describe('importBeerEpic', () => {
+    it('keeps the existing ADD_IMPORTED_BEER success flow', async () => {
+        const importedBeer = {id: 'beer-1', name: 'Import'} as Beer;
+        const request = {source: RecipeImportSource.BRAUREKA, recipe: {name: 'Import'}};
+        (BeerRepository.importBeer as jest.Mock).mockResolvedValueOnce(importedBeer);
+
+        const result = await firstValueFrom(importBeerEpic(of(BeerActions.importBeer(request))));
+
+        expect(BeerRepository.importBeer).toHaveBeenCalledWith(request);
+        expect(result).toEqual(BeerActions.addImportedBeer(importedBeer));
+    });
+});

--- a/src/model/RecipeImport.ts
+++ b/src/model/RecipeImport.ts
@@ -1,0 +1,10 @@
+export enum RecipeImportSource {
+    MAISCHE_MALZ_UND_MEHR = 'MAISCHE_MALZ_UND_MEHR',
+    BRAUREKA = 'BRAUREKA',
+    BRAUHAUS = 'BRAUHAUS',
+}
+
+export interface RecipeImportRequest {
+    source: RecipeImportSource;
+    recipe: unknown;
+}

--- a/src/repositorys/BeerRepository.test.ts
+++ b/src/repositorys/BeerRepository.test.ts
@@ -1,6 +1,8 @@
 import {api} from './BaseRepository';
 import {BeerRepository} from './BeerRepository';
 import {BeerDTO} from '../model/BeerDTO';
+import {RecipeImportSource} from '../model/RecipeImport';
+import {Beer} from '../model/Beer';
 
 jest.mock('./BaseRepository', () => {
     const post = jest.fn();
@@ -66,5 +68,24 @@ describe('BeerRepository.submitBeer', () => {
 
         expect(mockedApi.put).toHaveBeenCalledWith('beer/existing-id', expect.objectContaining({id: 'existing-id'}));
         expect(mockedApi.post).not.toHaveBeenCalled();
+    });
+});
+
+describe('BeerRepository.importBeer', () => {
+    it('posts the typed source and untouched recipe as JSON', async () => {
+        const recipe = {NAME: 'Extern', AMOUNT: '20 l'};
+        const importedBeer = {id: 'imported-id', name: 'Extern'} as Beer;
+        mockedApi.post.mockResolvedValueOnce({data: importedBeer});
+
+        const result = await BeerRepository.importBeer({
+            source: RecipeImportSource.MAISCHE_MALZ_UND_MEHR,
+            recipe,
+        });
+
+        expect(mockedApi.post).toHaveBeenCalledWith('importbeer', {
+            source: RecipeImportSource.MAISCHE_MALZ_UND_MEHR,
+            recipe,
+        });
+        expect(result).toBe(importedBeer);
     });
 });

--- a/src/repositorys/BeerRepository.ts
+++ b/src/repositorys/BeerRepository.ts
@@ -2,6 +2,7 @@ import {BeerDTO} from "../model/BeerDTO";
 import {Beer} from "../model/Beer";
 import {BaseRepository} from "./BaseRepository";
 import { BeerSubmissionResponse, hasPersistedBeerId, toBeerCreatePayload } from "../utils/beerSubmission";
+import {RecipeImportRequest} from '../model/RecipeImport';
 
 export class BeerRepository extends BaseRepository {
 
@@ -17,16 +18,14 @@ export class BeerRepository extends BaseRepository {
         return this.post<BeerSubmissionResponse>("beer", toBeerCreatePayload(aBeer));
     }
 
-    static async importBeer(aFile: File): Promise<any> {
-        console.log(aFile)
-        return this.postFile<any>("importbeer", aFile);
+    static async importBeer(request: RecipeImportRequest): Promise<Beer> {
+        return this.post<Beer>("importbeer", request);
     }
 
     static async deleteBeer(aBeerId: string): Promise<void> {
         return this.delete(`beer/${aBeerId}`);
     }
 }
-
 
 
 


### PR DESCRIPTION
### Motivation
- Replace the legacy multipart `file` import flow with a JSON-first contract so the UI can send parsed external recipe JSON together with a typed `source` and rely on the backend for format validation and conversion.
- Document the new API contract across docs so cross-repository updates (backend) are visible and traceable.

### Description
- Changed the `/api/database/importbeer` contract in docs to accept `{ source, recipe }` and updated compatibility notes in `docs/` to reflect the new JSON request shape.
- Added a typed `RecipeImport` model (`src/model/RecipeImport.ts`) exposing `RecipeImportSource` and `RecipeImportRequest` and updated action types and creators to carry `RecipeImportRequest` instead of `File` in `src/actions/actions.ts`.
- Replaced file-based import UI with a dialog component `RecipeImportDialog` (`src/containers/DatabaseOverview/RecipeImportDialog.tsx`) and wired it into `BeerForm` (`src/containers/DatabaseOverview/BeerForm.tsx`) with a `showImportDialog` state flag and `importBeer(request)` prop usage.
- Updated repository and epic flow to use the typed request: `BeerRepository.importBeer(request)` now posts JSON and `importBeerEpic` forwards the `request` payload and improves error reporting in the error dialog message (`src/repositorys/BeerRepository.ts`, `src/epics/beerEpics.ts`).
- Added unit tests for the dialog, epic, and repository changes: `RecipeImportDialog.test.tsx`, `beerImportEpic.test.ts`, and extended `BeerRepository.test.ts` to cover the new behavior.

### Testing
- Ran the unit test suite with `jest` including the new `RecipeImportDialog` tests, `beerImportEpic` test, and updated `BeerRepository` tests, and all new/updated tests passed.
- Verified `importBeerEpic` sends the `RecipeImportRequest` to `BeerRepository.importBeer` and that the success action `ADD_IMPORTED_BEER` is still produced by the epic in tests.
- Exercised dialog behavior in tests to confirm source selection, file JSON parsing, validation errors, and successful `onImport` callback invocation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8df7b29b98832f8012b58f40717ada)