### PR TITLE
Fix beer reducer state typing and normalize finished-brews null to undefined

### DIFF
--- a/src/reducers/beerReducer.test.ts
+++ b/src/reducers/beerReducer.test.ts
@@ -27,3 +27,10 @@ describe('beerDataReducer recipe import', () => {
         expect(replayed.importResult?.replayed).toBe(true);
     });
 });
+
+describe('beerDataReducer finished brews', () => {
+    it('normalizes a null response to an undefined list', () => {
+        const state = beerDataReducer(initialBeerState, BeerActions.getFinishedBeersSuccess(null));
+        expect(state.finishedBrews).toBeUndefined();
+    });
+});

--- a/src/reducers/beerReducer.ts
+++ b/src/reducers/beerReducer.ts
@@ -44,7 +44,7 @@ export const initialBeerState: BeerDataReducerState =
 const beerDataReducer = (
   aState: BeerDataReducerState = initialBeerState,
   aAction: AllBeerActions
-) => {
+): BeerDataReducerState => {
   switch (aAction.type) {
     case BeerActions.ActionTypes.SUBMIT_BEER: {
       return { ...aState, isSavingBeer: true, isSubmitSuccessful: undefined, message: undefined, type: undefined };
@@ -123,7 +123,7 @@ const beerDataReducer = (
       return { ...aState, isFetching: aAction.payload.isFetching };
     }
     case BeerActions.ActionTypes.GET_FINISHED_BEERS_SUCCESS: {
-      return { ...aState, finishedBrews: aAction.payload.finishedBeers };
+      return { ...aState, finishedBrews: aAction.payload.finishedBeers ?? undefined };
     }
     case BeerActions.ActionTypes.UPDATE_ACTIVE_BEER: {
       return { ...aState };


### PR DESCRIPTION
### Motivation

- A TypeScript error (`TS2345`) occurred when tests passed a `null` finished-brews payload into the reducer because the reducer state typed `finishedBrews` as `FinishedBrew[] | undefined` while some action payloads can be `FinishedBrew[] | null`. 
- The change aims to make the reducer's return type explicit and to normalize nullable API results into the reducer contract to avoid the type mismatch.

### Description

- Declare the reducer return type explicitly as `BeerDataReducerState` for `beerDataReducer` to avoid widening/incompatible inferred unions. 
- Normalize the `GET_FINISHED_BEERS_SUCCESS` branch to convert a `null` `finishedBeers` payload to `undefined` (`finishedBrews: aAction.payload.finishedBeers ?? undefined`).
- Add a unit test `beerDataReducer finished brews` asserting that a `null` finished-beers response is normalized to `undefined` in the reducer state.

### Testing

- Ran `npm test -- --watchAll=false src/reducers/beerReducer.test.ts`, but the test run could not complete because project dependencies (including `react-scripts`) were not installed in the environment. (test blocked)
- Attempted `npm run build`, but the build could not run for the same missing-dependencies reason. (build blocked)
- Attempted `npm ci` to install dependencies, but the install failed due to an HTTP 403 response from the npm registry in this environment, preventing local test/build verification. (install failed)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8ea886df84832fa05703264ab2dfb2)