### PR TITLE
Simplify recipe import success message

### DIFF
--- a/src/containers/DatabaseOverview/BeerForm.test.tsx
+++ b/src/containers/DatabaseOverview/BeerForm.test.tsx
@@ -294,7 +294,19 @@ describe('BeerForm accordions', () => {
         expect(screen.getByText(/Bitte prüfe den Brauprozess: Bitte ordne der Dekoktion eine Rast zu/)).toBeInTheDocument();
         expect(props.onSubmitBeer).not.toHaveBeenCalled();
     });
-    it('shows replay, warning, mapping and created-master-data import information', () => {
+    it('shows the concise success message for an import without metadata', () => {
+        renderBeerForm({importResult: {
+            recipe: {id: 'beer-1', name: 'Import'} as Beer,
+            warnings: [],
+            ingredientMappings: [],
+            createdMasterData: [],
+            replayed: false,
+        }});
+
+        expect(screen.getByText('Rezept erfolgreich importiert.')).toBeInTheDocument();
+    });
+
+    it('does not include warnings, mappings or created master data in the success message', () => {
         renderBeerForm({importResult: {
             recipe: {id: 'beer-1', name: 'Import'} as Beer,
             warnings: [{code: 'SOURCE_INFORMATION_IGNORED', message: 'Eine Quellenangabe wurde ignoriert.'}],
@@ -302,9 +314,11 @@ describe('BeerForm accordions', () => {
             createdMasterData: [{ingredientId: 'h1', ingredientType: 'HOP', name: 'Hopfen XYZ'}],
             replayed: true,
         }});
-        expect(screen.getByText(/bereits verarbeitet/)).toHaveTextContent('Pilsner Malt');
-        expect(screen.getByText(/bereits verarbeitet/)).toHaveTextContent('Hopfen XYZ');
-        expect(screen.getByText(/bereits verarbeitet/)).toHaveTextContent('Eine Quellenangabe wurde ignoriert.');
+
+        expect(screen.getByText('Rezept erfolgreich importiert.')).toBeInTheDocument();
+        expect(screen.queryByText(/Pilsner Malt/)).not.toBeInTheDocument();
+        expect(screen.queryByText(/Hopfen XYZ/)).not.toBeInTheDocument();
+        expect(screen.queryByText(/Eine Quellenangabe wurde ignoriert/)).not.toBeInTheDocument();
     });
 
 });

--- a/src/containers/DatabaseOverview/BeerForm.tsx
+++ b/src/containers/DatabaseOverview/BeerForm.tsx
@@ -840,15 +840,7 @@ export class BeerForm extends React.Component<BeerFormProps, BeerFormState> {
     getImportInfo = (): string => {
         const result = this.props.importResult;
         if (!result) return '';
-        const headline = result.replayed
-            ? 'Der Import wurde bereits verarbeitet. Das vorhandene Rezept wurde geladen.'
-            : 'Rezept erfolgreich importiert.';
-        const warnings = result.warnings.map(warning => warning.message);
-        const mappings = result.ingredientMappings
-            .filter(mapping => mapping.matchType !== 'EXACT')
-            .map(mapping => `„${mapping.sourceName}“ wurde „${mapping.resolvedName}“ zugeordnet (${mapping.matchType}).`);
-        const created = result.createdMasterData.map(ingredient => `Neue Zutat angelegt: „${ingredient.name}“ (${ingredient.ingredientType}).`);
-        return [headline, ...warnings, ...mappings, ...created].join(' ');
+        return 'Rezept erfolgreich importiert.';
     };
 
     renderCreateBeerForm() {


### PR DESCRIPTION
### Motivation
- The UI currently concatenates `warnings`, `ingredientMappings` and `createdMasterData` into a large success text shown in the recipe view, which produces overly long messages that should not be displayed automatically.
- The goal is to show a concise success message (`Rezept erfolgreich importiert.`) for normal and replayed imports while keeping all import metadata in the `RecipeImportResult` and Redux state.

### Description
- Replace the detailed import summary with a single message by changing `getImportInfo` in `src/containers/DatabaseOverview/BeerForm.tsx` to always return `Rezept erfolgreich importiert.`.
- Adjust `src/containers/DatabaseOverview/BeerForm.test.tsx` to assert the concise success message and to verify that warnings, mappings and created master-data are not rendered in the normal recipe view.
- Do not change the `RecipeImportResult` type or backend/import logic; the `RecipeImportResult` remains defined in `src/model/RecipeImport.ts` and the reducer still stores `importResult` in state.

### Testing
- Unit tests were updated (`src/containers/DatabaseOverview/BeerForm.test.tsx`) to cover: successful import without metadata shows `Rezept erfolgreich importiert.`, successful import with warnings/mappings/created data still only shows `Rezept erfolgreich importiert.` and failed imports keep existing error behavior. 
- An attempt to run the test suite with `CI=true npm test -- --runInBand ...` failed in this environment because project dependencies / `react-scripts` were not available and `npm ci` could not complete due to registry access errors, so the updated tests could not be executed here. 
- Static checks performed locally (file diffs and source edits) completed without changing `RecipeImportResult` or import flows.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8ead420a14832f82958df924231555)