### PR TITLE
Fix yeast reducer master data type

### DIFF
--- a/src/reducers/yeastReducer.ts
+++ b/src/reducers/yeastReducer.ts
@@ -1,9 +1,9 @@
-import {Yeast} from "../model/Beer";
+import {Yeasts} from "../model/Yeasts";
 import {YeastActions} from "../actions/yeast.actions";
 import AllYeastActions = YeastActions.AllYeastActions;
 
 export interface YeastReducerState {
-    yeasts: Yeast[] | undefined
+    yeasts: Yeasts[] | undefined
     isFetching: boolean,
     isSubmitYeastSuccessful: boolean | undefined,
     isUpdating: boolean,


### PR DESCRIPTION
### Motivation
- Fix a TypeScript type mismatch in the yeast reducer where the reducer used the recipe `Yeast` shape (which exposes `EVG`) while the application and backend master-data model use the `Yeasts` shape with lowercase `evg`, which caused `TS2322` errors in tests.

### Description
- Update `src/reducers/yeastReducer.ts` to import and use the `Yeasts` master-data type from `src/model/Yeasts` and set `YeastReducerState.yeasts` to `Yeasts[] | undefined` instead of the recipe `Yeast` type.

### Testing
- Ran `git diff --check` and committed the change (`Fix yeast reducer master data type`), and these VCS checks succeeded.
- Attempted to run the unit test `CI=true npm test -- --runInBand src/reducers/ingredientUpdateReducers.test.ts`, but execution could not proceed because project dependencies are not installed.
- Attempted `CI=true npx react-scripts test --runInBand src/reducers/ingredientUpdateReducers.test.ts`, but `react-scripts` could not be installed due to npm registry HTTP 403, so tests were not executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8ebf402ba8832f9e7cd58fb472b354)