### PR TITLE
Fix global styles with lazy loaded routes

### DIFF
--- a/docs/codex/app-context.md
+++ b/docs/codex/app-context.md
@@ -6,7 +6,7 @@ This repository is a Create React App TypeScript UI named `test1`. It presents b
 
 ## Entry points and shell
 
-- `src/index.tsx` imports global color CSS, creates the React tree, wraps `App` in the Redux `Provider`, dispatches the initial theme, and registers `public/service-worker.js` through `process.env.PUBLIC_URL`.
+- `src/index.tsx` eagerly imports the global color tokens, Bootstrap base CSS, SimpleBar base CSS, and `index.css` reset/theme defaults before it creates the React tree. It wraps `App` in the Redux `Provider`, dispatches the initial theme, and registers `public/service-worker.js` through `process.env.PUBLIC_URL`. Route components and their page-specific CSS remain lazy-loaded.
 - `src/containers/App.tsx` switches between a mobile-only UI and the desktop UI based on `window.innerWidth < 768`. There is no React Router in the code inspected; navigation is Redux view-state driven, with lightweight browser path synchronization in `src/utils/viewRoutes.ts` for direct links such as `/dashboard`.
 - Desktop shell renders `Header` plus `containers/index.tsx`. Mobile shell renders `MobileProductionView` directly.
 

--- a/src/containers/App.css
+++ b/src/containers/App.css
@@ -2,13 +2,6 @@
     --desktop-header-height: 5.25rem;
 }
 
-.AppBody {
-    margin: 0;
-    padding: 0;
-    font-family: sans-serif;
-    background: var(--color-app-bg);
-}
-
 .AppContainer {
     width: 100%;
     height: 100vh;

--- a/src/containers/BrewingCalculations/BrewingCalculations.css
+++ b/src/containers/BrewingCalculations/BrewingCalculations.css
@@ -1,34 +1,32 @@
 /* Stil für die Seite Bierbrau-Berechnungen */
 
 /* Farben und Kontraste für Dark Mode */
-.Paper-root, .MuiPaper-root {
+.BrewingCalculations-outer .Paper-root,
+.BrewingCalculations-outer .MuiPaper-root {
     background-color: var(--color-brew-bg) !important; /* Dunkler Hintergrund */
     color: var(--color-white) !important;
 }
 
-.MuiTypography-root, .MuiInputBase-root, .MuiFormLabel-root {
+.BrewingCalculations-outer .MuiTypography-root,
+.BrewingCalculations-outer .MuiInputBase-root,
+.BrewingCalculations-outer .MuiFormLabel-root {
     color: var(--color-white) !important;
 }
 
-.MuiOutlinedInput-root .MuiOutlinedInput-notchedOutline {
+.BrewingCalculations-outer .MuiOutlinedInput-root .MuiOutlinedInput-notchedOutline {
     border-color: var(--color-accent) !important;
 }
 
-.MuiTextField-root {
+.BrewingCalculations-outer .MuiTextField-root {
     margin-bottom: 1.2rem;
 }
 
-.header-container h1 {
+.BrewingCalculations-outer .header-container h1 {
     color: var(--color-accent);
 }
 
-.icon {
-    /* filter: brightness(0) invert(1); */
-    /* Entfernt, damit Icons wieder originalfarbig sind */
-}
-
 /* Beispiel: Abstand zwischen Boxen */
-.MuiBox-root {
+.BrewingCalculations-outer .MuiBox-root {
     background: var(--color-brew-bg);
     border-radius: 10px;
     padding: 1.5rem;
@@ -37,13 +35,13 @@
 }
 
 /* Buttons, falls benötigt */
-.MuiButton-root {
+.BrewingCalculations-outer .MuiButton-root {
     background: var(--color-accent);
 
 }
 
 /* Orange für Labels und Akzente */
-.MuiTypography-subtitle2 {
+.BrewingCalculations-outer .MuiTypography-subtitle2 {
     color: var(--color-accent) !important;
 }
 
@@ -73,20 +71,13 @@
     overflow: hidden;
 }
 
-body, html, #root {
-    height: 100%;
-    margin: 0;
-    padding: 0;
-    overflow: hidden;
-}
-
 /* Spin-Buttons bei number-Inputs entfernen */
-input[type=number]::-webkit-inner-spin-button,
-input[type=number]::-webkit-outer-spin-button {
+.BrewingCalculations-outer input[type=number]::-webkit-inner-spin-button,
+.BrewingCalculations-outer input[type=number]::-webkit-outer-spin-button {
     -webkit-appearance: none;
     margin: 0;
 }
-input[type=number] {
+.BrewingCalculations-outer input[type=number] {
     -moz-appearance: textfield;
 }
 

--- a/src/containers/BrewingCalculations/BrewingCalculations.tsx
+++ b/src/containers/BrewingCalculations/BrewingCalculations.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import SimpleBar from 'simplebar-react';
-import 'simplebar/dist/simplebar.min.css';
 import { Paper, TextField, Typography, Box, Grid } from '@mui/material';
 import './BrewingCalculations.css';
 import {

--- a/src/containers/MainView/Details/Details.tsx
+++ b/src/containers/MainView/Details/Details.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import './Details.css';
 import { Beer } from "../../../model/Beer";
-import 'simplebar-react/dist/simplebar.min.css';
 
 import {
     Accordion, AccordionDetails, AccordionSummary,

--- a/src/containers/MainView/FinishBrewsBeers/FinishedBrewsTable.tsx
+++ b/src/containers/MainView/FinishBrewsBeers/FinishedBrewsTable.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { Paper, Table, TableBody, TableCell, TableContainer, TableHead, TableRow, TextField } from '@mui/material';
 import SimpleBar from 'simplebar-react';
-import 'simplebar/dist/simplebar.min.css';
 import './FinishedBrewsTable.css';
 import {FinishedBrew} from "../../../model/FinishedBrew";
 import {isNil} from "lodash";

--- a/src/containers/MainView/Main.tsx
+++ b/src/containers/MainView/Main.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 
 import Details from "./Details/Details.connect";
 import SimpleBar from 'simplebar-react';
-import 'simplebar/dist/simplebar.min.css';
 import BeerTable from "./BeerRecipes/Table.connect";
 import {Beer} from "../../model/Beer";
 

--- a/src/containers/Production/Production.tsx
+++ b/src/containers/Production/Production.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import {isUndefined} from 'lodash';
 import {Beer} from "../../model/Beer";
-import 'bootstrap/dist/css/bootstrap.min.css';
 import {v4 as uuidv4} from 'uuid';
 import '@fortawesome/fontawesome-free/css/all.css'; // Stile
 import './Production.css'

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,18 @@
+html,
+body,
+#root {
+    width: 100%;
+    height: 100%;
+    margin: 0;
+    padding: 0;
+}
+
+body {
+    overflow: hidden;
+    background: var(--color-app-bg);
+    font-family: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", "Noto Sans", "Liberation Sans", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+}
+
 .MainContainer {
     width: 100%;
     height: 100%;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,4 +1,7 @@
 import './colors.css';
+import 'bootstrap/dist/css/bootstrap.min.css';
+import 'simplebar/dist/simplebar.min.css';
+import './index.css';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';


### PR DESCRIPTION
### Motivation

- Restore application-global base styles that were previously (and unintentionally) provided by a lazy-loaded route so the MAIN view renders correctly on first load.
- Keep `React.lazy`/`Suspense` and route code-splitting intact while removing global CSS dependencies from individual route chunks.

### Description

- Eagerly import base CSS from the app entry by adding `bootstrap` and `simplebar` base CSS and a small reset/theme file in `src/index.tsx` (`import 'bootstrap/dist/css/bootstrap.min.css';`, `import 'simplebar/dist/simplebar.min.css';`, `import './index.css';`).
- Add `src/index.css` with the global reset and the global font/background defaults and root sizing (`html, body, #root { ... }` and `body { font-family: ...; background: var(--color-app-bg); }`).
- Remove the global `body, html, #root` reset from `src/containers/BrewingCalculations/BrewingCalculations.css` and scope MUI and number-input selectors to `.BrewingCalculations-outer` so the Calculations page cannot affect other routes.
- Remove route-local eager imports of `simplebar`/`bootstrap` from route files (`Production`, `Main`, `Details`, `FinishedBrewsTable`, `BrewingCalculations`) so the base CSS is only loaded once at startup.
- Remove the unused `.AppBody` global font reset from `src/containers/App.css` (global font is now in `src/index.css`).
- Update documentation in `docs/codex/app-context.md` to reflect that global CSS tokens and base styles are eager-loaded from `src/index.tsx` while routes remain lazy-loaded.
- Commit: `b94e021dbf247b8ed0b53b9ac956b9a3f354b95e`.

### Testing

- Ran `git diff --check` and static repository checks which reported no leftover style-import conflicts and the working copy is clean.
- Executed automated assertions verifying `src/index.tsx` contains the eager imports, `src/index.css` contains the reset, `BrewingCalculations.css` no longer contains `body, html, #root`, all MUI and input selectors in that file are scoped to `.BrewingCalculations-outer`, and all route components remain declared with `React.lazy` and rendered inside `Suspense`, and these assertions passed.
- Performed `rg`/source scans to confirm removal of late `simplebar`/`bootstrap` imports from route files and the single eager import in `src/index.tsx`, which succeeded.
- Attempted `npm ci` / production build but dependency installation failed in this environment due to npm registry errors (HTTP 403 / missing cached packages), so a full production build could not be produced here and is marked as environment-limited.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8ed6494bc0832fa4188b8cb9d42d7d)