### PR TITLE
Use recipe reference volume/efficiency for scaling; update Details UI and remove efficiency spinner

### DIFF
--- a/docs/codex/compatibility/cross-repo-contracts.md
+++ b/docs/codex/compatibility/cross-repo-contracts.md
@@ -43,6 +43,8 @@ Before changing any database/backend field or endpoint, check whether the UI use
 
 ### High-risk UI/database fields
 
+- `Beer.referenceVolume` / `BeerDTO.referenceVolume` (recipe-basis liters; UI create default `10`)
+- `Beer.referenceBrewhouseEfficiency` / `BeerDTO.referenceBrewhouseEfficiency` (recipe-basis percent; UI create default `52`)
 - `Beer.id`
 - `Beer.name`
 - `Beer.type`
@@ -71,6 +73,8 @@ Before changing any database/backend field or endpoint, check whether the UI use
 - `FinishedBrew.endDate`
 
 The recipe editor now omits `time` when serializing the fixed `Einmaischen` and `Abmaischen` steps because those phases have no recipe duration. The TypeScript contract already permits this field to be absent, but database/backend persistence tolerance is **Needs verification**; the UI does not synthesize a compatibility value.
+
+The database/import service must preserve or derive `referenceVolume` and `referenceBrewhouseEfficiency` for imported recipes and return them unchanged. Otherwise the UI has no reliable way to distinguish a legacy 20-/30-l import from its temporary legacy fallback. Database support for these two optional fields is **Needs cross-repository update**.
 
 The UI now persists `stepId` and `relatedRastId` in recipe mash steps. Database/backend DTO validation, storage, and read-back of both fields **Needs cross-repository update**; dropping either field would break stable decoction relationships.
 

--- a/docs/codex/data-flow.md
+++ b/docs/codex/data-flow.md
@@ -19,6 +19,7 @@ BeerDatabase 2.x returns `RecipeImportResult`, including `replayed`; a replay is
 - `beerDataReducer.GET_BEERS_SUCCESS` stores the list and selects the last returned recipe as `selectedBeer`.
 - Table sorting is client-side on `name`, `type`, `color`, or `alcohol`.
 - Selecting a row stores `selectedBeer`; clicking brew stores `beerToBrew`.
+- Recipe-detail scaling derives volume from `targetVolume / referenceVolume` and malt efficiency from `referenceBrewhouseEfficiency / targetBrewhouseEfficiency`. The scaled copy remains only in `selectedBeer`; the persisted entry in `beers` is unchanged. Clicking brew for that selected row stores this scaled copy as `beerToBrew`, so production and shopping-list consumers use the planned quantities rather than the original recipe.
 
 Needs verification: backend ordering of `GET beers`, because the UI treats the last item as default selection.
 

--- a/docs/codex/domain-model.md
+++ b/docs/codex/domain-model.md
@@ -4,6 +4,9 @@
 
 Visible/used fields include:
 
+- Scaling references: optional `referenceVolume` (liters of finished beer) and `referenceBrewhouseEfficiency` (percent) describe the quantities stored in the recipe. New recipes created in this UI use `10` l and `52` % as their recipe basis. Imported/existing recipes preserve values returned by the database. Legacy records without either field retain the UI compatibility fallback of `10` l / `52` %. Database validation, import mapping, and persistence of both fields are **Needs verification**; without them the UI cannot reliably recover whether a legacy import was originally a 20-/30-l recipe.
+- Temporary scaled copies additionally carry client-only `plannedVolume` and `plannedBrewhouseEfficiency`; these are not part of `BeerDTO` and are never persisted to the recipe database.
+
 - Identity/display: `id`, `name`, `type`, `color`, `description`, `rating`.
 - Metrics: `alcohol`, `originalwort`, `bitterness`, `mashVolume`, `spargeVolume`, `cookingTime`, `cookingTemperatur`.
 - New recipes initialize `cookingTemperatur` to `100` °C in the recipe UI. Existing and imported values are preserved. The read-only `Kochen` row derives its display from this top-level form value; the persisted fixed step is synchronized from it only when the existing recipe DTO is submitted.

--- a/docs/codex/interfaces.md
+++ b/docs/codex/interfaces.md
@@ -4,6 +4,8 @@
 
 Base URL: `DatabaseURL` (`/api/database`).
 
+Recipe scaling requires optional numeric `referenceVolume` (liters) and `referenceBrewhouseEfficiency` (percent) on `Beer`/`BeerDTO`. The UI preserves supplied import/existing-recipe values and sends defaults of `10` and `52` for recipes newly created in the UI. Database DTO validation, storage, read-back, and import extraction of the source recipe volume/efficiency are **Needs verification**. Until confirmed, legacy responses without these fields use a compatibility fallback and cannot safely distinguish an originally imported 20-/30-l basis.
+
 | Method | Path | UI use | Payload/response expected |
 |---|---|---|---|
 | GET | `beers` | Load recipes | `Beer[]` |

--- a/src/containers/DatabaseOverview/BeerForm.tsx
+++ b/src/containers/DatabaseOverview/BeerForm.tsx
@@ -48,6 +48,8 @@ const procedureTypeOptions = [
 ];
 
 const DEFAULT_COOKING_TEMPERATURE = 100;
+const DEFAULT_REFERENCE_VOLUME = 10;
+const DEFAULT_REFERENCE_BREWHOUSE_EFFICIENCY = 52;
 
 interface BeerFormState {
     id: string;
@@ -61,6 +63,8 @@ interface BeerFormState {
     rating: number;
     mashVolume: number;
     spargeVolume: number;
+    referenceVolume?: number;
+    referenceBrewhouseEfficiency?: number;
     cookingTime: number;
     cookingTemperatur: number;
     fermentationSteps: FermentationSteps[];
@@ -98,6 +102,8 @@ export class BeerForm extends React.Component<BeerFormProps, BeerFormState> {
             rating: 0,
             mashVolume: 0,
             spargeVolume: 0,
+            referenceVolume: DEFAULT_REFERENCE_VOLUME,
+            referenceBrewhouseEfficiency: DEFAULT_REFERENCE_BREWHOUSE_EFFICIENCY,
             cookingTime: 0,
             cookingTemperatur: DEFAULT_COOKING_TEMPERATURE,
             fermentationSteps: createDefaultFermentationSteps(),
@@ -174,6 +180,9 @@ export class BeerForm extends React.Component<BeerFormProps, BeerFormState> {
                 rating: importedBeer.rating || 0,
                 mashVolume: importedBeer.mashVolume || 0,
                 spargeVolume: importedBeer.spargeVolume || 0,
+                // Never relabel an import as a 10-l recipe when its source basis is unknown.
+                referenceVolume: importedBeer.referenceVolume,
+                referenceBrewhouseEfficiency: importedBeer.referenceBrewhouseEfficiency,
                 cookingTime: importedBeer.cookingTime || 0,
                 cookingTemperatur: importedBeer.cookingTemperatur || 0,
                 // Importierte Rasten werden defensiv normalisiert (Altformat ohne executionMode => TIMED).
@@ -469,6 +478,8 @@ export class BeerForm extends React.Component<BeerFormProps, BeerFormState> {
             rating,
             mashVolume,
             spargeVolume,
+            referenceVolume,
+            referenceBrewhouseEfficiency,
             cookingTime,
             cookingTemperatur,
             fermentationSteps,
@@ -561,6 +572,8 @@ export class BeerForm extends React.Component<BeerFormProps, BeerFormState> {
             rating,
             mashVolume,
             spargeVolume,
+            referenceVolume,
+            referenceBrewhouseEfficiency,
             fermentationSteps: normalizedFermentationSteps,
             cookingTime,
             cookingTemperatur,
@@ -596,6 +609,8 @@ export class BeerForm extends React.Component<BeerFormProps, BeerFormState> {
             rating: 0,
             mashVolume: 0,
             spargeVolume: 0,
+            referenceVolume: DEFAULT_REFERENCE_VOLUME,
+            referenceBrewhouseEfficiency: DEFAULT_REFERENCE_BREWHOUSE_EFFICIENCY,
             cookingTime: 0,
             cookingTemperatur: DEFAULT_COOKING_TEMPERATURE,
             fermentationSteps: createDefaultFermentationSteps(),
@@ -638,6 +653,8 @@ export class BeerForm extends React.Component<BeerFormProps, BeerFormState> {
             rating: selectedBeer.rating || 0,
             mashVolume: selectedBeer.mashVolume || 0,
             spargeVolume: selectedBeer.spargeVolume || 0,
+            referenceVolume: selectedBeer.referenceVolume,
+            referenceBrewhouseEfficiency: selectedBeer.referenceBrewhouseEfficiency,
             cookingTime: selectedBeer.cookingTime || 0,
             cookingTemperatur: selectedBeer.cookingTemperatur || 0,
             fermentationSteps: normalizeMashPlan(selectedBeer.fermentation || []),
@@ -763,6 +780,8 @@ export class BeerForm extends React.Component<BeerFormProps, BeerFormState> {
                 rating: selectedBeer.rating || 0,
                 mashVolume: selectedBeer.mashVolume || 0,
                 spargeVolume: selectedBeer.spargeVolume || 0,
+                referenceVolume: selectedBeer.referenceVolume,
+                referenceBrewhouseEfficiency: selectedBeer.referenceBrewhouseEfficiency,
                 cookingTime: selectedBeer.cookingTime || 0,
                 cookingTemperatur: selectedBeer.cookingTemperatur || 0,
                 fermentationSteps: normalizeMashPlan(selectedBeer.fermentation || []),

--- a/src/containers/MainView/BeerRecipes/Table.test.tsx
+++ b/src/containers/MainView/BeerRecipes/Table.test.tsx
@@ -1,0 +1,19 @@
+import {Beer} from '../../../model/Beer';
+import {BeerTableComponent, BeerTableProps} from './Table';
+
+const storedRecipe = {id: 'beer-1', name: 'Stored', malts: [{quantity: 1000}]} as Beer;
+const plannedBrew = {id: 'beer-1', name: 'Stored', malts: [{quantity: 3000}]} as Beer;
+
+it('uses the temporary scaled selection when the user starts brewing', () => {
+    const setBeerToBrew = jest.fn();
+    const props = {
+        beers: [storedRecipe], selectedBeer: plannedBrew, setBeerToBrew,
+        setSelectedBeer: jest.fn(), exportShoppingListPdf: jest.fn(), deleteBeer: jest.fn(),
+    } as BeerTableProps;
+    const table = new BeerTableComponent(props);
+
+    table.onBrewBeer(storedRecipe);
+
+    expect(setBeerToBrew).toHaveBeenCalledWith(plannedBrew);
+    expect(storedRecipe.malts[0].quantity).toBe(1000);
+});

--- a/src/containers/MainView/BeerRecipes/Table.tsx
+++ b/src/containers/MainView/BeerRecipes/Table.tsx
@@ -75,8 +75,10 @@ export class BeerTableComponent extends React.Component<BeerTableProps, BeerTabl
     }
 
     onBrewBeer = (beer: Beer) => {
-        const {setBeerToBrew} = this.props;
-        setBeerToBrew(beer);
+        const {setBeerToBrew, selectedBeer} = this.props;
+        // selectedBeer contains the temporary plan produced by the scaler. The
+        // immutable recipe in `beers` must not replace it when brewing starts.
+        setBeerToBrew(selectedBeer.id === beer.id ? selectedBeer : beer);
     }
 
     onCancelBrew = () => {

--- a/src/containers/MainView/Details/Details.css
+++ b/src/containers/MainView/Details/Details.css
@@ -39,7 +39,7 @@
 .batch-settings .settings-row {
     display: flex;
     align-items: center;
-    gap: 40px; /* etwas weiter auseinander */
+    gap: 24px;
 }
 
 .batch-settings label {
@@ -82,10 +82,22 @@
     color: white;
 }
 
-/* Number input: Entferne die Spinners (Chrome) */
-.batch-input::-webkit-inner-spin-button,
-.batch-input::-webkit-outer-spin-button {
-    opacity: 1; /* 1 = sichtbar, 0 = unsichtbar, choose your style */
+/* Sudhausausbeute bleibt numerisch editierbar, ohne Browser-Spinner. */
+.brewhouse-efficiency-input::-webkit-inner-spin-button,
+.brewhouse-efficiency-input::-webkit-outer-spin-button {
+    -webkit-appearance: none;
+    margin: 0;
+}
+
+.brewhouse-efficiency-input {
+    -moz-appearance: textfield;
+    appearance: textfield;
+}
+
+.recipe-reference {
+    color: var(--color-gray-light);
+    font-size: 12px;
+    white-space: nowrap;
 }
 
 

--- a/src/containers/MainView/Details/Details.test.tsx
+++ b/src/containers/MainView/Details/Details.test.tsx
@@ -1,0 +1,23 @@
+import {render, screen} from '@testing-library/react';
+import {Beer} from '../../../model/Beer';
+import {Details} from './Details';
+
+const beer = {
+    id: 'recipe-30', name: 'Import', type: 'Ale', color: '10', alcohol: 5,
+    originalwort: 12, bitterness: 25, description: '', rating: 4,
+    mashVolume: 20, spargeVolume: 10, cookingTime: 60, cookingTemperatur: 100,
+    fermentation: [], malts: [], wortBoiling: {totalTime: 60, hops: []},
+    fermentationMaturation: {fermentationTemperature: 20, carbonation: 5, yeast: []},
+    referenceVolume: 30, referenceBrewhouseEfficiency: 71,
+} as Beer;
+
+it('labels the planned batch clearly and displays the compact recipe reference', () => {
+    render(<Details selectedBeer={beer} updateRecipeScaling={jest.fn()} />);
+
+    expect(screen.getByText('Ausschlagmenge:')).toBeInTheDocument();
+    expect(screen.getByText('Sudhausausbeute:')).toBeInTheDocument();
+    expect(screen.getByText('Rezeptbasis: 30 l · 71 % SHA')).toBeInTheDocument();
+    expect(screen.getByRole('spinbutton')).toHaveClass('brewhouse-efficiency-input');
+    expect(screen.getByRole('combobox')).toHaveValue('30');
+    expect(screen.queryByText('Liter:')).not.toBeInTheDocument();
+});

--- a/src/containers/MainView/Details/Details.tsx
+++ b/src/containers/MainView/Details/Details.tsx
@@ -14,7 +14,7 @@ import {
     Typography
 } from "@mui/material";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
-import {scalingValues} from "../../../utils/BeerScaler/ScalingBeerRecipe";
+import {BeerRecipeScaler, scalingValues} from "../../../utils/BeerScaler/ScalingBeerRecipe";
 import {COLOR_ACCENT, COLOR_BREW_BG} from "../../../colors";
 
 interface DetailsProps {
@@ -34,8 +34,8 @@ export class Details extends React.Component<DetailsProps, DetailsState> {
         super(props);
         this.state = {
             selectedBeer: undefined,
-            batchSize: 10,
-            brewhouseEfficiency: 52
+            batchSize: BeerRecipeScaler.getReferenceVolume(props.selectedBeer),
+            brewhouseEfficiency: BeerRecipeScaler.getReferenceEfficiency(props.selectedBeer)
         };
     }
 
@@ -47,8 +47,8 @@ export class Details extends React.Component<DetailsProps, DetailsState> {
             if(selectedBeer?.id !== prevProps?.selectedBeer.id)
             {
                 this.setState({
-                    batchSize: 10,
-                    brewhouseEfficiency:52});
+                    batchSize: BeerRecipeScaler.getReferenceVolume(selectedBeer),
+                    brewhouseEfficiency: BeerRecipeScaler.getReferenceEfficiency(selectedBeer)});
             }
         }
 
@@ -105,11 +105,16 @@ export class Details extends React.Component<DetailsProps, DetailsState> {
     // Batch Settings
     // -------------------------------------------------------------
     renderBatchSettings() {
+        const {selectedBeer} = this.props;
+        const hasRecipeReference = Boolean(
+            selectedBeer.referenceVolume && selectedBeer.referenceVolume > 0 &&
+            selectedBeer.referenceBrewhouseEfficiency && selectedBeer.referenceBrewhouseEfficiency > 0
+        );
         return (
             <div className="batch-settings">
                 <div className="settings-row">
                     <div>
-                        <label style={{ color: 'white' }}>Liter:</label>
+                        <label style={{ color: 'white' }}>Ausschlagmenge:</label>
                         <select
                             value={this.state.batchSize}
                             onChange={(e) => this.setState({ batchSize: Number(e.target.value) })}
@@ -132,9 +137,14 @@ export class Details extends React.Component<DetailsProps, DetailsState> {
                             step={1}
                             value={this.state.brewhouseEfficiency}
                             onChange={(e) => this.setState({ brewhouseEfficiency: Number(e.target.value) })}
-                            className="batch-input"
+                            className="batch-input brewhouse-efficiency-input"
                         />
                     </div>
+                    {hasRecipeReference && (
+                        <span className="recipe-reference">
+                            Rezeptbasis: {selectedBeer.referenceVolume} l · {selectedBeer.referenceBrewhouseEfficiency} % SHA
+                        </span>
+                    )}
                 </div>
             </div>
         );

--- a/src/model/Beer.ts
+++ b/src/model/Beer.ts
@@ -90,6 +90,13 @@ export interface Beer {
     rating: number;
     mashVolume: number;
     spargeVolume: number;
+    /** Persisted recipe basis; absent on legacy database records. */
+    referenceVolume?: number;
+    /** Persisted brewhouse efficiency of the recipe basis; absent on legacy records. */
+    referenceBrewhouseEfficiency?: number;
+    /** Client-only values on a temporary scaled brew plan. */
+    plannedVolume?: number;
+    plannedBrewhouseEfficiency?: number;
     cookingTime: number;
     cookingTemperatur: number;
     fermentation: FermentationSteps[];

--- a/src/model/BeerDTO.ts
+++ b/src/model/BeerDTO.ts
@@ -69,6 +69,8 @@ export interface BeerDTO {
     rating: number;
     mashVolume: number;
     spargeVolume: number
+    referenceVolume?: number;
+    referenceBrewhouseEfficiency?: number;
     cookingTime: number;
     cookingTemperatur: number;
     fermentationSteps: FermentationStepsDTO[];

--- a/src/utils/BeerScaler/ScalingBeerRecipe.test.ts
+++ b/src/utils/BeerScaler/ScalingBeerRecipe.test.ts
@@ -1,0 +1,37 @@
+import {AdditionalIngredientPhase, Beer} from '../../model/Beer';
+import {BeerRecipeScaler} from './ScalingBeerRecipe';
+
+const recipe = (overrides: Partial<Beer> = {}): Beer => ({
+    id: 'recipe-1', name: 'Test', type: 'Ale', color: '10', alcohol: 5,
+    originalwort: 12, bitterness: 25, description: '', rating: 4,
+    mashVolume: 20, spargeVolume: 10, cookingTime: 60, cookingTemperatur: 100,
+    fermentation: [],
+    malts: [{id: 'm1', name: 'Pilsner', description: '', EBC: 3, quantity: 6000}],
+    wortBoiling: {totalTime: 60, hops: [{id: 'h1', name: 'Hopfen', description: '', alpha: 5, quantity: 60}]},
+    fermentationMaturation: {fermentationTemperature: 20, carbonation: 5, yeast: [{id: 'y1', name: 'Hefe', description: '', EVG: '75', temperature: '20', type: 'Ale', quantity: 3}]},
+    additionalIngredients: [{name: 'Zucker', quantity: 300, unit: 'g', phase: AdditionalIngredientPhase.BOIL}],
+    ...overrides,
+});
+
+describe('BeerRecipeScaler', () => {
+    it('uses the stored recipe volume and efficiency as independent references', () => {
+        const scaled = BeerRecipeScaler.scale({
+            beer: recipe({referenceVolume: 30, referenceBrewhouseEfficiency: 71}),
+            volume: 60,
+            brewhouseEfficiency: 80,
+        });
+
+        expect(scaled.malts[0].quantity).toBe(10650); // 6000 * (60 / 30) * (71 / 80)
+        expect(scaled.wortBoiling.hops[0].quantity).toBe(120);
+        expect(scaled.fermentationMaturation.yeast[0].quantity).toBe(6);
+        expect(scaled.additionalIngredients?.[0].quantity).toBe(600);
+        expect(scaled.plannedVolume).toBe(60);
+        expect(scaled.plannedBrewhouseEfficiency).toBe(80);
+    });
+
+    it('keeps a compatible fallback only for legacy recipes without reference fields', () => {
+        const scaled = BeerRecipeScaler.scale({beer: recipe(), volume: 20, brewhouseEfficiency: 52});
+        expect(scaled.malts[0].quantity).toBe(12000);
+        expect(BeerRecipeScaler.getReferenceVolume(recipe())).toBe(10);
+    });
+});

--- a/src/utils/BeerScaler/ScalingBeerRecipe.ts
+++ b/src/utils/BeerScaler/ScalingBeerRecipe.ts
@@ -83,29 +83,44 @@ class WaterProfileCalculator {
 // ---------------------------------------------------------
 export class BeerRecipeScaler {
 
-    static readonly BASE_VOLUME = 10;
-    static readonly BASE_EFFICIENCY = 52;
+    /** Compatibility values for records created before recipe references existed. */
+    static readonly LEGACY_REFERENCE_VOLUME = 10;
+    static readonly LEGACY_REFERENCE_EFFICIENCY = 52;
+
+    static getReferenceVolume(aBeer: Beer): number {
+        return aBeer.referenceVolume && aBeer.referenceVolume > 0
+            ? aBeer.referenceVolume
+            : BeerRecipeScaler.LEGACY_REFERENCE_VOLUME;
+    }
+
+    static getReferenceEfficiency(aBeer: Beer): number {
+        return aBeer.referenceBrewhouseEfficiency && aBeer.referenceBrewhouseEfficiency > 0
+            ? aBeer.referenceBrewhouseEfficiency
+            : BeerRecipeScaler.LEGACY_REFERENCE_EFFICIENCY;
+    }
 
     static scale(aValues: scalingValues, aProfile: EquipmentProfile = DEFAULT_PROFILE): Beer {
 
         const aBeer = aValues.beer;
         const targetVolume = aValues.volume;
-        if(aValues.beer.cookingTime)
-        {
-            aProfile.boilTimeMinutes = aValues.beer.cookingTime
-        }
+        const profile = aValues.beer.cookingTime
+            ? {...aProfile, boilTimeMinutes: aValues.beer.cookingTime}
+            : aProfile;
+
+        const referenceVolume = BeerRecipeScaler.getReferenceVolume(aBeer);
+        const referenceEfficiency = BeerRecipeScaler.getReferenceEfficiency(aBeer);
 
 
         const userEfficiency =
             aValues.brewhouseEfficiency > 0
                 ? aValues.brewhouseEfficiency
-                : BeerRecipeScaler.BASE_EFFICIENCY;
+                : referenceEfficiency;
 
         // VOLUMENFAKTOR
-        const volumeFactor = targetVolume / BeerRecipeScaler.BASE_VOLUME;
+        const volumeFactor = targetVolume / referenceVolume;
 
         // AUSBEUTEFAKTOR (nur für Malz)
-        const efficiencyFactor = BeerRecipeScaler.BASE_EFFICIENCY / userEfficiency;
+        const efficiencyFactor = referenceEfficiency / userEfficiency;
 
         // ---------------------------
         // MALZ (Dreisatz × SHA)
@@ -134,10 +149,15 @@ export class BeerRecipeScaler {
                     : 0
             }));
 
+        const scaledAdditionalIngredients = aBeer.additionalIngredients?.map(ingredient => ({
+            ...ingredient,
+            quantity: Number((ingredient.quantity * volumeFactor).toFixed(2))
+        }));
+
         // ---------------------------
         // REALISTISCHE WASSERBERECHNUNG
         // ---------------------------
-        const water = WaterProfileCalculator.calculate(scaledMalts, targetVolume, aProfile);
+        const water = WaterProfileCalculator.calculate(scaledMalts, targetVolume, profile);
 
         const mashVolume = water.hauptguss;
         const spargeVolume = water.nachguss;
@@ -148,6 +168,8 @@ export class BeerRecipeScaler {
         return {
             ...aBeer,
 
+            plannedVolume: targetVolume,
+            plannedBrewhouseEfficiency: userEfficiency,
             mashVolume,
             spargeVolume,
 
@@ -165,7 +187,8 @@ export class BeerRecipeScaler {
             fermentationMaturation: {
                 ...aBeer.fermentationMaturation,
                 yeast: scaledYeast
-            }
+            },
+            additionalIngredients: scaledAdditionalIngredients
         };
     }
 }


### PR DESCRIPTION
### Motivation

- Implement the new concept where a recipe carries a reference volume and reference brewhouse efficiency and the user can choose an independent planned batch size and expected efficiency. 
- Make the Details scaling UI semantically explicit (`Ausschlagmenge`) and hide number-spinner controls only for the brewhouse-efficiency field. 
- Preserve legacy compatibility for recipes that lack reference fields and avoid silently converting imported recipes to a 10 l basis. 

### Description

- Scaling core: `BeerRecipeScaler` now uses per-recipe `referenceVolume` and `referenceBrewhouseEfficiency` (fallbacks `10` l / `52` %) and computes
  `volumeFactor = targetVolume / referenceVolume` and `efficiencyFactor = referenceBrewhouseEfficiency / targetBrewhouseEfficiency`; water calculation uses the possibly adjusted `boilTimeMinutes`. Added `plannedVolume` and `plannedBrewhouseEfficiency` to scaled (client-only) beer objects. (`src/utils/BeerScaler/ScalingBeerRecipe.ts`, tests)
- Data model and form: added optional `referenceVolume` and `referenceBrewhouseEfficiency` to `Beer` and `BeerDTO`; the recipe editor initializes new recipes with default reference values but preserves imported/loaded recipe reference values without coercion. (`src/model/Beer.ts`, `src/model/BeerDTO.ts`, `src/containers/DatabaseOverview/BeerForm.tsx`)
- Details UI: renamed `Liter:` label → `Ausschlagmenge:`, kept compact layout, show a small informational line `Rezeptbasis: 30 l · 71 % SHA` when a recipe exposes reference values, and keep existing 300ms debounce for scaling updates. (`src/containers/MainView/Details/Details.tsx`, `src/containers/MainView/Details/Details.css`)
- Number spinner removal: targeted CSS selectors removed spinner controls only for the brewhouse-efficiency input via a dedicated class `.brewhouse-efficiency-input` to avoid a global change. (`src/containers/MainView/Details/Details.css`)
- Brew start flow: ensure the temporally scaled copy (`selectedBeer`) is used as `beerToBrew` when starting a brew, so production/shopping-list and control mapping operate on the planned/scaled quantities rather than the unmodified DB record. (`src/containers/MainView/BeerRecipes/Table.tsx`)
- Additional: scale `additionalIngredients` quantities with same volume factor so the scaler covers malt/hops/yeast/other ingredients; document the new fields and compatibility requirements in `docs/codex/*`. (`docs/codex/interfaces.md`, `docs/codex/data-flow.md`, `docs/codex/domain-model.md`, `docs/codex/compatibility/cross-repo-contracts.md`)
- Tests added: unit tests for scaler logic (`src/utils/BeerScaler/ScalingBeerRecipe.test.ts`), Details UI (`src/containers/MainView/Details/Details.test.tsx`), and brew-start behavior (`src/containers/MainView/BeerRecipes/Table.test.tsx`).

### Testing

- Ran `git diff --check` and committed the changes (commit message: `Use recipe references for brew scaling`); this succeeded. 
- Attempted focused test runs (`npm test -- --runTestsByPath ...` and `npx react-scripts test --runTestsByPath ...`) but the environment lacks installed dependencies and `react-scripts` registry access failed (HTTP 403), so the Jest runs / build could not be executed here; test files were added and should pass in CI with dependencies installed. 
- Manual verification: css and small UI changes limited to the Details area and a targeted input class to avoid global regressions; scaling logic unit tests were authored to validate reference-based scaling and the legacy fallback (to be executed in CI).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8ee010501c832f94659bfe791cda3f)