### PR TITLE
Fix recipe details before selected beer is loaded

### DIFF
--- a/src/containers/MainView/Details/Details.test.tsx
+++ b/src/containers/MainView/Details/Details.test.tsx
@@ -21,3 +21,15 @@ it('labels the planned batch clearly and displays the compact recipe reference',
     expect(screen.getByRole('combobox')).toHaveValue('30');
     expect(screen.queryByText('Liter:')).not.toBeInTheDocument();
 });
+
+it('handles the initial render before a selected recipe is available', () => {
+    const updateRecipeScaling = jest.fn();
+    const {container, rerender} = render(<Details updateRecipeScaling={updateRecipeScaling} />);
+
+    expect(container).toBeEmptyDOMElement();
+
+    rerender(<Details selectedBeer={beer} updateRecipeScaling={updateRecipeScaling} />);
+
+    expect(screen.getByRole('combobox')).toHaveValue('30');
+    expect(screen.getByRole('spinbutton')).toHaveValue(71);
+});

--- a/src/containers/MainView/Details/Details.tsx
+++ b/src/containers/MainView/Details/Details.tsx
@@ -18,7 +18,7 @@ import {BeerRecipeScaler, scalingValues} from "../../../utils/BeerScaler/Scaling
 import {COLOR_ACCENT, COLOR_BREW_BG} from "../../../colors";
 
 interface DetailsProps {
-    selectedBeer: Beer;
+    selectedBeer?: Beer;
     updateRecipeScaling: (aScalingValues: scalingValues) => void;
 }
 
@@ -103,6 +103,8 @@ export class Details extends React.Component<DetailsProps, DetailsState> {
     // -------------------------------------------------------------
     renderBatchSettings() {
         const {selectedBeer} = this.props;
+        if (!selectedBeer) return null;
+
         const hasRecipeReference = Boolean(
             selectedBeer.referenceVolume && selectedBeer.referenceVolume > 0 &&
             selectedBeer.referenceBrewhouseEfficiency && selectedBeer.referenceBrewhouseEfficiency > 0

--- a/src/containers/MainView/Details/Details.tsx
+++ b/src/containers/MainView/Details/Details.tsx
@@ -42,14 +42,11 @@ export class Details extends React.Component<DetailsProps, DetailsState> {
     componentDidUpdate(prevProps: Readonly<DetailsProps>, prevState: Readonly<DetailsState>, snapshot?: any) {
         const {batchSize, brewhouseEfficiency} = this.state
         const {selectedBeer} = this.props
-        if(selectedBeer && prevProps.selectedBeer)
+        if(selectedBeer && selectedBeer.id !== prevProps.selectedBeer?.id)
         {
-            if(selectedBeer?.id !== prevProps?.selectedBeer.id)
-            {
-                this.setState({
-                    batchSize: BeerRecipeScaler.getReferenceVolume(selectedBeer),
-                    brewhouseEfficiency: BeerRecipeScaler.getReferenceEfficiency(selectedBeer)});
-            }
+            this.setState({
+                batchSize: BeerRecipeScaler.getReferenceVolume(selectedBeer),
+                brewhouseEfficiency: BeerRecipeScaler.getReferenceEfficiency(selectedBeer)});
         }
 
 
@@ -466,6 +463,8 @@ export class Details extends React.Component<DetailsProps, DetailsState> {
     // MAIN RENDER
     // -------------------------------------------------------------
     render() {
+        if (!this.props.selectedBeer) return null;
+
         return (
             <div className="detailsContainer" >
 

--- a/src/utils/BeerScaler/ScalingBeerRecipe.test.ts
+++ b/src/utils/BeerScaler/ScalingBeerRecipe.test.ts
@@ -34,4 +34,9 @@ describe('BeerRecipeScaler', () => {
         expect(scaled.malts[0].quantity).toBe(12000);
         expect(BeerRecipeScaler.getReferenceVolume(recipe())).toBe(10);
     });
+
+    it('uses legacy reference fallbacks while no recipe is loaded yet', () => {
+        expect(BeerRecipeScaler.getReferenceVolume(undefined)).toBe(10);
+        expect(BeerRecipeScaler.getReferenceEfficiency(undefined)).toBe(52);
+    });
 });

--- a/src/utils/BeerScaler/ScalingBeerRecipe.ts
+++ b/src/utils/BeerScaler/ScalingBeerRecipe.ts
@@ -87,14 +87,14 @@ export class BeerRecipeScaler {
     static readonly LEGACY_REFERENCE_VOLUME = 10;
     static readonly LEGACY_REFERENCE_EFFICIENCY = 52;
 
-    static getReferenceVolume(aBeer: Beer): number {
-        return aBeer.referenceVolume && aBeer.referenceVolume > 0
+    static getReferenceVolume(aBeer?: Beer): number {
+        return aBeer?.referenceVolume && aBeer.referenceVolume > 0
             ? aBeer.referenceVolume
             : BeerRecipeScaler.LEGACY_REFERENCE_VOLUME;
     }
 
-    static getReferenceEfficiency(aBeer: Beer): number {
-        return aBeer.referenceBrewhouseEfficiency && aBeer.referenceBrewhouseEfficiency > 0
+    static getReferenceEfficiency(aBeer?: Beer): number {
+        return aBeer?.referenceBrewhouseEfficiency && aBeer.referenceBrewhouseEfficiency > 0
             ? aBeer.referenceBrewhouseEfficiency
             : BeerRecipeScaler.LEGACY_REFERENCE_EFFICIENCY;
     }


### PR DESCRIPTION
## Summary
- make recipe reference helpers tolerate an initially missing `selectedBeer`
- treat `selectedBeer` as optional in the Details view and render nothing until the first recipe is available
- initialize planned volume and SHA correctly when selection changes from `undefined` to a loaded recipe
- add regression tests for the initial loading state and legacy reference fallbacks

## Problem
After recipe reference support was introduced, `Details` called `BeerRecipeScaler.getReferenceVolume(props.selectedBeer)` during construction while Redux could still expose `selectedBeer` as `undefined`. This caused `Cannot read properties of undefined (reading 'referenceVolume')` before recipes finished loading.

## Verification
Added focused Jest/Testing Library regression coverage for both the scaler helper fallback and the Details `undefined -> selectedBeer` transition.