### PR TITLE
Skaliere ausgewählte Rezepte auf Anlagen-SHA (52%)

### DIFF
--- a/docs/codex/data-flow.md
+++ b/docs/codex/data-flow.md
@@ -19,7 +19,7 @@ BeerDatabase 2.x returns `RecipeImportResult`, including `replayed`; a replay is
 - `beerDataReducer.GET_BEERS_SUCCESS` stores the list and selects the last returned recipe as `selectedBeer`.
 - Table sorting is client-side on `name`, `type`, `color`, or `alcohol`.
 - Selecting a row stores `selectedBeer`; clicking brew stores `beerToBrew`.
-- Recipe-detail scaling derives volume from `targetVolume / referenceVolume` and malt efficiency from `referenceBrewhouseEfficiency / targetBrewhouseEfficiency`. The scaled copy remains only in `selectedBeer`; the persisted entry in `beers` is unchanged. Clicking brew for that selected row stores this scaled copy as `beerToBrew`, so production and shopping-list consumers use the planned quantities rather than the original recipe.
+- Recipe-detail scaling initializes every selected recipe with its `referenceVolume` and the equipment plan default of `52` % SHA, then derives volume from `targetVolume / referenceVolume` and malt efficiency from `referenceBrewhouseEfficiency / targetBrewhouseEfficiency`. This initial plan is calculated immediately, including equipment-based water values. The scaled copy remains only in `selectedBeer`; the persisted entry in `beers` is unchanged. Clicking brew for that selected row stores this scaled copy as `beerToBrew`, so production and shopping-list consumers use the planned quantities rather than the original recipe.
 
 Needs verification: backend ordering of `GET beers`, because the UI treats the last item as default selection.
 

--- a/docs/codex/domain-model.md
+++ b/docs/codex/domain-model.md
@@ -5,7 +5,7 @@
 Visible/used fields include:
 
 - Scaling references: optional `referenceVolume` (liters of finished beer) and `referenceBrewhouseEfficiency` (percent) describe the quantities stored in the recipe. New recipes created in this UI use `10` l and `52` % as their recipe basis. Imported/existing recipes preserve values returned by the database. Legacy records without either field retain the UI compatibility fallback of `10` l / `52` %. Database validation, import mapping, and persistence of both fields are **Needs verification**; without them the UI cannot reliably recover whether a legacy import was originally a 20-/30-l recipe.
-- Temporary scaled copies additionally carry client-only `plannedVolume` and `plannedBrewhouseEfficiency`; these are not part of `BeerDTO` and are never persisted to the recipe database.
+- Temporary scaled copies additionally carry client-only `plannedVolume` and `plannedBrewhouseEfficiency`; these are not part of `BeerDTO` and are never persisted to the recipe database. Selecting a recipe initializes the plan volume from `referenceVolume` and the plan efficiency from the current equipment default of `52` %, not from the stored recipe efficiency.
 
 - Identity/display: `id`, `name`, `type`, `color`, `description`, `rating`.
 - Metrics: `alcohol`, `originalwort`, `bitterness`, `mashVolume`, `spargeVolume`, `cookingTime`, `cookingTemperatur`.

--- a/src/containers/MainView/Details/Details.test.tsx
+++ b/src/containers/MainView/Details/Details.test.tsx
@@ -1,4 +1,4 @@
-import {render, screen} from '@testing-library/react';
+import {fireEvent, render, screen} from '@testing-library/react';
 import {Beer} from '../../../model/Beer';
 import {Details} from './Details';
 
@@ -12,14 +12,17 @@ const beer = {
 } as Beer;
 
 it('labels the planned batch clearly and displays the compact recipe reference', () => {
-    render(<Details selectedBeer={beer} updateRecipeScaling={jest.fn()} />);
+    const updateRecipeScaling = jest.fn();
+    render(<Details selectedBeer={beer} updateRecipeScaling={updateRecipeScaling} />);
 
     expect(screen.getByText('Ausschlagmenge:')).toBeInTheDocument();
     expect(screen.getByText('Sudhausausbeute:')).toBeInTheDocument();
     expect(screen.getByText('Rezeptbasis: 30 l · 71 % SHA')).toBeInTheDocument();
     expect(screen.getByRole('spinbutton')).toHaveClass('brewhouse-efficiency-input');
+    expect(screen.getByRole('spinbutton')).toHaveValue(52);
     expect(screen.getByRole('combobox')).toHaveValue('30');
     expect(screen.queryByText('Liter:')).not.toBeInTheDocument();
+    expect(updateRecipeScaling).toHaveBeenCalledWith({beer, volume: 30, brewhouseEfficiency: 52});
 });
 
 it('handles the initial render before a selected recipe is available', () => {
@@ -31,5 +34,30 @@ it('handles the initial render before a selected recipe is available', () => {
     rerender(<Details selectedBeer={beer} updateRecipeScaling={updateRecipeScaling} />);
 
     expect(screen.getByRole('combobox')).toHaveValue('30');
-    expect(screen.getByRole('spinbutton')).toHaveValue(71);
+    expect(screen.getByRole('spinbutton')).toHaveValue(52);
+    expect(updateRecipeScaling).toHaveBeenCalledWith({beer, volume: 30, brewhouseEfficiency: 52});
+});
+
+it('resets volume and planned efficiency when the selected recipe changes', () => {
+    const updateRecipeScaling = jest.fn();
+    const {rerender} = render(<Details selectedBeer={beer} updateRecipeScaling={updateRecipeScaling} />);
+    const nextBeer = {...beer, id: 'recipe-20', referenceVolume: 20, referenceBrewhouseEfficiency: 80};
+
+    fireEvent.change(screen.getByRole('spinbutton'), {target: {value: '72'}});
+    rerender(<Details selectedBeer={nextBeer} updateRecipeScaling={updateRecipeScaling} />);
+
+    expect(screen.getByRole('combobox')).toHaveValue('20');
+    expect(screen.getByRole('spinbutton')).toHaveValue(52);
+    expect(updateRecipeScaling).toHaveBeenLastCalledWith({beer: nextBeer, volume: 20, brewhouseEfficiency: 52});
+});
+
+it('keeps the 10 l / 52 % defaults for a legacy recipe without references', () => {
+    const legacyBeer = {...beer, referenceVolume: undefined, referenceBrewhouseEfficiency: undefined};
+    const updateRecipeScaling = jest.fn();
+
+    render(<Details selectedBeer={legacyBeer} updateRecipeScaling={updateRecipeScaling} />);
+
+    expect(screen.getByRole('combobox')).toHaveValue('10');
+    expect(screen.getByRole('spinbutton')).toHaveValue(52);
+    expect(updateRecipeScaling).toHaveBeenCalledWith({beer: legacyBeer, volume: 10, brewhouseEfficiency: 52});
 });

--- a/src/containers/MainView/Details/Details.tsx
+++ b/src/containers/MainView/Details/Details.tsx
@@ -35,8 +35,12 @@ export class Details extends React.Component<DetailsProps, DetailsState> {
         this.state = {
             selectedBeer: undefined,
             batchSize: BeerRecipeScaler.getReferenceVolume(props.selectedBeer),
-            brewhouseEfficiency: BeerRecipeScaler.getReferenceEfficiency(props.selectedBeer)
+            brewhouseEfficiency: BeerRecipeScaler.DEFAULT_PLANNED_BREWHOUSE_EFFICIENCY
         };
+    }
+
+    componentDidMount() {
+        this.updateRecipe();
     }
 
     componentDidUpdate(prevProps: Readonly<DetailsProps>, prevState: Readonly<DetailsState>, snapshot?: any) {
@@ -46,7 +50,7 @@ export class Details extends React.Component<DetailsProps, DetailsState> {
         {
             this.setState({
                 batchSize: BeerRecipeScaler.getReferenceVolume(selectedBeer),
-                brewhouseEfficiency: BeerRecipeScaler.getReferenceEfficiency(selectedBeer)});
+                brewhouseEfficiency: BeerRecipeScaler.DEFAULT_PLANNED_BREWHOUSE_EFFICIENCY});
         }
 
 
@@ -55,19 +59,6 @@ export class Details extends React.Component<DetailsProps, DetailsState> {
             this.updateRecipe()
         }
     }
-
-    private aDebounceHandle: any = null;
-
-    debounceUpdateRecipe(values: scalingValues) {
-        if (this.aDebounceHandle) {
-            clearTimeout(this.aDebounceHandle);
-        }
-
-        this.aDebounceHandle = setTimeout(() => {
-            this.props.updateRecipeScaling(values);
-        }, 300);
-    }
-
 
     updateRecipe() {
         const { batchSize, brewhouseEfficiency } = this.state;
@@ -81,7 +72,7 @@ export class Details extends React.Component<DetailsProps, DetailsState> {
             brewhouseEfficiency: brewhouseEfficiency
         };
 
-        this.debounceUpdateRecipe(values);
+        this.props.updateRecipeScaling(values);
     }
 
 

--- a/src/utils/BeerScaler/ScalingBeerRecipe.test.ts
+++ b/src/utils/BeerScaler/ScalingBeerRecipe.test.ts
@@ -29,6 +29,35 @@ describe('BeerRecipeScaler', () => {
         expect(scaled.plannedBrewhouseEfficiency).toBe(80);
     });
 
+    it('immediately scales a 30 l / 72 % recipe to the 52 % equipment plan', () => {
+        const original = recipe({referenceVolume: 30, referenceBrewhouseEfficiency: 72});
+        const scaled = BeerRecipeScaler.scale({
+            beer: original,
+            volume: 30,
+            brewhouseEfficiency: BeerRecipeScaler.DEFAULT_PLANNED_BREWHOUSE_EFFICIENCY,
+        });
+
+        expect(scaled.malts[0].quantity).toBe(8307.69);
+        expect(scaled.plannedVolume).toBe(30);
+        expect(scaled.plannedBrewhouseEfficiency).toBe(52);
+        expect(original.malts[0].quantity).toBe(6000);
+        expect(original.referenceVolume).toBe(30);
+        expect(original.referenceBrewhouseEfficiency).toBe(72);
+    });
+
+    it('restores exact ingredient quantities at recipe efficiency and additionally scales volume', () => {
+        const original = recipe({referenceVolume: 30, referenceBrewhouseEfficiency: 72});
+        const referencePlan = BeerRecipeScaler.scale({beer: original, volume: 30, brewhouseEfficiency: 72});
+        const doublePlan = BeerRecipeScaler.scale({beer: original, volume: 60, brewhouseEfficiency: 72});
+
+        expect(referencePlan.malts[0].quantity).toBe(6000);
+        expect(referencePlan.wortBoiling.hops[0].quantity).toBe(60);
+        expect(referencePlan.fermentationMaturation.yeast[0].quantity).toBe(3);
+        expect(referencePlan.additionalIngredients?.[0].quantity).toBe(300);
+        expect(doublePlan.malts[0].quantity).toBe(12000);
+        expect(doublePlan.wortBoiling.hops[0].quantity).toBe(120);
+    });
+
     it('keeps a compatible fallback only for legacy recipes without reference fields', () => {
         const scaled = BeerRecipeScaler.scale({beer: recipe(), volume: 20, brewhouseEfficiency: 52});
         expect(scaled.malts[0].quantity).toBe(12000);

--- a/src/utils/BeerScaler/ScalingBeerRecipe.ts
+++ b/src/utils/BeerScaler/ScalingBeerRecipe.ts
@@ -86,6 +86,8 @@ export class BeerRecipeScaler {
     /** Compatibility values for records created before recipe references existed. */
     static readonly LEGACY_REFERENCE_VOLUME = 10;
     static readonly LEGACY_REFERENCE_EFFICIENCY = 52;
+    /** Current equipment/default efficiency used when creating a temporary brew plan. */
+    static readonly DEFAULT_PLANNED_BREWHOUSE_EFFICIENCY = 52;
 
     static getReferenceVolume(aBeer?: Beer): number {
         return aBeer?.referenceVolume && aBeer.referenceVolume > 0


### PR DESCRIPTION
### Motivation

- Die Bier-Detailseite soll ein ausgewähltes Rezept sofort temporär auf die geplante Sudhausausbeute der Anlage umrechnen, ohne gespeicherte Rezeptdaten zu verändern.
- Standard-Verhalten für Legacy-Rezepte und Fallbacks (10 l / 52 %) bleibt kompatibel.

### Description

- Initialisiert die UI-Planwerte in `Details` mit der Rezept-Referenzmenge und einem zentralen Anlagen-Default von `52 %` statt mit der Rezept-SHA, ruft die Skalierung unmittelbar beim Mount und bei Änderungen auf, und setzt beim Rezeptwechsel Batchgröße und geplante SHA auf die neuen Defaults (`src/containers/MainView/Details/Details.tsx`).
- Führt eine konstante `DEFAULT_PLANNED_BREWHOUSE_EFFICIENCY = 52` im Scaler ein und trennt damit das Anlagen-/Plan-Default von den Legacy-Fallback-Werten (`src/utils/BeerScaler/ScalingBeerRecipe.ts`).
- Ändert das Update-Verhalten so, dass `updateRecipeScaling` direkt (ohne Debounce) mit den temporären Planwerten aufgerufen wird; die Skalierungsformel (`volumeFactor`, `efficiencyFactor`) und die Erzeugung einer temporären, nicht-persistenten `selectedBeer` bleiben unverändert (`BeerRecipeScaler.scale`).
- Dokumentation ergänzt, damit der Datenfluss und das Domain-Modell den sofortigen 52-%-Plan beim Laden eines Rezepts sowie die Trennung persistenter Rezeptbasis vs. temporärem Brauplan reflektieren (`docs/codex/data-flow.md`, `docs/codex/domain-model.md`).

### Testing

- `git diff --check` und diff-Stat liefen lokal erfolgreich as a smoke check; Quelländerungen wurden committed and are present in the branch.
- Versuch die Jest-Tests mit `npm test` / `react-scripts test` für die geänderten Tests (`ScalingBeerRecipe.test.ts`, `Details.test.tsx`, `beerReducer.test.ts`, `Table.test.tsx`) auszuführen schlug fehl, weil `react-scripts`/Abhängigkeiten nicht installiert werden konnten (Registry access returned HTTP 403), daher konnten die automatisierten Tests nicht vollständig ausgeführt werden in dieser Umgebung.
- Enthaltene/aktualisierte Tests: prüft nun die sofortige Skalierung eines 30 l / 72 % Rezepts auf 30 l / 52 % (Malz ≈ 8307.69 g), das Wiederherstellen exakter Originalmengen bei Übereinstimmung der SHA, das initiale UI-Verhalten bei fehlendem `selectedBeer`, das Rezeptwechsel-Verhalten und den Legacy-Fallback `10 l / 52 %` (`src/utils/BeerScaler/ScalingBeerRecipe.test.ts`, `src/containers/MainView/Details/Details.test.tsx`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8ee7d1e8ac832f96f12010beeeadcc)