### PR TITLE
Shutdown-Bestätigung im globalen Header ergänzen

### DIFF
--- a/src/components/ModalDialog/ModalDialog.tsx
+++ b/src/components/ModalDialog/ModalDialog.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {Button, Dialog, DialogTitle, DialogContent, DialogActions} from '@mui/material';
+import {Button, ButtonProps, Dialog, DialogTitle, DialogContent, DialogActions} from '@mui/material';
 import './ModalDialog.css';
 
 export enum DialogType {
@@ -18,6 +18,8 @@ interface ModalDialogProps {
     confirmLabel?: string;
     cancelLabel?: string;
     showCancelButton?: boolean;
+    confirmColor?: ButtonProps['color'];
+    confirmVariant?: ButtonProps['variant'];
 };
 
 interface ModalDialogState {
@@ -53,7 +55,7 @@ class ModalDialog extends React.Component<ModalDialogProps, ModalDialogState> {
         }
     };
     render() {
-        const {content, header, open, type, confirmLabel, cancelLabel, showCancelButton} = this.props;
+        const {content, header, open, type, confirmLabel, cancelLabel, showCancelButton, confirmColor, confirmVariant} = this.props;
 
         return (
             <Dialog open={open} maxWidth={'md'} onClose={showCancelButton ? this.handleCancel : this.handleClose}>
@@ -69,7 +71,7 @@ class ModalDialog extends React.Component<ModalDialogProps, ModalDialogState> {
                             {cancelLabel ?? "Abbrechen"}
                         </Button>
                     )}
-                    <Button onClick={this.handleClose} color="primary">
+                    <Button onClick={this.handleClose} color={confirmColor ?? "primary"} variant={confirmVariant ?? "text"}>
                         {confirmLabel ?? "Ok"}
                     </Button>
                 </DialogActions>

--- a/src/containers/MainView/Header/Header.css
+++ b/src/containers/MainView/Header/Header.css
@@ -79,6 +79,14 @@
   color: inherit;
 }
 
+.shutdown-button {
+  flex: 0 0 auto;
+}
+
+.shutdown-button:hover {
+  color: var(--color-text);
+}
+
 .icon:hover {
   background: var(--color-panel-highlight);
   border-color: var(--color-accent-border);

--- a/src/containers/MainView/Header/Header.test.tsx
+++ b/src/containers/MainView/Header/Header.test.tsx
@@ -62,4 +62,42 @@ describe('Header navigation', () => {
         expect(screen.queryByRole('alert')).not.toBeInTheDocument();
         expect(screen.getByText('Aufheizen')).toBeInTheDocument();
     });
+
+    it('asks for confirmation without performing a shutdown action', (): void => {
+        render(
+            <Header
+                setViewState={jest.fn()}
+                currentView={Views.MAIN}
+                removeAllMessages={jest.fn()}
+                backendStatus={true}
+                messages={[]}
+            />
+        );
+
+        fireEvent.click(screen.getByLabelText('Brauhaus herunterfahren'));
+        expect(screen.getByText('Brauhaus herunterfahren?')).toBeInTheDocument();
+        expect(screen.getByText('Die Steuerung und der Raspberry Pi werden beendet.')).toBeInTheDocument();
+
+        fireEvent.click(screen.getByRole('button', {name: 'Abbrechen'}));
+        expect(screen.queryByText('Brauhaus herunterfahren?')).not.toBeInTheDocument();
+    });
+
+    it('warns explicitly when a brewing process is active', (): void => {
+        render(
+            <Header
+                setViewState={jest.fn()}
+                currentView={Views.PRODUCTION}
+                removeAllMessages={jest.fn()}
+                backendStatus={true}
+                messages={[]}
+                brewingStatus={brewingStatus(false)}
+            />
+        );
+
+        fireEvent.click(screen.getByLabelText('Brauhaus herunterfahren'));
+        expect(screen.getByText(/Ein Brauvorgang läuft gerade/)).toBeInTheDocument();
+
+        fireEvent.click(screen.getByRole('button', {name: 'Herunterfahren'}));
+        expect(screen.queryByText('Brauhaus herunterfahren?')).not.toBeInTheDocument();
+    });
 });

--- a/src/containers/MainView/Header/Header.tsx
+++ b/src/containers/MainView/Header/Header.tsx
@@ -3,11 +3,14 @@ import './Header.css';
 import {Views} from "../../../enums/eViews";
 import StatusDisplay from './StatusDisplay';
 import DashboardIcon from '@mui/icons-material/Dashboard';
+import PowerSettingsNewIcon from '@mui/icons-material/PowerSettingsNew';
 import {BrewingStatus} from '../../../model/brewingStatus.types';
 import {equipmentAlarmDisplay, isEquipmentAlarmActive} from '../../../utils/brewingStatus/alarmDisplay';
+import {isProcessActive} from '../../../utils/brewingStatus/selectors';
 import {getUiMode} from '../../../utils/uiMode';
 import {getNavigationViews} from '../../../utils/viewConfig';
 import {UiMode} from '../../../enums/eUiMode';
+import ModalDialog, {DialogType} from '../../../components/ModalDialog/ModalDialog';
 
 
 
@@ -23,6 +26,7 @@ interface HeaderProps {
 interface HeaderState {
     currentTime: string;
     currentDate: string;
+    showShutdownDialog: boolean;
 }
 
 export class Header extends React.Component<HeaderProps, HeaderState> {
@@ -33,6 +37,7 @@ export class Header extends React.Component<HeaderProps, HeaderState> {
             this.state = {
                 currentTime: this.getCurrentTimeString(),
                 currentDate: this.getCurrentDateString(),
+                showShutdownDialog: false,
             };
     }
 
@@ -64,6 +69,11 @@ export class Header extends React.Component<HeaderProps, HeaderState> {
         setViewState(viewState);
     }
 
+    handleShutdownConfirmed = () => {
+        // Placeholder for the future POST /api/system/shutdown integration.
+        this.setState({showShutdownDialog: false});
+    }
+
     // Hilfsfunktion, um die aktiven Tab-Klassen zu bestimmen
     getTabClassName = (view: Views) => {
         return `icon ${this.props.currentView === view ? 'active' : ''}`;
@@ -75,6 +85,9 @@ export class Header extends React.Component<HeaderProps, HeaderState> {
        const uiMode = getUiMode();
        const navigationViews = getNavigationViews(uiMode);
        const isVisible = (view: Views) => navigationViews.includes(view);
+       const shutdownMessage = isProcessActive(brewingStatus)
+           ? 'Die Steuerung und der Raspberry Pi werden beendet.\n\n⚠ Ein Brauvorgang läuft gerade. Beim Herunterfahren wird die Steuerung beendet.'
+           : 'Die Steuerung und der Raspberry Pi werden beendet.';
 
         return (
             <div className="Header">
@@ -157,7 +170,29 @@ export class Header extends React.Component<HeaderProps, HeaderState> {
                     <span>{this.state.currentDate}</span>
                     <span>{this.state.currentTime}</span>
                   </div>
+                  <button
+                    type="button"
+                    className="icon shutdown-button"
+                    onClick={() => this.setState({showShutdownDialog: true})}
+                    title="Brauhaus herunterfahren"
+                    aria-label="Brauhaus herunterfahren"
+                  >
+                    <PowerSettingsNewIcon fontSize="inherit" />
+                  </button>
                 </div>
+                <ModalDialog
+                  type={DialogType.INFO}
+                  open={this.state.showShutdownDialog}
+                  header="Brauhaus herunterfahren?"
+                  content={shutdownMessage}
+                  showCancelButton={true}
+                  cancelLabel="Abbrechen"
+                  confirmLabel="Herunterfahren"
+                  confirmColor="error"
+                  confirmVariant="contained"
+                  onCancel={() => this.setState({showShutdownDialog: false})}
+                  onConfirm={this.handleShutdownConfirmed}
+                />
             </div>
 
         );


### PR DESCRIPTION
### Motivation
- Einen gut erkennbaren Power-/Shutdown-Button oben rechts im globalen Header bereitstellen, der vor einem späteren echten Shutdown eine UI-Bestätigung verlangt und bei aktivem Brauvorgang eine deutlichere Warnung anzeigt, ohne aktuell Backend- oder Systemaufrufe durchzuführen.

### Description
- Einen Power-Button mit `PowerSettingsNewIcon` in `src/containers/MainView/Header/Header.tsx` ergänzt, der beim Klick das vorhandene `ModalDialog` öffnet und den Dialogtext abhängig von `isProcessActive(brewingStatus)` um eine Warnung erweitert.
- `ModalDialog` (`src/components/ModalDialog/ModalDialog.tsx`) um optionale Props `confirmColor` und `confirmVariant` erweitert, damit der Bestätigungsbutton als destruktiv/rot und `contained` dargestellt werden kann, ohne Standardverhalten bestehender Aufrufer zu verändern.
- `handleShutdownConfirmed()` als klarer, lokaler Platzhalter in `Header` eingeführt, der aktuell nur den Dialog schließt und für eine spätere Integration von `POST /api/system/shutdown` vorbereitet ist; es werden keine Systemaufrufe oder Browser-/OS-Aktionen ausgeführt.
- Styling (`Header.css`) und Unit-Tests (`src/containers/MainView/Header/Header.test.tsx`) ergänzt; Tests decken Öffnen/Abbrechen des Dialogs sowie die Warnung bei laufendem Brauvorgang ab.

### Testing
- `git diff --check` wurde erfolgreich ausgeführt und zeigte keine whitespace-/diff-Fehler.
- Neue/erweiterte Jest-Tests wurden in `src/containers/MainView/Header/Header.test.tsx` hinzugefügt, die Dialog-Öffnen, Abbrechen und die Warnmeldung bei aktivem Brauvorgang prüfen (Tests sind im Repository vorhanden).
- Versuch, die Tests automatisch mit `npx react-scripts test --runTestsByPath src/containers/MainView/Header/Header.test.tsx` auszuführen, schlug in dieser Umgebung fehl, da `react-scripts`/Abhängigkeiten nicht installiert sind und Registry-Zugriff mit HTTP 403 blockiert wurde, weshalb ein vollständiger CI-/Jest-Lauf hier nicht abgeschlossen werden konnte.
- Änderungen wurden im Commit „Add shutdown confirmation to header" erfasst.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8f301ace64832fbba68b65fb160579)