### PR TITLE
Connect shutdown dialog to system API

### DIFF
--- a/docs/codex/app-context.md
+++ b/docs/codex/app-context.md
@@ -34,6 +34,7 @@ The repository is mostly class-component React with Redux `connect(...)`. Functi
 - `src/containers/DatabaseOverview/`: recipe and ingredient forms.
 - `src/containers/Mobile/`: mobile status, active finished brew, calculations.
 - `src/components/`: reusable controls, modal, gauge, flame, water visual.
+- The desktop header's explicitly confirmed shutdown action uses `SystemRepository` to send one `POST /api/system/shutdown`. It blocks duplicate requests and leaves the UI in a terminal state after HTTP success.
 - `src/utils/`: calculations, recipe mapping, status normalization/selectors, PDF, theme, data collection.
 
 ## State management

--- a/docs/codex/compatibility/cross-repo-contracts.md
+++ b/docs/codex/compatibility/cross-repo-contracts.md
@@ -82,6 +82,8 @@ The recipe editor restricts hop time-unit choices by usage as a UI-only rule: `F
 
 ## UI ↔ PI control
 
+The desktop UI invokes the Caddy-routed system shutdown contract with `POST /api/system/shutdown`, without a request body, exclusively after explicit user confirmation. A successful HTTP status is sufficient; the UI does not depend on the exact response message, retry, poll, or repeat the request. Ownership and deployment routing of `/api/system` outside this repository are **Needs verification**.
+
 The PI control app produces runtime/control data that the UI displays and uses for workflow behavior.
 
 The Settings UI also consumes the existing `POST /api/audio/test` contract. Its `sound` request field is restricted to the logical values `ALARM`, `WARNING`, `CONFIRMATION`, `REST_FINISHED`, `BREW_FINISHED`, and `SUCCESS`; UI labels do not alter these values and the UI never sends WAV filenames. The routed `/api/audio` ownership and deployment mapping are **Needs verification** outside this repository.

--- a/docs/codex/dependencies.md
+++ b/docs/codex/dependencies.md
@@ -22,6 +22,7 @@ Needs verification: the app mixes Material UI v4 and MUI v5 packages, which can 
 - `CommandsURL = '/api/controller/Command/'`
 - `ConfirmURL = '/api/controller/Confirm/'`
 - `AudioURL = '/api/audio'`
+- `SystemURL = '/api/system'`
 
 No environment override is used for API origins. In local CRA development only, `src/setupProxy.js` proxies `/api/*` to `https://192.168.178.72/api/*` without path rewriting. `PUBLIC_URL` is used only for CRA public assets/service worker.
 

--- a/docs/codex/interfaces.md
+++ b/docs/codex/interfaces.md
@@ -59,6 +59,10 @@ Base URL: `BaseURL` (`/api/controller`), `CommandsURL` (`/api/controller/Command
 
 The Settings UI tests the control system's existing logical sounds through `POST /api/audio/test` with JSON `{ "sound": SoundType }`. Supported values are exactly `ALARM`, `WARNING`, `CONFIRMATION`, `REST_FINISHED`, `BREW_FINISHED`, and `SUCCESS`. HTTP 200 returns `{ "success": true, "sound": SoundType }`; invalid input returns HTTP 400 and playback errors return HTTP 500 with `{ "success": false, "error": string }`.
 
+## System REST endpoint
+
+The desktop header sends `POST /api/system/shutdown` without a request body only after explicit confirmation. Any successful HTTP response transitions the UI into its terminal shutdown state; the response message is not used as a control signal. The request is never retried or polled.
+
 ## Socket.io
 
 - URL is derived from `BaseURL` by replacing leading `http` with `ws`.

--- a/src/components/ModalDialog/ModalDialog.tsx
+++ b/src/components/ModalDialog/ModalDialog.tsx
@@ -20,6 +20,9 @@ interface ModalDialogProps {
     showCancelButton?: boolean;
     confirmColor?: ButtonProps['color'];
     confirmVariant?: ButtonProps['variant'];
+    actionsDisabled?: boolean;
+    showConfirmButton?: boolean;
+    disableClose?: boolean;
 };
 
 interface ModalDialogState {
@@ -55,10 +58,11 @@ class ModalDialog extends React.Component<ModalDialogProps, ModalDialogState> {
         }
     };
     render() {
-        const {content, header, open, type, confirmLabel, cancelLabel, showCancelButton, confirmColor, confirmVariant} = this.props;
+        const {content, header, open, type, confirmLabel, cancelLabel, showCancelButton, confirmColor, confirmVariant,
+            actionsDisabled, showConfirmButton = true, disableClose} = this.props;
 
         return (
-            <Dialog open={open} maxWidth={'md'} onClose={showCancelButton ? this.handleCancel : this.handleClose}>
+            <Dialog open={open} maxWidth={'md'} onClose={disableClose ? undefined : (showCancelButton ? this.handleCancel : this.handleClose)}>
                 <DialogTitle className={type}>
                     {header}
                 </DialogTitle>
@@ -67,13 +71,13 @@ class ModalDialog extends React.Component<ModalDialogProps, ModalDialogState> {
                 </DialogContent>
                 <DialogActions>
                     {showCancelButton && (
-                        <Button onClick={this.handleCancel} color="primary">
+                        <Button onClick={this.handleCancel} color="primary" disabled={actionsDisabled}>
                             {cancelLabel ?? "Abbrechen"}
                         </Button>
                     )}
-                    <Button onClick={this.handleClose} color={confirmColor ?? "primary"} variant={confirmVariant ?? "text"}>
+                    {showConfirmButton && <Button onClick={this.handleClose} color={confirmColor ?? "primary"} variant={confirmVariant ?? "text"} disabled={actionsDisabled}>
                         {confirmLabel ?? "Ok"}
-                    </Button>
+                    </Button>}
                 </DialogActions>
 
             </Dialog>

--- a/src/containers/MainView/Header/Header.test.tsx
+++ b/src/containers/MainView/Header/Header.test.tsx
@@ -1,8 +1,13 @@
 import React from 'react';
-import {render, screen, fireEvent} from '@testing-library/react';
+import {render, screen, fireEvent, waitFor} from '@testing-library/react';
 import {Header} from './Header';
 import {Views} from '../../../enums/eViews';
 import {AlarmType, BrewingStatus, ProcessMode, ProcessPhase, ProcessState, WaitingFor} from '../../../model/brewingStatus.types';
+import {SystemRepository} from '../../../repositorys/SystemRepository';
+
+jest.mock('../../../repositorys/SystemRepository');
+
+const mockedShutdown = SystemRepository.shutdown as jest.MockedFunction<typeof SystemRepository.shutdown>;
 
 const brewingStatus = (activeAlarm: boolean): BrewingStatus => ({
     elapsedTime: 0, currentTime: 0, process: {state: ProcessState.ACTIVE},
@@ -12,6 +17,10 @@ const brewingStatus = (activeAlarm: boolean): BrewingStatus => ({
 });
 
 describe('Header navigation', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockedShutdown.mockResolvedValue();
+    });
     it('keeps existing settings navigation and adds version navigation', (): void => {
         const setViewState = jest.fn();
         render(
@@ -77,9 +86,11 @@ describe('Header navigation', () => {
         fireEvent.click(screen.getByLabelText('Brauhaus herunterfahren'));
         expect(screen.getByText('Brauhaus herunterfahren?')).toBeInTheDocument();
         expect(screen.getByText('Die Steuerung und der Raspberry Pi werden beendet.')).toBeInTheDocument();
+        expect(mockedShutdown).not.toHaveBeenCalled();
 
         fireEvent.click(screen.getByRole('button', {name: 'Abbrechen'}));
         expect(screen.queryByText('Brauhaus herunterfahren?')).not.toBeInTheDocument();
+        expect(mockedShutdown).not.toHaveBeenCalled();
     });
 
     it('warns explicitly when a brewing process is active', (): void => {
@@ -97,7 +108,47 @@ describe('Header navigation', () => {
         fireEvent.click(screen.getByLabelText('Brauhaus herunterfahren'));
         expect(screen.getByText(/Ein Brauvorgang läuft gerade/)).toBeInTheDocument();
 
+    });
+
+    it('sends one request, blocks duplicate confirmation, and shows the terminal state', async (): Promise<void> => {
+        let resolveShutdown!: () => void;
+        mockedShutdown.mockImplementationOnce(() => new Promise<void>(resolve => { resolveShutdown = resolve; }));
+        render(
+            <Header setViewState={jest.fn()} currentView={Views.MAIN} removeAllMessages={jest.fn()}
+                backendStatus={true} messages={[]} />
+        );
+
+        fireEvent.click(screen.getByLabelText('Brauhaus herunterfahren'));
+        const confirmButton = screen.getByRole('button', {name: 'Herunterfahren'});
+        fireEvent.click(confirmButton);
+        fireEvent.click(confirmButton);
+
+        expect(mockedShutdown).toHaveBeenCalledTimes(1);
+        expect(screen.getByText('Herunterfahren wird gestartet …')).toBeInTheDocument();
+        expect(confirmButton).toBeDisabled();
+
+        resolveShutdown();
+        await waitFor(() => expect(screen.getByText('Brauhaus wird heruntergefahren …')).toBeInTheDocument());
+        expect(screen.queryByRole('button', {name: 'Herunterfahren'})).not.toBeInTheDocument();
+        expect(screen.getByLabelText('Brauhaus herunterfahren')).toBeDisabled();
+    });
+
+    it('shows a useful error and makes shutdown available again after failure', async (): Promise<void> => {
+        const consoleError = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+        mockedShutdown.mockRejectedValueOnce(new Error('offline'));
+        render(
+            <Header setViewState={jest.fn()} currentView={Views.MAIN} removeAllMessages={jest.fn()}
+                backendStatus={true} messages={[]} />
+        );
+
+        fireEvent.click(screen.getByLabelText('Brauhaus herunterfahren'));
         fireEvent.click(screen.getByRole('button', {name: 'Herunterfahren'}));
-        expect(screen.queryByText('Brauhaus herunterfahren?')).not.toBeInTheDocument();
+
+        await waitFor(() => expect(screen.getByText('Das System konnte nicht heruntergefahren werden.')).toBeInTheDocument());
+        expect(screen.getByRole('button', {name: 'Schließen'})).toBeEnabled();
+        fireEvent.click(screen.getByRole('button', {name: 'Schließen'}));
+        expect(screen.getByLabelText('Brauhaus herunterfahren')).toBeEnabled();
+        expect(consoleError).toHaveBeenCalledWith('Herunterfahren des Brauhauses fehlgeschlagen', expect.any(Error));
+        consoleError.mockRestore();
     });
 });

--- a/src/containers/MainView/Header/Header.tsx
+++ b/src/containers/MainView/Header/Header.tsx
@@ -11,6 +11,7 @@ import {getUiMode} from '../../../utils/uiMode';
 import {getNavigationViews} from '../../../utils/viewConfig';
 import {UiMode} from '../../../enums/eUiMode';
 import ModalDialog, {DialogType} from '../../../components/ModalDialog/ModalDialog';
+import {SystemRepository} from '../../../repositorys/SystemRepository';
 
 
 
@@ -27,10 +28,12 @@ interface HeaderState {
     currentTime: string;
     currentDate: string;
     showShutdownDialog: boolean;
+    shutdownState: 'idle' | 'pending' | 'success' | 'error';
 }
 
 export class Header extends React.Component<HeaderProps, HeaderState> {
     private timer: NodeJS.Timer | undefined;
+    private shutdownRequestPending = false;
 
     constructor(props: HeaderProps) {
         super(props);
@@ -38,6 +41,7 @@ export class Header extends React.Component<HeaderProps, HeaderState> {
                 currentTime: this.getCurrentTimeString(),
                 currentDate: this.getCurrentDateString(),
                 showShutdownDialog: false,
+                shutdownState: 'idle',
             };
     }
 
@@ -69,9 +73,31 @@ export class Header extends React.Component<HeaderProps, HeaderState> {
         setViewState(viewState);
     }
 
-    handleShutdownConfirmed = () => {
-        // Placeholder for the future POST /api/system/shutdown integration.
-        this.setState({showShutdownDialog: false});
+    handleShutdownConfirmed = async () => {
+        if (this.shutdownRequestPending || this.state.shutdownState === 'success') return;
+
+        this.shutdownRequestPending = true;
+        this.setState({shutdownState: 'pending'});
+        try {
+            await SystemRepository.shutdown();
+            this.setState({shutdownState: 'success'});
+        } catch (error) {
+            console.error('Herunterfahren des Brauhauses fehlgeschlagen', error);
+            this.shutdownRequestPending = false;
+            this.setState({shutdownState: 'error'});
+        }
+    }
+
+    openShutdownDialog = () => {
+        if (!this.shutdownRequestPending && this.state.shutdownState !== 'success') {
+            this.setState({showShutdownDialog: true, shutdownState: 'idle'});
+        }
+    }
+
+    closeShutdownDialog = () => {
+        if (!this.shutdownRequestPending) {
+            this.setState({showShutdownDialog: false, shutdownState: 'idle'});
+        }
     }
 
     // Hilfsfunktion, um die aktiven Tab-Klassen zu bestimmen
@@ -88,6 +114,13 @@ export class Header extends React.Component<HeaderProps, HeaderState> {
        const shutdownMessage = isProcessActive(brewingStatus)
            ? 'Die Steuerung und der Raspberry Pi werden beendet.\n\n⚠ Ein Brauvorgang läuft gerade. Beim Herunterfahren wird die Steuerung beendet.'
            : 'Die Steuerung und der Raspberry Pi werden beendet.';
+       const shutdownDialogContent = this.state.shutdownState === 'success'
+           ? 'Brauhaus wird heruntergefahren …'
+           : this.state.shutdownState === 'error'
+               ? 'Das System konnte nicht heruntergefahren werden.'
+               : this.state.shutdownState === 'pending'
+                   ? 'Herunterfahren wird gestartet …'
+                   : shutdownMessage;
 
         return (
             <div className="Header">
@@ -173,7 +206,8 @@ export class Header extends React.Component<HeaderProps, HeaderState> {
                   <button
                     type="button"
                     className="icon shutdown-button"
-                    onClick={() => this.setState({showShutdownDialog: true})}
+                    onClick={this.openShutdownDialog}
+                    disabled={this.state.shutdownState === 'pending' || this.state.shutdownState === 'success'}
                     title="Brauhaus herunterfahren"
                     aria-label="Brauhaus herunterfahren"
                   >
@@ -181,17 +215,20 @@ export class Header extends React.Component<HeaderProps, HeaderState> {
                   </button>
                 </div>
                 <ModalDialog
-                  type={DialogType.INFO}
+                  type={this.state.shutdownState === 'error' ? DialogType.ERROR : DialogType.INFO}
                   open={this.state.showShutdownDialog}
                   header="Brauhaus herunterfahren?"
-                  content={shutdownMessage}
-                  showCancelButton={true}
+                  content={shutdownDialogContent}
+                  showCancelButton={this.state.shutdownState === 'idle' || this.state.shutdownState === 'pending'}
                   cancelLabel="Abbrechen"
-                  confirmLabel="Herunterfahren"
+                  confirmLabel={this.state.shutdownState === 'error' ? 'Schließen' : 'Herunterfahren'}
                   confirmColor="error"
                   confirmVariant="contained"
-                  onCancel={() => this.setState({showShutdownDialog: false})}
-                  onConfirm={this.handleShutdownConfirmed}
+                  actionsDisabled={this.state.shutdownState === 'pending'}
+                  showConfirmButton={this.state.shutdownState !== 'success'}
+                  disableClose={this.state.shutdownState === 'pending' || this.state.shutdownState === 'success'}
+                  onCancel={this.closeShutdownDialog}
+                  onConfirm={this.state.shutdownState === 'error' ? this.closeShutdownDialog : this.handleShutdownConfirmed}
                 />
             </div>
 

--- a/src/global.ts
+++ b/src/global.ts
@@ -3,3 +3,4 @@ export const BaseURL = "/api/controller";
 export const CommandsURL = `${BaseURL}/Command/`;
 export const ConfirmURL = `${BaseURL}/Confirm/`;
 export const AudioURL = "/api/audio";
+export const SystemURL = "/api/system";

--- a/src/repositorys/SystemRepository.test.ts
+++ b/src/repositorys/SystemRepository.test.ts
@@ -1,0 +1,20 @@
+import axios from 'axios';
+import {SystemRepository} from './SystemRepository';
+
+jest.mock('axios');
+
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+describe('SystemRepository', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockedAxios.post.mockResolvedValue({data: {success: true}} as any);
+    });
+
+    it('sends the shutdown command through the system API', async () => {
+        await SystemRepository.shutdown();
+
+        expect(mockedAxios.post).toHaveBeenCalledTimes(1);
+        expect(mockedAxios.post).toHaveBeenCalledWith('/api/system/shutdown');
+    });
+});

--- a/src/repositorys/SystemRepository.ts
+++ b/src/repositorys/SystemRepository.ts
@@ -1,0 +1,8 @@
+import axios from 'axios';
+import {SystemURL} from '../global';
+
+export class SystemRepository {
+    static async shutdown(): Promise<void> {
+        await axios.post(`${SystemURL}/shutdown`);
+    }
+}


### PR DESCRIPTION
### Motivation

- Die existierende Shutdown-UI (Power-Button + Bestätigungsdialog) soll nach Bestätigung eine echte, einmalige API-Anfrage an die Steuerung senden, statt nur ein Platzhalterverhalten auszuführen.

### Description

- Fügt ein zentrales `SystemRepository` hinzu, das `POST /api/system/shutdown` über `SystemURL` kapselt und vom Header verwendet wird.
- Verbindet den vorhandenen Header/Confirm-Dialog mit `SystemRepository.shutdown()`, verhindert doppelte Bestätigungen während eines laufenden Requests und führt einen terminalen Erfolgszustand (`"Brauhaus wird heruntergefahren …"`) sowie einen wiederherstellbaren Fehlerzustand ein.
- Erweitert `ModalDialog` um Props zur Deaktivierung von Aktionen, Bedingung zum Ausblenden des Bestätigungsbuttons und zur Unterbindung des Schließens während des Pending-/Terminalzustands, um keine neue Dialog-Architektur einzuführen.
- Aktualisiert Tests und Dokumentation: neue/angepasste Tests für das Header-Verhalten und ein Test für `SystemRepository`, sowie Ergänzungen in `docs/codex/*` zur API-Vertragsbeschreibung.
- Geänderte/neu hinzugefügte Dateien: `src/repositorys/SystemRepository.ts`, `src/repositorys/SystemRepository.test.ts`, `src/containers/MainView/Header/Header.tsx`, `src/containers/MainView/Header/Header.test.tsx`, `src/components/ModalDialog/ModalDialog.tsx`, `src/global.ts`, und aktualisierte Docs in `docs/codex/*`.
- Shutdown-Request wird jetzt über den API-Pfad `/api/system/shutdown` ausgeführt (konfiguriert via `SystemURL` in `src/global.ts`).

### Testing

- `git diff --check` wurde ausgeführt und zeigte keine Probleme.
- Neue Unit-Tests wurden hinzugefügt: `src/repositorys/SystemRepository.test.ts` und erweiterte `src/containers/MainView/Header/Header.test.tsx` covering: kein Request bei nur Öffnen/Abbrechen, genau ein `POST /api/system/shutdown` bei Bestätigung, Blockieren von Doppelbestätigungen, Anzeige von Erfolgs- und Fehlerzuständen.
- Testausführung im Container mit `CI=true npm test -- --runInBand src/containers/MainView/Header/Header.test.tsx src/repositorys/SystemRepository.test.ts` bzw. `npx react-scripts test ...` konnte nicht vollständig ausgeführt werden, weil Projektabhängigkeiten (`react-scripts` u.ä.) nicht installiert sind bzw. externe Registry-Zugriffe blockiert wurden, weshalb automatisierte Tests hier nicht grün gelaufen sind.
- Dokumentation ergänzt, die das Verhalten und die Nicht-Retry/Kein-Polling-Regeln für `POST /api/system/shutdown` beschreibt; die Ownership/Routing von `/api/system` außerhalb dieses Repos ist als `Needs verification` markiert.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8f543e4178832f86b1f98d49687288)