### PR TITLE
Polish production settings panel design

### DIFF
--- a/src/components/Controlls/QuantityPicker/QuantityPicker.css
+++ b/src/components/Controlls/QuantityPicker/QuantityPicker.css
@@ -2,74 +2,73 @@
 .quantity-picker-container {
     display: flex;
     flex-direction: column;
-    align-items: center;
+    align-items: stretch;
+    min-width: 0;
 }
 
 .quantity-picker-label {
-    padding: 0.2rem 0.2rem;
-    color: var(--color-light-text);
+    padding: 0 0 0.3rem;
+    color: var(--color-text-secondary);
+    font-size: var(--font-size-small);
+    font-weight: 600;
 }
 
 .quantity-picker-content {
     display: flex;
     align-items: center;
+    height: var(--control-height-compact);
+    overflow: hidden;
+    background: var(--color-input-bg);
+    border: 1px solid var(--color-border);
+    border-radius: var(--border-radius-medium);
 }
-.decrement-btn {
-    width: 3rem;
-    height: 3rem;
-    border-radius: 8px 0 0 8px;
-    background-color: var(--color-input-bg); /* Weißer Hintergrund für den Bereich mit der Zahl */
-    color: var(--color-input-border);
-    border-right: var(--color-input-border) 1px solid;
-    &:disabled {
-        background-color: var(--color-input-bg2);
-        cursor: not-allowed;
-    }
-}
+.decrement-btn,
 .increment-btn {
-    width: 3rem;
-    height: 3rem;
-    border-radius: 0 8px 8px 0;
-
-    background-color: var(--color-input-bg); /* Weißer Hintergrund für den Bereich mit der Zahl */
-    color: var(--color-input-border);
-    border-left: var(--color-input-border) 1px solid;
+    width: 2.25rem;
+    height: 100%;
+    padding: 0;
+    border: 0;
+    border-radius: 0;
+    background: var(--color-panel-highlight);
+    color: var(--color-text);
+    font-size: 1.1rem;
+    line-height: 1;
+    transition: background-color 0.15s ease, color 0.15s ease;
 }
-.increment-btn:hover {
-    background-color: var(--color-input-bg3);
+.increment-btn { border-left: 1px solid var(--color-border); }
+.decrement-btn { border-right: 1px solid var(--color-border); }
+.increment-btn:hover:not(:disabled),
+.decrement-btn:hover:not(:disabled) {
+    background: var(--color-accent-subtle-hover);
+    color: var(--color-primary-hover);
     cursor: pointer;
 }
-.decrement-btn:hover {
-    background-color: var(--color-input-bg3);
-    cursor: pointer;
-}
-.increment-btn:disabled
-{
-    background-color: var(--color-input-bg2);
-    cursor: not-allowed;
-}
-
+.increment-btn:active:not(:disabled),
+.decrement-btn:active:not(:disabled) { background: var(--color-accent-subtle); }
+.increment-btn:disabled,
 .decrement-btn:disabled {
-    background-color: var(--color-input-bg2);
+    background: var(--color-disabled-bg);
+    color: var(--color-disabled-text);
     cursor: not-allowed;
-    /* Weitere Styles für den deaktivierten Button... */
 }
 
 
 .quantity-picker-input{
-    width: 3.5rem;
-    height: 3rem;
+    min-width: 2.75rem;
+    height: 100%;
     flex-grow: 1;
     flex: 1; /* Nimmt den verfügbaren Platz ein, um den Raum zwischen Buttons und der Zahl zu füllen */
     display: flex;
     justify-content: center;
     align-items: center;
 
-    background-color: var(--color-input-bg); /* Weißer Hintergrund für den Bereich mit der Zahl */
-
+    background: var(--color-input-bg);
+    color: var(--color-text);
+    font-weight: 700;
 }
 .quantity-picker-input-disabled {
-    background-color: var(--color-input-bg2);
+    background: var(--color-disabled-bg);
+    color: var(--color-disabled-text);
     cursor: not-allowed;
 }
 /* Positionierung des Labels */

--- a/src/containers/Production/Production.css
+++ b/src/containers/Production/Production.css
@@ -126,21 +126,45 @@
 /* Settings Panel */
 .containerProduction .settings {
     grid-area: settings;
-    background: var(--color-brew-bg);
-    border-radius: 12px;
-    padding: 0.75rem 0.875rem 0.875rem;
+    background: var(--color-panel-bg);
+    border: 1px solid var(--color-border-soft);
+    border-radius: var(--border-radius-large);
+    padding: var(--spacing-md);
     min-width: 0;
     box-shadow: 0 2px 16px var(--shadow-medium);
     display: flex;
     flex-direction: column;
-    gap: 0.7rem;
+    gap: var(--spacing-md);
     overflow: hidden;
 }
 
 .containerProduction .settings h3 {
     margin: 0;
-    font-size: 1.35rem;
+    font-size: var(--font-size-section-title);
     line-height: 1.15;
+}
+
+.settingsHeader {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    min-height: var(--control-height-compact);
+    padding: 0 var(--spacing-xs) var(--spacing-sm);
+    border-bottom: 1px solid var(--color-border-soft);
+}
+
+.settingsGroup {
+    padding: var(--spacing-md);
+    background: var(--color-panel-raised);
+    border: 1px solid var(--color-border-soft);
+    border-radius: var(--border-radius-large);
+}
+
+.settingsGroup h4 {
+    margin: 0 0 var(--spacing-md);
+    color: var(--color-text);
+    font-size: var(--font-size-normal);
+    font-weight: 700;
 }
 
 .containerProduction .info {
@@ -211,63 +235,73 @@
 /* Bedienelemente/Settings innen */
 .settingsRow,
 .settingsRowWater {
-    display: flex;
-    justify-content: space-between;
+    display: grid;
+    grid-template-columns: minmax(9rem, 1fr) minmax(9rem, 1fr);
     align-items: flex-start;
-    gap: 1rem;
+    gap: var(--spacing-lg);
 }
+.settingsRowWater { align-items: center; }
 .rightAligned,
 .leftAligned {
     margin: 0;
     min-width: 0;
 }
 
-.leftAligned label {
-    display: block;
-    margin: 0 0 0.25rem;
-    color: var(--color-light-text);
-    line-height: 1.2;
+.settingsRow .rightAligned {
+    display: grid;
+    gap: var(--spacing-sm);
 }
 
-.leftAligned label:not(:first-child) {
-    margin-top: 0.6rem;
+.settingsToggleRow {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--spacing-md);
+    min-height: var(--control-height-compact);
+    color: var(--color-text-secondary);
+    font-size: var(--font-size-small);
+    font-weight: 600;
 }
 
-.quantityPickerItem { display: none; }
+.settingsToggleRow + .settingsToggleRow { margin-top: var(--spacing-sm); }
+.productionSwitch { flex: 0 0 auto; }
+.productionSwitch .react-switch-bg { background: var(--color-panel-highlight) !important; }
+.productionSwitch:has(input:checked) .react-switch-bg { background: var(--color-primary) !important; }
+.productionSwitch:focus-visible { outline: 2px solid var(--color-primary); outline-offset: 2px; }
+.productionSwitch:has(input:disabled) { opacity: 0.45; cursor: not-allowed; }
 
 /* Buttons */
 .startBtnDiv {
     margin-top: auto;
-    display: flex;
-    justify-content: center;
+    display: block;
 }
 .startBtn {
-    height: 2.75rem;
-    width: 12rem;
+    height: var(--control-height);
+    width: 100%;
     font-size: 1rem;
     padding: 0.3rem 1.2rem;
-    border-radius: 6px;
-    background-color: var(--color-success);
-    color: var(--color-white);
-    border: none;
-    margin-right: 0.5rem;
+    border-radius: var(--border-radius-medium);
+    background-color: var(--color-primary);
+    color: var(--color-text-on-primary);
+    border: 1px solid var(--color-accent-border);
     min-width: 80px;
     min-height: 32px;
     transition: background 0.2s, box-shadow 0.2s, transform 0.1s;
     box-shadow: 0 2px 8px var(--shadow-soft);
 }
 .startBtn:hover:not(:disabled) {
-    background-color: var(--color-accent);
-    color: var(--color-white);
-    box-shadow: 0 4px 16px var(--shadow-green);
-    transform: translateY(-2px) scale(1.03);
+    background-color: var(--color-primary-hover);
+    color: var(--color-text-on-primary);
+    box-shadow: 0 4px 16px var(--shadow-orange-strong);
+    transform: translateY(-1px);
     cursor: pointer;
 }
 .startBtn:disabled,
 .startBtn:disabled:hover {
-    background-color: var(--color-accent);
-    color: var(--color-white);
-    opacity: 0.5;
+    background-color: var(--color-disabled-bg);
+    border-color: var(--color-disabled-border);
+    color: var(--color-disabled-text);
+    opacity: 1;
     cursor: not-allowed;
     transform: none;
 }
@@ -287,15 +321,19 @@
     background-color: var(--color-surface-alt-dark);
 }
 
-.startPollingBtnDiv {
-    display: flex;
-    justify-content: center;
-}
-
 .startPollingBtn {
-    min-width: 3rem;
-    min-height: 2.5rem;
+    width: var(--control-height-compact);
+    height: var(--control-height-compact);
+    padding: 0;
+    border: 1px solid var(--color-border);
+    border-radius: var(--border-radius-medium);
+    background: var(--color-panel-raised);
+    color: var(--color-text-secondary);
+    transition: background-color 0.15s ease, color 0.15s ease;
 }
+.startPollingBtn:hover:not(:disabled) { background: var(--color-panel-highlight); color: var(--color-primary-hover); cursor: pointer; }
+.startPollingBtn:active:not(:disabled) { color: var(--color-primary-active); }
+.startPollingBtn:disabled { background: var(--color-disabled-bg); color: var(--color-disabled-text); cursor: not-allowed; }
 
 /* Gauge-Container */
 .GaugeContainer {
@@ -310,29 +348,34 @@
 
 .recipeWaterButtons {
     display: flex;
-    gap: 0.75rem;
-    justify-content: center;
-    margin-top: 0;
+    gap: var(--spacing-sm);
+    margin-top: var(--spacing-md);
 }
 
 .recipeWaterBtn {
-    background-color: var(--color-surface-alt);
-    border: none;
-    border-radius: 0.5rem;
-    color: var(--color-white);
+    flex: 1 1 0;
+    background-color: var(--color-panel-highlight);
+    border: 1px solid var(--color-border);
+    border-radius: var(--border-radius-medium);
+    color: var(--color-text);
     cursor: pointer;
-    font-size: 1rem;
-    min-width: 7.25rem;
-    padding: 0.45rem 0.85rem;
+    font-size: var(--font-size-small);
+    min-height: var(--control-height-compact);
+    min-width: 0;
+    padding: var(--spacing-sm) var(--spacing-md);
+    transition: background-color 0.15s ease, border-color 0.15s ease;
 }
 
 .recipeWaterBtn:hover:not(:disabled) {
-    background-color: var(--color-surface-alt-dark);
+    background-color: var(--color-accent-subtle-hover);
+    border-color: var(--color-accent-border);
 }
 
 .recipeWaterBtn:disabled {
     cursor: not-allowed;
-    opacity: 0.5;
+    background: var(--color-disabled-bg);
+    border-color: var(--color-disabled-border);
+    color: var(--color-disabled-text);
 }
 
 .flame-strip {
@@ -392,4 +435,10 @@
     .containerProduction .settings {
         min-height: 24rem;
     }
+}
+
+@media (max-width: 520px) {
+    .settingsRow,
+    .settingsRowWater { grid-template-columns: 1fr; }
+    .recipeWaterButtons { flex-direction: column; }
 }

--- a/src/containers/Production/Production.tsx
+++ b/src/containers/Production/Production.tsx
@@ -592,65 +592,69 @@ export class Production extends React.Component<ProductionProps, ProductionState
         const settingsDisabled = !this.isControllerAvailable();
         const mashWaterDisabled = settingsDisabled || this.isRecipeWaterButtonDisabled('mash');
         const spargeWaterDisabled = settingsDisabled || this.isRecipeWaterButtonDisabled('sparge');
+        const renderSwitch = (label: string, checked: boolean, onChange: (checked: boolean) => void, disabled = settingsDisabled) => (
+            <div className="settingsToggleRow">
+                <span>{label}</span>
+                <Switch
+                    className="productionSwitch"
+                    onChange={onChange}
+                    checked={checked}
+                    height={24}
+                    width={44}
+                    handleDiameter={18}
+                    checkedIcon={false}
+                    uncheckedIcon={false}
+                    disabled={disabled}
+                    aria-label={label}
+                />
+            </div>
+        );
         return (
             <div className="settings">
-                <h3>Settings</h3>
-                <div className="settingsRow">
-                    <div className="leftAligned" id="formControl">
-                      <label>
-                        <span>Hauptschalter Rührwerk</span>
-                        </label>
-                        <Switch onChange={this.toggleAgitator} checked={mainSwitchState} height={40} width={100} disabled={settingsDisabled} />
-                        <label>
-                        <span>Interval</span>
-                        </label>
-                        <Switch onChange={this.toggleInterval} checked={intervalSwitchState} height={40} width={100} disabled={settingsDisabled}/>
-                        <label>
-                        <span>Heizphase</span>
-                        </label>
-                        <Switch onChange={this.toggleHeatingAndStirring} checked={heatingAndStirringSwitchState} height={40} width={100} disabled={settingsDisabled} />
-                    </div>
-                    <div className="rightAligned" id="quantityPicker">
-                        <QuantityPicker initialValue={1} min={1} max={this.MAX_AGITATOR_SPEED} onChange={this.onAgitatorSpeedChange}
-                                        isDisabled={settingsDisabled} label="Geschwindigkeit" labelPosition="above"/>
-                        <div className="quantityPickerItem">
-
-                        </div>
-                        <QuantityPicker initialValue={1} min={1} max={this.MAX_BREAK_TIME} onChange={this.onIntervalChangeBreakTime}
-                                        isDisabled={settingsDisabled} label="Pausenzeit" labelPosition="above"/>
-                        <div className="quantityPickerItem">
-
-                        </div>
-                        <QuantityPicker initialValue={1} min={1} max={this.MAX_RUNNING_TIME} onChange={this.onIntervalChangeRunningTime}
-                                        isDisabled={settingsDisabled} label="Laufzeit" labelPosition="above"/>
-                    </div>
-                </div>
-
-                <div className="settingsRowWater">
-                    <div className="leftAligned">
-                    <label>
-                        <span>Wasser</span>
-                    </label>
-                    <Switch onChange={this.toggleWaterSwitchState} checked={waterSwitchState} height={40} width={100} disabled={settingsDisabled} />
-                    </div>
-                    <div className="rightAligned">
-                        <QuantityPicker initialValue={1} min={1} max={this.MAX_WATER_LEVEL} onChange={this.onSetWaterChangeQuantity}
-                                        isDisabled={settingsDisabled || waterSwitchState} label="Liter" labelPosition="above"/>
-                    </div>
-
-
-                </div>
-                <div className="recipeWaterButtons">
-                    <button className="recipeWaterBtn" disabled={spargeWaterDisabled} onClick={this.startSpargeWaterFilling}>{this.getRecipeWaterButtonLabel('sparge')}</button>
-                    <button className="recipeWaterBtn" disabled={mashWaterDisabled} onClick={this.startMashWaterFilling}>{this.getRecipeWaterButtonLabel('mash')}</button>
-                </div>
-                <div className="startBtnDiv">
-                    <button className="startBtn" disabled={this.isStartButtonDisabled()} onClick={this.startBrewing}>Start</button>
-                </div>
-                <div className="startPollingBtnDiv">
-                    <button className="startPollingBtn" disabled={settingsDisabled || this.props.isPollingRunning} onClick={this.startPolling}>
+                <div className="settingsHeader">
+                    <h3>Settings</h3>
+                    <button className="startPollingBtn" title="Status aktualisieren" aria-label="Status aktualisieren" disabled={settingsDisabled || this.props.isPollingRunning} onClick={this.startPolling}>
                         <FontAwesomeIcon icon={faRepeat as IconProp} />
                     </button>
+                </div>
+
+                <section className="settingsGroup" aria-labelledby="agitator-settings-title">
+                    <h4 id="agitator-settings-title">Rührwerk</h4>
+                    <div className="settingsRow">
+                        <div className="leftAligned" id="formControl">
+                            {renderSwitch('Hauptschalter Rührwerk', mainSwitchState, this.toggleAgitator)}
+                            {renderSwitch('Intervall', intervalSwitchState, this.toggleInterval)}
+                            {renderSwitch('Heizphase', heatingAndStirringSwitchState, this.toggleHeatingAndStirring)}
+                        </div>
+                        <div className="rightAligned" id="quantityPicker">
+                            <QuantityPicker initialValue={1} min={1} max={this.MAX_AGITATOR_SPEED} onChange={this.onAgitatorSpeedChange}
+                                            isDisabled={settingsDisabled} label="Geschwindigkeit" labelPosition="above"/>
+                            <QuantityPicker initialValue={1} min={1} max={this.MAX_BREAK_TIME} onChange={this.onIntervalChangeBreakTime}
+                                            isDisabled={settingsDisabled} label="Pausenzeit" labelPosition="above"/>
+                            <QuantityPicker initialValue={1} min={1} max={this.MAX_RUNNING_TIME} onChange={this.onIntervalChangeRunningTime}
+                                            isDisabled={settingsDisabled} label="Laufzeit" labelPosition="above"/>
+                        </div>
+                    </div>
+                </section>
+
+                <section className="settingsGroup" aria-labelledby="water-settings-title">
+                    <h4 id="water-settings-title">Wasser</h4>
+                    <div className="settingsRowWater">
+                        <div className="leftAligned">
+                            {renderSwitch('Wasser aktivieren', waterSwitchState, this.toggleWaterSwitchState)}
+                        </div>
+                        <div className="rightAligned">
+                            <QuantityPicker initialValue={1} min={1} max={this.MAX_WATER_LEVEL} onChange={this.onSetWaterChangeQuantity}
+                                            isDisabled={settingsDisabled || waterSwitchState} label="Liter" labelPosition="above"/>
+                        </div>
+                    </div>
+                    <div className="recipeWaterButtons">
+                        <button className="recipeWaterBtn" disabled={spargeWaterDisabled} onClick={this.startSpargeWaterFilling}>{this.getRecipeWaterButtonLabel('sparge')}</button>
+                        <button className="recipeWaterBtn" disabled={mashWaterDisabled} onClick={this.startMashWaterFilling}>{this.getRecipeWaterButtonLabel('mash')}</button>
+                    </div>
+                </section>
+                <div className="startBtnDiv">
+                    <button className="startBtn" disabled={this.isStartButtonDisabled()} onClick={this.startBrewing}>Start</button>
                 </div>
             </div>);
     }


### PR DESCRIPTION
### Motivation

- Die Settings-Sektion der Produktionsseite wirkte inkonsistent zum restlichen UI und sollte kompakter sowie optisch besser integriert werden.  
- Ziel war, vorhandene Komponenten/Tokens zu verwenden und ausschließlich Layout/Style zu ändern, ohne Business-Logik oder Verhalten zu verändern.

### Description

- Visuelle Neugliederung: Settings in semantische Gruppen aufgeteilt (`Rührwerk`, `Wasser`) und als kompakte Karten gestaltet, unter Verwendung der bestehenden CSS-Variablen und Theme-Tokens. Die Änderungen betreffen hauptsächlich `Production.tsx` und `Production.css`.  
- Schalter: vorhandene `react-switch`-Schalter wurden beibehalten, optisch verkleinert, mit konsistenten States und zugänglichen Labels in eine kleine `renderSwitch`-Hilfe ausgelagert (keine neuen Switch-Komponenten). Änderungen in `src/containers/Production/Production.tsx`.  
- Mengensteuerung: die `- / Wert / +`-Controls (`QuantityPicker`) wurden kompakter stilisiert, als zusammengehörige Control gestaltet und mit klaren Hover/Active/Disabled-Zuständen versehen; Styles in `src/components/Controlls/QuantityPicker/QuantityPicker.css`.  
- Aktionen: `Start`-Button als deutlichere primäre Aktion (vollbreite, Theme-Tokens für Disabled), und der Refresh/Reset-Button wurde aus seinem isolierten Bereich in die Settings-Headerleiste verschoben und als `startPolling`-Button mit Tooltip integriert; Änderungen in `src/containers/Production/Production.css` und `Production.tsx`.  
- Responsivität: bestehende Grid-Layouts bleiben erhalten; für sehr schmale Bildschirme schalten die Einstellungsgruppen auf eine einspaltige Darstellung um; kein Verhalten oder Handler wurde entfernt oder verändert.

### Testing

- `git diff --check` wurde ausgeführt und zeigte keine Probleme. (erfolgreich)  
- Lokales Repository-Statusprüfungen: `git status --short` und `git log -1 --oneline` validierten den Commit `89112d4 Polish production settings panel design`. (erfolgreich)  
- Build/Test: es wurde versucht, `npm run build` und unit tests (`CI=true npx react-scripts test --watchAll=false src/containers/Production/Production.test.tsx`) zu starten, jedoch konnten die automatischen Frontend-Build-/Testläufe in dieser Umgebung nicht abgeschlossen werden wegen fehlender `node_modules` / Registry-Zugriffsfehler (HTTP 403); daher konnten die Jest-Tests nicht ausgeführt werden. (nicht ausführbar)  
- Hinweis: Die Änderungen betreffen nur Layout/Styles und nutzen vorhandene Handler/Props unverändert; funktionale Tests sollten wie bisher laufen, sobald Abhängigkeiten in der CI/Entwicklungsumgebung verfügbar sind.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8ff8c54b10832f8ad22c8b645885be)