### PR TITLE
Zentralen Debug-Modus hinzufügen

### DIFF
--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -13,6 +13,7 @@ import {scalingValues} from "../utils/BeerScaler/ScalingBeerRecipe";
 import {RecipeImportRequest, RecipeImportResult} from '../model/RecipeImport';
 import { ThemeName, setTheme as applyAndStoreTheme } from "../utils/theme";
 import { pushViewPath } from "../utils/viewRoutes";
+import { setStoredDebugMode } from "../utils/debugMode";
 
 export namespace BeerActions {
 
@@ -455,6 +456,7 @@ export namespace ApplicationActions {
         SET_MESSAGE = 'ApplicationActions.SET_MESSAGE',
         REMOVE_MESSAGE = 'ApplicationActions.REMOVE_MESSAGE',
         SET_THEME = 'ApplicationActions.SET_THEME',
+        SET_DEBUG = 'ApplicationActions.SET_DEBUG',
     }
 
     export interface SetView {
@@ -487,13 +489,19 @@ export namespace ApplicationActions {
         payload: { theme: ThemeName }
     }
 
+    export interface SetDebug {
+        readonly type: ActionTypes.SET_DEBUG
+        payload: { debug: boolean }
+    }
+
     export type AllApplicationActions =
 
         SetView |
         OpenDialog |
         SetMessage |
         RemoveMessage |
-        SetTheme;
+        SetTheme |
+        SetDebug;
 
     export function setViewState(aView: Views): SetView {
         pushViewPath(aView);
@@ -529,6 +537,15 @@ export namespace ApplicationActions {
         return {
             type: ActionTypes.SET_THEME,
             payload: { theme },
+        };
+    }
+
+    export function setDebug(debug: boolean): SetDebug {
+        setStoredDebugMode(debug);
+
+        return {
+            type: ActionTypes.SET_DEBUG,
+            payload: { debug },
         };
     }
 }

--- a/src/containers/Production/Production.connect.ts
+++ b/src/containers/Production/Production.connect.ts
@@ -54,7 +54,8 @@ const mapStateToProps = (state: RootState) => (
         brewingStatus: state.productionReducer.brewingStatus,
         isBackenAvailable: state.productionReducer.isBackenAvailable,
         waterStatus: state.productionReducer.waterStatus,
-        isPollingRunning: state.productionReducer.isPollingRunning
+        isPollingRunning: state.productionReducer.isPollingRunning,
+        debug: state.applicationReducer.debug
 
     });
 export default connect(mapStateToProps, mapDispatchToProps)(Production);

--- a/src/containers/Production/Production.test.tsx
+++ b/src/containers/Production/Production.test.tsx
@@ -74,6 +74,7 @@ const renderProduction = (aOverrides: Partial<React.ComponentProps<typeof Produc
         addFinishedBrew: jest.fn(),
         nextProcedureStep: jest.fn(),
         confirm: jest.fn(),
+        debug: true,
         ...aOverrides
     };
     return {props, ...render(<Production {...props} />)};
@@ -301,6 +302,11 @@ describe('Production equipment alarm dialog', () => {
 
 describe('Production next button', () => {
     const getNextButton = () => screen.getByRole('button', {name: 'Nächster Schritt'});
+
+    it('does not render the next button outside debug mode', () => {
+        renderProduction({debug: false});
+        expect(screen.queryByRole('button', {name: 'Nächster Schritt'})).not.toBeInTheDocument();
+    });
 
     it('disables the next button while the status has not been loaded yet', () => {
         renderProduction({brewingStatus: undefined});

--- a/src/containers/Production/Production.tsx
+++ b/src/containers/Production/Production.tsx
@@ -64,6 +64,7 @@ export interface ProductionProps {
     nextProcedureStep: () => void;
     isPollingRunning: boolean;
     confirm: (confirmState: ConfirmStates) => void;
+    debug: boolean;
 }
 
 interface ProductionState {
@@ -731,7 +732,7 @@ export class Production extends React.Component<ProductionProps, ProductionState
         }
         const isNextStepDisabled = !this.isControllerAvailable() || !this.isNextProcedureStepAvailable();
         return (
-            <ProcessList displayMode="overview" selectedBeer={selectedBeer} currentStepIndex={brewingStatus?.currentStep?.index ?? 0} currentStep={brewingStatus?.currentStep} brewingStatus={brewingStatus} remainingSeconds={this.state.displayedRemainingSeconds} onNextStep={this.handleNextProcedureStep} isNextStepDisabled={isNextStepDisabled} />
+            <ProcessList displayMode="overview" selectedBeer={selectedBeer} currentStepIndex={brewingStatus?.currentStep?.index ?? 0} currentStep={brewingStatus?.currentStep} brewingStatus={brewingStatus} remainingSeconds={this.state.displayedRemainingSeconds} onNextStep={this.props.debug ? this.handleNextProcedureStep : undefined} isNextStepDisabled={isNextStepDisabled} />
         );
     }
 

--- a/src/containers/Settings/SettingsPage.connect.ts
+++ b/src/containers/Settings/SettingsPage.connect.ts
@@ -5,10 +5,12 @@ import {SettingsPage} from './SettingsPage';
 
 const mapStateToProps = (state: any) => ({
     theme: state.applicationReducer.theme as ThemeName,
+    debug: state.applicationReducer.debug as boolean,
 });
 
 const mapDispatchToProps = (dispatch: any) => ({
     setTheme: (theme: ThemeName) => dispatch(ApplicationActions.setTheme(theme)),
+    setDebug: (debug: boolean) => dispatch(ApplicationActions.setDebug(debug)),
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(SettingsPage);

--- a/src/containers/Settings/SettingsPage.test.tsx
+++ b/src/containers/Settings/SettingsPage.test.tsx
@@ -8,12 +8,23 @@ jest.mock('../../repositorys/AudioRepository');
 
 const mockedTestSound = AudioRepository.testSound as jest.MockedFunction<typeof AudioRepository.testSound>;
 
-const renderSettings = () => render(<SettingsPage theme="default" setTheme={jest.fn()} />);
+const renderSettings = (debug = true, setDebug = jest.fn()) => render(
+    <SettingsPage theme="default" setTheme={jest.fn()} debug={debug} setDebug={setDebug} />
+);
 
 describe('Settings sound tests', () => {
     beforeEach(() => {
         jest.clearAllMocks();
         mockedTestSound.mockResolvedValue();
+    });
+
+    it('hides sound tests outside debug mode and enables debug centrally', () => {
+        const setDebug = jest.fn();
+        renderSettings(false, setDebug);
+
+        expect(screen.queryByText('Sounds')).not.toBeInTheDocument();
+        fireEvent.click(screen.getByRole('checkbox', { name: 'Debug-Modus' }));
+        expect(setDebug).toHaveBeenCalledWith(true);
     });
 
     it('renders all six user-friendly sound labels', () => {

--- a/src/containers/Settings/SettingsPage.tsx
+++ b/src/containers/Settings/SettingsPage.tsx
@@ -10,6 +10,8 @@ import { getUiMode, setUiMode } from '../../utils/uiMode';
 interface SettingsPageProps {
     theme: ThemeName;
     setTheme: (theme: ThemeName) => void;
+    debug: boolean;
+    setDebug: (debug: boolean) => void;
 }
 
 interface SettingsPageState {
@@ -182,7 +184,7 @@ export class SettingsPage extends React.Component<SettingsPageProps, SettingsPag
     };
 
     render() {
-        const { theme } = this.props;
+        const { theme, debug } = this.props;
         const { autoConnect, notificationsEnabled, temperatureUnit, statusMessage, pushSupported, pushSubscribed, pushLoading, pushError, pushPermission, soundPlaying, soundError } = this.state;
 
         return (
@@ -272,6 +274,28 @@ export class SettingsPage extends React.Component<SettingsPageProps, SettingsPag
 
                     <section className="settings-card">
                         <div className="settings-card-header">
+                            <h3>Entwicklung</h3>
+                            <p>Blende Funktionen zur manuellen Prüfung der Brausteuerung ein.</p>
+                        </div>
+                        <div className="setting-row">
+                            <div className="setting-label-group">
+                                <label htmlFor="debug-mode">Debug-Modus</label>
+                                <span className="setting-description">Aktiviert Soundtests und die manuelle Prozessnavigation.</span>
+                            </div>
+                            <div className="setting-toggle">
+                                <input
+                                    id="debug-mode"
+                                    type="checkbox"
+                                    checked={debug}
+                                    onChange={(event) => this.props.setDebug(event.target.checked)}
+                                />
+                                <label htmlFor="debug-mode">{debug ? 'Aktiviert' : 'Deaktiviert'}</label>
+                            </div>
+                        </div>
+                    </section>
+
+                    <section className="settings-card">
+                        <div className="settings-card-header">
                             <h3>Benachrichtigungen</h3>
                             <p>Kontrolliere, ob Hinweistexte automatisch angezeigt werden sollen.</p>
                         </div>
@@ -292,7 +316,7 @@ export class SettingsPage extends React.Component<SettingsPageProps, SettingsPag
                         </div>
                     </section>
 
-                    <section className="settings-card">
+                    {debug && <section className="settings-card">
                         <div className="settings-card-header">
                             <h3>Sounds</h3>
                             <p>Hier können die Signaltöne der Brausteuerung getestet werden.</p>
@@ -316,7 +340,7 @@ export class SettingsPage extends React.Component<SettingsPageProps, SettingsPag
                                 </div>
                             ))}
                         </div>
-                    </section>
+                    </section>}
 
 
 

--- a/src/reducers/applicationReducer.test.ts
+++ b/src/reducers/applicationReducer.test.ts
@@ -2,6 +2,11 @@ import {ApplicationActions} from '../actions/actions';
 import {applicationReducer, initialApplicationState, MAX_APPLICATION_MESSAGES} from './applicationReducer';
 
 describe('applicationReducer messages', (): void => {
+  it('updates the central debug setting', (): void => {
+    const state = applicationReducer(initialApplicationState, ApplicationActions.setDebug(true));
+    expect(state.debug).toBe(true);
+    expect(window.localStorage.getItem('debug')).toBe('true');
+  });
   it('keeps only the newest configured number of messages', (): void => {
     let aState = initialApplicationState;
 

--- a/src/reducers/applicationReducer.ts
+++ b/src/reducers/applicationReducer.ts
@@ -2,6 +2,7 @@ import {ApplicationActions} from '../actions/actions';
 import {Views} from '../enums/eViews';
 import { ThemeName, resolveInitialTheme } from '../utils/theme';
 import { resolveInitialView } from '../utils/viewRoutes';
+import { getStoredDebugMode } from '../utils/debugMode';
 import AllApplicationActions = ApplicationActions.AllApplicationActions;
 import ActionTypes = ApplicationActions.ActionTypes;
 
@@ -14,6 +15,7 @@ export interface ApplicationReducerState {
     errorDialogOpen: boolean;
     message?: string[];
     theme: ThemeName;
+    debug: boolean;
 }
 
 export const initialApplicationState: ApplicationReducerState = {
@@ -23,6 +25,7 @@ export const initialApplicationState: ApplicationReducerState = {
     errorDialogOpen: false,
     message: [],
     theme: resolveInitialTheme(),
+    debug: getStoredDebugMode(),
 };
 
 const applicationReducer = (
@@ -63,6 +66,12 @@ const applicationReducer = (
             return {
                 ...aState,
                 theme: aAction.payload.theme,
+            };
+        }
+        case ApplicationActions.ActionTypes.SET_DEBUG: {
+            return {
+                ...aState,
+                debug: aAction.payload.debug,
             };
         }
         default:

--- a/src/utils/debugMode.ts
+++ b/src/utils/debugMode.ts
@@ -1,0 +1,17 @@
+const DEBUG_MODE_STORAGE_KEY = 'debug';
+
+export const getStoredDebugMode = (): boolean => {
+    try {
+        return window.localStorage.getItem(DEBUG_MODE_STORAGE_KEY) === 'true';
+    } catch {
+        return false;
+    }
+};
+
+export const setStoredDebugMode = (debug: boolean): void => {
+    try {
+        window.localStorage.setItem(DEBUG_MODE_STORAGE_KEY, String(debug));
+    } catch {
+        // Redux still keeps the setting for the current session when storage is unavailable.
+    }
+};


### PR DESCRIPTION
### Motivation
- Eine zentrale, persistent steuerbare Debug-Flag ist nötig, damit debug-only UI-Elemente (Sound-Test-Card, Produktions‑„Nächster Schritt“ Button) konsistent ein- und ausgeblendet werden können.
- Die Implementierung soll die bestehende Redux/Settings‑Struktur und lokale Persistenz (`localStorage`) wiederverwenden und die bestehende Prozesslogik nicht verändern.

### Description
- Fügt `src/utils/debugMode.ts` hinzu, das `debug` über `localStorage` liest und schreibt mit fehlertolerantem Fallback.
- Ergänzt `ApplicationActions` um `SET_DEBUG` und `setDebug(...)` (speichert über `setStoredDebugMode`) und erweitert den Reducer `applicationReducer` um das `debug`-Feld, das initial aus `localStorage` geladen wird.
- Bindet `debug` an die Settings-Page (`SettingsPage.connect.ts` / `SettingsPage.tsx`) und ergänzt dort einen Debug‑Schalter; die bestehende Sound-Test-Card wird nur gerendert, wenn `debug === true`.
- Übergibt `debug` in `Production.connect.ts` / `Production.tsx` und übergibt den `onNextStep`-Callback an `ProcessList` nur, wenn `debug === true`, so dass der Button „Nächster Schritt“ nur im Debug-Modus sichtbar/aktiv ist.
- Aktualisiert Unit-Tests: `applicationReducer.test.ts`, `SettingsPage.test.tsx` und `Production.test.tsx` um Abdeckung für das Setzen des zentralen Debug-Zustands sowie Sichtbarkeitsverhalten in Settings und Production.

### Testing
- `git diff --check` wurde ausgeführt (keine Probleme gemeldet).
- Lokale Jest-Tests und Build konnten nicht vollständig ausgeführt werden, weil `npm install` in dieser Umgebung an einem HTTP 403 gegen die Registry scheiterte, daher konnten die aktualisierten Tests nicht wirklich ausgeführt werden; die Testdateien wurden jedoch angepasst und committed.
- Änderungen wurden committed unter dem Commit-Hash `a23f8a2` mit der Nachricht "Add persisted central debug mode".

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a90023a1a84832fa04481e2479727f9)