### PR TITLE
Settings-Seite überarbeitet: Oberfläche, Brausteuerung, Benachrichtigungen (Redesign)

### DIFF
--- a/src/containers/Settings/SettingsPage.css
+++ b/src/containers/Settings/SettingsPage.css
@@ -1,312 +1,107 @@
 .settings-page {
-  padding: 1.5rem 2rem;
-  color: var(--color-black);
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
   box-sizing: border-box;
   width: 100%;
-  max-width: 100%;
-  overflow-wrap: anywhere;
+  min-height: 100%;
+  padding: var(--spacing-xl);
+  color: var(--color-text);
 }
 
-.settings-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 1rem;
-}
-
-.settings-eyebrow {
-  font-size: 0.75rem;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  font-weight: 700;
-  color: var(--color-orange-dark);
-  margin: 0 0 0.25rem 0;
-}
-
-.settings-header h2 {
-  margin: 0;
-  font-size: 1.5rem;
-}
-
-.settings-subtitle {
-  margin: 0.25rem 0 0 0;
-  color: var(--color-gray-very-dark);
-}
-
-.settings-status {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.5rem;
-  padding: 0.5rem 0.75rem;
-  background: var(--color-input-bg2);
-  border-radius: 0.75rem;
-  border: 1px solid var(--color-input-border);
-  font-weight: 600;
-}
-
-.status-dot {
-  width: 0.75rem;
-  height: 0.75rem;
-  border-radius: 50%;
-  background: var(--color-success-bright);
-  box-shadow: 0 0 0 3px var(--shadow-success-soft);
-}
+.settings-header { margin-bottom: var(--spacing-lg); }
+.settings-header h1 { margin: 0; font-size: var(--font-size-page-title); line-height: 1.2; }
+.settings-subtitle { margin: var(--spacing-xs) 0 0; color: var(--color-text-secondary); }
 
 .settings-message {
-  padding: 0.75rem 1rem;
-  background: var(--color-success-surface);
-  color: var(--color-success-dark);
-  border: 1px solid var(--color-chart-green);
-  border-radius: 0.5rem;
-  box-shadow: 0 1px 2px var(--shadow-card-medium-alt);
+  margin-bottom: var(--spacing-md);
+  padding: var(--spacing-sm) var(--spacing-md);
+  color: var(--color-text);
+  background: var(--color-success-subtle);
+  border: 1px solid var(--color-success);
+  border-radius: var(--border-radius-medium);
 }
 
 .settings-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-  gap: 1rem;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  align-items: start;
+  gap: var(--spacing-lg);
 }
 
 .settings-card {
-  background: var(--color-white);
-  border: 1px solid var(--color-input-border);
-  border-radius: 1rem;
-  padding: 1rem;
-  box-shadow: 0 2px 6px var(--shadow-card-light);
-  display: flex;
-  flex-direction: column;
-  gap: 0.75rem;
   min-width: 0;
+  padding: var(--spacing-lg);
+  background: var(--color-panel-bg);
+  border: 1px solid var(--color-border);
+  border-radius: var(--border-radius-large);
+  box-shadow: 0 2px 6px var(--shadow-card-light);
 }
 
-.settings-card-header {
-  margin-bottom: 0.25rem;
-}
+.settings-card-header { display: flex; align-items: flex-start; gap: var(--spacing-md); margin-bottom: var(--spacing-sm); }
+.settings-card-header > svg { flex: 0 0 auto; color: var(--color-primary); font-size: 1.5rem; }
+.settings-card h2, .settings-card h3, .settings-card p { margin: 0; }
+.settings-card h2 { font-size: var(--font-size-section-title); }
+.settings-card h3 { font-size: var(--font-size-normal); }
+.settings-card-header p, .push-heading p, .sound-tools-header p { margin-top: 2px; color: var(--color-text-secondary); font-size: var(--font-size-small); }
 
-.settings-card h3 {
-  margin: 0;
-}
+.setting-block, .setting-row, .push-section, .sound-tools { border-top: 1px solid var(--color-border-soft); }
+.setting-block { display: grid; gap: var(--spacing-md); padding: var(--spacing-md) 0; }
+.setting-row { display: flex; align-items: center; justify-content: space-between; gap: var(--spacing-lg); padding: var(--spacing-md) 0; }
+.setting-label-group { min-width: 0; display: flex; flex-direction: column; gap: 2px; }
+.setting-label, .setting-label-group label { color: var(--color-text); font-weight: 600; }
+.setting-description { color: var(--color-text-secondary); font-size: var(--font-size-small); line-height: var(--line-height-normal); }
 
-.settings-card p {
-  margin: 0.25rem 0 0 0;
-  color: var(--color-border-strong);
-}
+.settings-segmented { display: inline-flex; width: fit-content; max-width: 100%; padding: 3px; background: var(--color-panel-contrast); border: 1px solid var(--color-border); border-radius: var(--border-radius-medium); }
+.settings-segmented button { min-height: var(--control-height-compact); padding: var(--spacing-xs) var(--spacing-md); color: var(--color-text-secondary); background: transparent; border: 0; border-radius: var(--border-radius-small); font: inherit; font-weight: 600; cursor: pointer; transition: background .15s, color .15s; white-space: nowrap; }
+.settings-segmented button:hover { color: var(--color-text); background: var(--color-panel-highlight); }
+.settings-segmented button.active { color: var(--color-text-on-primary); background: var(--color-primary); box-shadow: 0 2px 5px var(--shadow-secondary); }
 
-.setting-row {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 1rem;
-  padding-top: 0.5rem;
-  border-top: 1px solid var(--color-input-border);
-}
+.settings-toggle { position: relative; flex: 0 0 auto; width: 44px; height: 24px; cursor: pointer; }
+.settings-toggle input { position: absolute; width: 1px; height: 1px; opacity: 0; }
+.settings-toggle span { display: block; width: 100%; height: 100%; box-sizing: border-box; background: var(--color-panel-contrast); border: 1px solid var(--color-border); border-radius: var(--border-radius-pill); transition: background .15s, border-color .15s; }
+.settings-toggle span::after { content: ''; position: absolute; top: 4px; left: 4px; width: 16px; height: 16px; border-radius: 50%; background: var(--color-text-secondary); transition: transform .15s, background .15s; }
+.settings-toggle input:checked + span { background: var(--color-primary); border-color: var(--color-primary); }
+.settings-toggle input:checked + span::after { transform: translateX(20px); background: var(--color-text-on-primary); }
+.settings-toggle input:focus-visible + span { outline: 2px solid var(--color-primary); outline-offset: 2px; }
 
-.setting-label-group {
-  display: flex;
-  flex-direction: column;
-  gap: 0.25rem;
-}
+.settings-select { min-width: 160px; min-height: var(--control-height-compact); padding: var(--spacing-xs) var(--spacing-md); color: var(--color-text); background: var(--color-panel-contrast); border: 1px solid var(--color-border); border-radius: var(--border-radius-medium); font: inherit; }
+.settings-select:focus { outline: 2px solid var(--color-primary); outline-offset: 1px; }
 
-.setting-label-group label {
-  font-weight: 700;
-}
+.push-section, .sound-tools { padding-top: var(--spacing-md); }
+.push-heading { display: flex; align-items: flex-start; justify-content: space-between; gap: var(--spacing-md); }
+.push-state { display: inline-flex; align-items: center; gap: 6px; color: var(--color-text-secondary); font-size: var(--font-size-small); white-space: nowrap; }
+.push-state i { width: 8px; height: 8px; background: var(--color-text-muted); border-radius: 50%; }
+.push-state.active { color: var(--color-success); }
+.push-state.active i { background: var(--color-success); box-shadow: 0 0 0 3px var(--color-success-subtle); }
+.push-status-list { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: var(--spacing-sm); margin: var(--spacing-md) 0; }
+.push-status-list div { min-width: 0; padding: var(--spacing-sm); background: var(--color-panel-contrast); border-radius: var(--border-radius-medium); }
+.push-status-list dt { color: var(--color-text-secondary); font-size: .75rem; }
+.push-status-list dd { margin: 2px 0 0; font-size: var(--font-size-small); }
 
-.setting-description {
-  color: var(--color-border-mid);
-  font-size: 0.9rem;
-}
+.settings-actions { display: flex; flex-wrap: wrap; gap: var(--spacing-sm); margin-top: var(--spacing-md); }
+.settings-primary, .settings-secondary { min-height: var(--control-height-compact); padding: var(--spacing-xs) var(--spacing-lg); border-radius: var(--border-radius-medium); font: inherit; font-weight: 600; cursor: pointer; transition: background .15s, border-color .15s, transform .1s; }
+.settings-primary { color: var(--color-text-on-primary); background: var(--color-primary); border: 1px solid var(--color-primary); }
+.settings-primary:hover:not(:disabled) { background: var(--color-primary-hover); border-color: var(--color-primary-hover); transform: translateY(-1px); }
+.settings-secondary { color: var(--color-text); background: var(--color-panel-contrast); border: 1px solid var(--color-border); }
+.settings-secondary:hover:not(:disabled) { background: var(--color-panel-highlight); border-color: var(--color-primary); }
+.settings-primary:disabled, .settings-secondary:disabled { color: var(--color-disabled-text); background: var(--color-disabled-bg); border-color: var(--color-disabled-border); cursor: not-allowed; transform: none; }
 
-.setting-options {
-  display: flex;
-  gap: 0.5rem;
-  flex-wrap: wrap;
-  max-width: 100%;
-}
+.sound-tools-header { margin-bottom: var(--spacing-sm); }
+.sound-list { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); column-gap: var(--spacing-lg); }
+.sound-row { display: flex; align-items: center; justify-content: space-between; gap: var(--spacing-sm); padding: var(--spacing-sm) 0; border-top: 1px solid var(--color-border-soft); font-size: var(--font-size-small); }
+.sound-test-button { min-width: 5.5rem; padding-inline: var(--spacing-sm); }
+.settings-error, .settings-warning { margin: var(--spacing-md) 0 0 !important; padding: var(--spacing-sm) var(--spacing-md); border-radius: var(--border-radius-medium); font-size: var(--font-size-small); }
+.settings-error { color: var(--color-error); background: var(--color-error-subtle); border: 1px solid var(--color-error); }
+.settings-warning { color: var(--color-warning); background: var(--color-warning-subtle); border: 1px solid var(--color-warning); }
 
-.settings-chip {
-  padding: 0.5rem 0.9rem;
-  border-radius: 999px;
-  border: 1px solid var(--color-input-border);
-  background: var(--color-input-bg2);
-  cursor: pointer;
-  transition: all 0.15s ease;
-  font-weight: 600;
-}
+.settings-footer { display: flex; align-items: center; gap: var(--spacing-md); margin-top: var(--spacing-lg); padding-top: var(--spacing-md); border-top: 1px solid var(--color-border-soft); }
+.settings-footer p { margin: 0; color: var(--color-text-secondary); font-size: var(--font-size-small); }
 
-.settings-chip.active {
-  background: linear-gradient(180deg, var(--color-orange-warm) 10%, var(--color-orange-main) 100%);
-  color: var(--color-brown-deep);
-  border-color: var(--color-orange-dark);
-  box-shadow: 0 4px 10px var(--shadow-orange-bold);
-}
-
-.settings-chip:hover {
-  transform: translateY(-1px);
-  box-shadow: 0 4px 8px var(--shadow-card-medium-alt);
-}
-
-.setting-toggle {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  font-weight: 600;
-}
-
-.setting-toggle input {
-  width: 1.2rem;
-  height: 1.2rem;
-}
-
-.settings-select {
-  padding: 0.5rem 0.75rem;
-  border-radius: 0.5rem;
-  border: 1px solid var(--color-input-border);
-  background: var(--color-input-bg2);
-  min-width: 180px;
-}
-
-.settings-footer {
-  display: flex;
-  align-items: center;
-  gap: 1rem;
-  justify-content: flex-start;
-  padding-top: 0.5rem;
-  border-top: 1px solid var(--color-input-border);
-}
-
-.settings-primary {
-  padding: 0.75rem 1.25rem;
-  border-radius: 0.75rem;
-  background: linear-gradient(180deg, var(--color-orange-warm) 10%, var(--color-orange-main) 100%);
-  border: 1px solid var(--color-orange-dark);
-  color: var(--color-brown-deep);
-  font-weight: 800;
-  cursor: pointer;
-  box-shadow: 0 4px 10px var(--shadow-orange-bold);
-  transition: transform 0.15s ease, box-shadow 0.15s ease;
-  overflow-wrap: anywhere;
-}
-
-.settings-primary:hover {
-  transform: translateY(-1px);
-  box-shadow: 0 6px 14px var(--shadow-medium);
-}
-
-.settings-primary:active {
-  transform: translateY(0);
-}
-
-.settings-hint {
-  margin: 0;
-  color: var(--color-border-mid);
-}
-
-@media (max-width: 768px) {
-  .settings-page {
-    padding: 1rem 0;
-  }
-
-  .settings-header {
-    flex-direction: column;
-    align-items: flex-start;
-  }
-
-  .settings-grid {
-    grid-template-columns: minmax(0, 1fr);
-  }
-
-  .setting-row {
-    flex-direction: column;
-    align-items: flex-start;
-  }
-
-  .setting-options,
-  .settings-primary,
-  .settings-secondary,
-  .settings-chip,
-  .settings-select {
-    width: 100%;
-  }
-
-  .settings-primary,
-  .settings-secondary,
-  .settings-chip {
-    min-height: 44px;
-  }
-
-  .settings-footer {
-    flex-direction: column;
-    align-items: flex-start;
-  }
-}
-
-.push-status-list {
-  display: flex;
-  flex-direction: column;
-  gap: 0.35rem;
-  color: var(--color-border-strong);
-}
-
-.settings-error,
-.settings-warning {
-  border-radius: 0.5rem;
-  padding: 0.65rem 0.75rem;
-  margin: 0;
-  overflow-wrap: anywhere;
-}
-
-.settings-error {
-  background: var(--color-danger-surface, #fff0f0);
-  border: 1px solid var(--color-danger, #c62828);
-  color: var(--color-danger-dark, #8b0000);
-}
-
-.settings-warning {
-  background: var(--color-warning-surface, #fff7e6);
-  border: 1px solid var(--color-orange-dark);
-  color: var(--color-brown-deep);
-}
-
-.settings-secondary {
-  padding: 0.75rem 1.25rem;
-  border-radius: 0.75rem;
-  background: var(--color-input-bg2);
-  border: 1px solid var(--color-input-border);
-  color: var(--color-black);
-  font-weight: 800;
-  cursor: pointer;
-}
-
-.sound-list {
-  display: flex;
-  flex-direction: column;
-}
-
-.sound-row {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 1rem;
-  padding: 0.6rem 0;
-  border-top: 1px solid var(--color-input-border);
-}
-
-.sound-label {
-  font-weight: 700;
-}
-
-.sound-test-button {
-  min-width: 9.5rem;
-  padding: 0.5rem 0.75rem;
-}
-
-.settings-primary:disabled,
-.settings-secondary:disabled {
-  cursor: not-allowed;
-  opacity: 0.55;
-  transform: none;
-  box-shadow: none;
+@media (max-width: 900px) { .settings-grid { grid-template-columns: minmax(0, 1fr); } }
+@media (max-width: 600px) {
+  .settings-page { padding: var(--spacing-lg); }
+  .setting-row { align-items: flex-start; }
+  .settings-segmented { display: grid; width: 100%; }
+  .settings-segmented button { white-space: normal; }
+  .push-status-list, .sound-list { grid-template-columns: minmax(0, 1fr); }
+  .settings-actions, .settings-footer { align-items: stretch; flex-direction: column; }
+  .settings-actions button, .settings-footer button { width: 100%; }
 }

--- a/src/containers/Settings/SettingsPage.tsx
+++ b/src/containers/Settings/SettingsPage.tsx
@@ -6,6 +6,9 @@ import { AudioRepository } from '../../repositorys/AudioRepository';
 import { SOUND_LABELS, SOUND_TYPES, SoundType } from '../../enums/eSoundType';
 import { UiMode } from '../../enums/eUiMode';
 import { getUiMode, setUiMode } from '../../utils/uiMode';
+import PaletteOutlinedIcon from '@mui/icons-material/PaletteOutlined';
+import PrecisionManufacturingOutlinedIcon from '@mui/icons-material/PrecisionManufacturingOutlined';
+import NotificationsNoneOutlinedIcon from '@mui/icons-material/NotificationsNoneOutlined';
 
 interface SettingsPageProps {
     theme: ThemeName;
@@ -48,10 +51,6 @@ export class SettingsPage extends React.Component<SettingsPageProps, SettingsPag
     }
 
     private soundRequestActive = false;
-
-    get activeThemeLabel() {
-        return this.props.theme === 'dark-alt' ? 'Dunkles Theme' : 'Helles Theme';
-    }
 
     componentDidMount() {
         this.refreshPushState();
@@ -188,19 +187,10 @@ export class SettingsPage extends React.Component<SettingsPageProps, SettingsPag
         const { autoConnect, notificationsEnabled, temperatureUnit, statusMessage, pushSupported, pushSubscribed, pushLoading, pushError, pushPermission, soundPlaying, soundError } = this.state;
 
         return (
-            <div className="settings-page">
+            <main className="settings-page">
                 <header className="settings-header">
-                    <div>
-                        <p className="settings-eyebrow">Neue Seite</p>
-                        <h2>Einstellungen</h2>
-                        <p className="settings-subtitle">
-                            Passe das Verhalten der Anwendung an und speichere deine persönlichen Vorlieben.
-                        </p>
-                    </div>
-                    <div className="settings-status">
-                        <span className="status-dot" aria-hidden="true"></span>
-                        <span className="status-label">{this.activeThemeLabel}</span>
-                    </div>
+                    <h1>Einstellungen</h1>
+                    <p className="settings-subtitle">Passe Darstellung und Verhalten der Anwendung an.</p>
                 </header>
 
                 {statusMessage && (
@@ -212,222 +202,144 @@ export class SettingsPage extends React.Component<SettingsPageProps, SettingsPag
                 <div className="settings-grid">
                     <section className="settings-card">
                         <div className="settings-card-header">
-                            <h3>Oberfläche</h3>
-                            <p>Lege fest, welche Bereiche auf diesem Browser bereitstehen.</p>
+                            <PaletteOutlinedIcon aria-hidden="true" />
+                            <div>
+                                <h2>Oberfläche</h2>
+                                <p>Darstellung und Funktionsumfang dieses Browsers.</p>
+                            </div>
                         </div>
-                        <div className="setting-row">
+
+                        <div className="setting-block">
                             <div className="setting-label-group">
-                                <label>UI-Modus</label>
-                                <span className="setting-description">
-                                    Desktop: Vollständige Oberfläche zum Planen, Bearbeiten und Verwalten.
-                                </span>
-                                <span className="setting-description">
-                                    Brausteuerung: Reduzierte Oberfläche für Produktion, Bierübersicht und lokale Einstellungen.
-                                </span>
+                                <span className="setting-label">UI-Modus</span>
+                                <span className="setting-description">Desktop bietet die vollständige Verwaltung, Brausteuerung konzentriert sich auf den laufenden Sud.</span>
                             </div>
-                            <div className="setting-options">
-                                <button
-                                    className={`settings-chip ${getUiMode() === UiMode.DESKTOP ? 'active' : ''}`}
-                                    type="button"
-                                    onClick={() => this.handleUiModeChange(UiMode.DESKTOP)}
-                                >
-                                    Desktop
-                                </button>
-                                <button
-                                    className={`settings-chip ${getUiMode() === UiMode.CONTROLLER ? 'active' : ''}`}
-                                    type="button"
-                                    onClick={() => this.handleUiModeChange(UiMode.CONTROLLER)}
-                                >
-                                    Brausteuerung
-                                </button>
+                            <div className="settings-segmented" aria-label="UI-Modus">
+                                <button className={getUiMode() === UiMode.DESKTOP ? 'active' : ''} type="button" aria-pressed={getUiMode() === UiMode.DESKTOP} onClick={() => this.handleUiModeChange(UiMode.DESKTOP)}>Desktop</button>
+                                <button className={getUiMode() === UiMode.CONTROLLER ? 'active' : ''} type="button" aria-pressed={getUiMode() === UiMode.CONTROLLER} onClick={() => this.handleUiModeChange(UiMode.CONTROLLER)}>Brausteuerung</button>
                             </div>
                         </div>
-                    </section>
-                    <section className="settings-card">
-                        <div className="settings-card-header">
-                            <h3>Darstellung</h3>
-                            <p>Steuere das aktive Theme der Oberfläche.</p>
-                        </div>
-                        <div className="setting-row">
+
+                        <div className="setting-block">
                             <div className="setting-label-group">
-                                <label>Theme auswählen</label>
-                                <span className="setting-description">Wechsle jederzeit zwischen heller und dunkler Ansicht.</span>
+                                <span className="setting-label">Darstellung</span>
+                                <span className="setting-description">Wähle das Theme der Anwendung.</span>
                             </div>
-                            <div className="setting-options">
-                                <button
-                                    className={`settings-chip ${theme === 'default' ? 'active' : ''}`}
-                                    type="button"
-                                    onClick={() => this.handleThemeChange('default')}
-                                >
-                                    Helles Theme
-                                </button>
-                                <button
-                                    className={`settings-chip ${theme === 'dark-alt' ? 'active' : ''}`}
-                                    type="button"
-                                    onClick={() => this.handleThemeChange('dark-alt')}
-                                >
-                                    Dunkles Theme
-                                </button>
+                            <div className="settings-segmented" aria-label="Darstellung">
+                                <button className={theme === 'default' ? 'active' : ''} type="button" aria-pressed={theme === 'default'} onClick={() => this.handleThemeChange('default')}>Helles Theme</button>
+                                <button className={theme === 'dark-alt' ? 'active' : ''} type="button" aria-pressed={theme === 'dark-alt'} onClick={() => this.handleThemeChange('dark-alt')}>Dunkles Theme</button>
                             </div>
                         </div>
                     </section>
 
                     <section className="settings-card">
                         <div className="settings-card-header">
-                            <h3>Entwicklung</h3>
-                            <p>Blende Funktionen zur manuellen Prüfung der Brausteuerung ein.</p>
+                            <PrecisionManufacturingOutlinedIcon aria-hidden="true" />
+                            <div>
+                                <h2>Brausteuerung</h2>
+                                <p>Verbindung, Messwerte und Werkzeuge für den Brauprozess.</p>
+                            </div>
                         </div>
+
                         <div className="setting-row">
                             <div className="setting-label-group">
                                 <label htmlFor="debug-mode">Debug-Modus</label>
-                                <span className="setting-description">Aktiviert Soundtests und die manuelle Prozessnavigation.</span>
+                                <span className="setting-description">Zeigt zusätzliche Funktionen für Entwicklung und Tests.</span>
                             </div>
-                            <div className="setting-toggle">
-                                <input
-                                    id="debug-mode"
-                                    type="checkbox"
-                                    checked={debug}
-                                    onChange={(event) => this.props.setDebug(event.target.checked)}
-                                />
-                                <label htmlFor="debug-mode">{debug ? 'Aktiviert' : 'Deaktiviert'}</label>
-                            </div>
-                        </div>
-                    </section>
-
-                    <section className="settings-card">
-                        <div className="settings-card-header">
-                            <h3>Benachrichtigungen</h3>
-                            <p>Kontrolliere, ob Hinweistexte automatisch angezeigt werden sollen.</p>
-                        </div>
-                        <div className="setting-row">
-                            <div className="setting-label-group">
-                                <label htmlFor="notifications">Systemmeldungen</label>
-                                <span className="setting-description">Zeige Hinweise direkt in der Statusleiste an.</span>
-                            </div>
-                            <div className="setting-toggle">
-                                <input
-                                    id="notifications"
-                                    type="checkbox"
-                                    checked={notificationsEnabled}
-                                    onChange={this.handleNotificationChange}
-                                />
-                                <label htmlFor="notifications">{notificationsEnabled ? 'Aktiviert' : 'Deaktiviert'}</label>
-                            </div>
-                        </div>
-                    </section>
-
-                    {debug && <section className="settings-card">
-                        <div className="settings-card-header">
-                            <h3>Sounds</h3>
-                            <p>Hier können die Signaltöne der Brausteuerung getestet werden.</p>
-                        </div>
-                        {soundError && (
-                            <p className="settings-error" role="alert">{soundError}</p>
-                        )}
-                        <div className="sound-list">
-                            {SOUND_TYPES.map((sound) => (
-                                <div className="sound-row" key={sound}>
-                                    <span className="sound-label">{SOUND_LABELS[sound]}</span>
-                                    <button
-                                        className="settings-secondary sound-test-button"
-                                        type="button"
-                                        onClick={() => this.handleSoundTest(sound)}
-                                        disabled={soundPlaying !== null}
-                                        aria-label={`${SOUND_LABELS[sound]} testen`}
-                                    >
-                                        {soundPlaying === sound ? 'Wird abgespielt…' : '▶ Testen'}
-                                    </button>
-                                </div>
-                            ))}
-                        </div>
-                    </section>}
-
-
-
-                    <section className="settings-card">
-                        <div className="settings-card-header">
-                            <h3>Push-Benachrichtigungen</h3>
-                            <p>Erhalte Hinweise, wenn der Brauvorgang eine Bestätigung benötigt.</p>
-                        </div>
-                        <div className="push-status-list">
-                            <div><strong>Browser unterstützt Push:</strong> {pushSupported ? 'Ja' : 'Nein'}</div>
-                            <div><strong>Berechtigung:</strong> {this.permissionLabel}</div>
-                            <div><strong>Subscription:</strong> {pushSubscribed ? 'Aktiv' : 'Nicht aktiv'}</div>
-                        </div>
-                        {pushPermission === 'denied' && (
-                            <p className="settings-warning">
-                                Die Berechtigung ist blockiert. Bitte Push-Benachrichtigungen in den Browser- oder App-Einstellungen wieder erlauben.
-                            </p>
-                        )}
-                        {pushError && (
-                            <p className="settings-error" role="alert">{pushError}</p>
-                        )}
-                        <div className="setting-options">
-                            <button
-                                className="settings-primary"
-                                type="button"
-                                onClick={this.handlePushToggle}
-                                disabled={!pushSupported || pushLoading || pushPermission === 'denied'}
-                            >
-                                {pushSubscribed ? 'Push-Benachrichtigungen deaktivieren' : 'Push-Benachrichtigungen aktivieren'}
-                            </button>
-                            <button
-                                className="settings-secondary"
-                                type="button"
-                                onClick={this.handlePushTest}
-                                disabled={!pushSubscribed || pushLoading}
-                            >
-                                Testnachricht senden
-                            </button>
-                        </div>
-                    </section>
-
-                    <section className="settings-card">
-                        <div className="settings-card-header">
-                            <h3>Verbindung</h3>
-                            <p>Steuere Hintergrundaktionen zum Abruf der Produktionsdaten.</p>
+                            <label className="settings-toggle">
+                                <input id="debug-mode" type="checkbox" checked={debug} onChange={(event) => this.props.setDebug(event.target.checked)} />
+                                <span aria-hidden="true"></span>
+                            </label>
                         </div>
                         <div className="setting-row">
                             <div className="setting-label-group">
                                 <label htmlFor="autoconnect">Automatisch verbinden</label>
-                                <span className="setting-description">Startet die Synchronisation unmittelbar nach dem Laden.</span>
+                                <span className="setting-description">Verbindung beim Start herstellen.</span>
                             </div>
-                            <div className="setting-toggle">
-                                <input
-                                    id="autoconnect"
-                                    type="checkbox"
-                                    checked={autoConnect}
-                                    onChange={this.handleAutoConnectChange}
-                                />
-                                <label htmlFor="autoconnect">{autoConnect ? 'Aktiviert' : 'Deaktiviert'}</label>
-                            </div>
+                            <label className="settings-toggle">
+                                <input id="autoconnect" type="checkbox" checked={autoConnect} onChange={this.handleAutoConnectChange} />
+                                <span aria-hidden="true"></span>
+                            </label>
                         </div>
-
                         <div className="setting-row">
                             <div className="setting-label-group">
                                 <label htmlFor="temperature-unit">Temperatureinheit</label>
-                                <span className="setting-description">Lege fest, in welcher Einheit Werte angezeigt werden.</span>
+                                <span className="setting-description">Einheit für angezeigte Messwerte.</span>
                             </div>
-                            <select
-                                id="temperature-unit"
-                                className="settings-select"
-                                value={temperatureUnit}
-                                onChange={this.handleTemperatureUnitChange}
-                            >
-                                <option value="celsius">Celsius (°C)</option>
-                                <option value="fahrenheit">Fahrenheit (°F)</option>
+                            <select id="temperature-unit" className="settings-select" value={temperatureUnit} onChange={this.handleTemperatureUnitChange}>
+                                <option value="celsius">Celsius °C</option>
+                                <option value="fahrenheit">Fahrenheit °F</option>
                             </select>
+                        </div>
+
+                        {debug && <div className="sound-tools">
+                            <div className="sound-tools-header">
+                                <h3>Soundtests</h3>
+                                <p>Signaltöne der Brausteuerung prüfen.</p>
+                            </div>
+                            {soundError && <p className="settings-error" role="alert">{soundError}</p>}
+                            <div className="sound-list">
+                                {SOUND_TYPES.map((sound) => (
+                                    <div className="sound-row" key={sound}>
+                                        <span>{SOUND_LABELS[sound]}</span>
+                                        <button className="settings-secondary sound-test-button" type="button" onClick={() => this.handleSoundTest(sound)} disabled={soundPlaying !== null} aria-label={`${SOUND_LABELS[sound]} testen`}>
+                                            {soundPlaying === sound ? 'Wird abgespielt…' : 'Testen'}
+                                        </button>
+                                    </div>
+                                ))}
+                            </div>
+                        </div>}
+                    </section>
+
+                    <section className="settings-card">
+                        <div className="settings-card-header">
+                            <NotificationsNoneOutlinedIcon aria-hidden="true" />
+                            <div>
+                                <h2>Benachrichtigungen</h2>
+                                <p>Systemmeldungen und Hinweise aus der Brausteuerung.</p>
+                            </div>
+                        </div>
+                        <div className="setting-row">
+                            <div className="setting-label-group">
+                                <label htmlFor="notifications">Systemmeldungen</label>
+                                <span className="setting-description">Hinweise direkt in der Statusleiste anzeigen.</span>
+                            </div>
+                            <label className="settings-toggle">
+                                <input id="notifications" type="checkbox" checked={notificationsEnabled} onChange={this.handleNotificationChange} />
+                                <span aria-hidden="true"></span>
+                            </label>
+                        </div>
+
+                        <div className="push-section">
+                            <div className="push-heading">
+                                <div>
+                                    <h3>Push-Benachrichtigungen</h3>
+                                    <p>Informiert dich, wenn der Brauvorgang eine Bestätigung benötigt.</p>
+                                </div>
+                                <span className={`push-state ${pushSubscribed ? 'active' : ''}`}><i aria-hidden="true"></i>{pushSubscribed ? 'Aktiv' : 'Inaktiv'}</span>
+                            </div>
+                            <dl className="push-status-list">
+                                <div><dt>Browser</dt><dd>{pushSupported ? 'Unterstützt' : 'Nicht unterstützt'}</dd></div>
+                                <div><dt>Berechtigung</dt><dd>{this.permissionLabel}</dd></div>
+                                <div><dt>Subscription</dt><dd>{pushSubscribed ? 'Verbunden' : 'Nicht verbunden'}</dd></div>
+                            </dl>
+                            {pushPermission === 'denied' && <p className="settings-warning">Die Berechtigung ist blockiert. Bitte Push in den Browser- oder App-Einstellungen wieder erlauben.</p>}
+                            {pushError && <p className="settings-error" role="alert">{pushError}</p>}
+                            <div className="settings-actions">
+                                <button className="settings-primary" type="button" onClick={this.handlePushToggle} disabled={!pushSupported || pushLoading || pushPermission === 'denied'}>
+                                    {pushSubscribed ? 'Push-Benachrichtigungen deaktivieren' : 'Push-Benachrichtigungen aktivieren'}
+                                </button>
+                                <button className="settings-secondary" type="button" onClick={this.handlePushTest} disabled={!pushSubscribed || pushLoading}>Testnachricht senden</button>
+                            </div>
                         </div>
                     </section>
                 </div>
 
                 <footer className="settings-footer">
-                    <button className="settings-primary" type="button" onClick={this.handleSave}>
-                        Einstellungen speichern
-                    </button>
-                    <p className="settings-hint">Alle Änderungen lassen sich jederzeit zurücksetzen.</p>
+                    <button className="settings-primary" type="button" onClick={this.handleSave}>Einstellungen speichern</button>
+                    <p>Alle Änderungen lassen sich jederzeit anpassen.</p>
                 </footer>
-            </div>
+            </main>
         );
     }
 }


### PR DESCRIPTION
### Motivation

- Die bestehende Settings-Seite wirkte als fremde, weiße Formularseite und soll optisch und strukturell an das vorhandene Brauhaus-Design angeglichen werden. 
- Einstellungen sollen logisch gruppiert und kompakter präsentiert werden (Oberfläche, Brausteuerung, Benachrichtigungen) ohne Änderungen an Persistenz oder Backend-Verhalten.

### Description

- Konsolidiert die Einstellungselemente in drei Cards: `Oberfläche` (UI-Modus + Theme als Segmented Controls), `Brausteuerung` (Debug-Mode Toggle, Automatisch verbinden Toggle, Temperatureinheit Select) und `Benachrichtigungen` (Systemmeldungen Toggle + Push-Status und Aktionen). (Änderungen in `src/containers/Settings/SettingsPage.tsx`)
- Entfernt die obere „NEUE SEITE“-Eyebrow und die separate Theme-Anzeige aus dem Header und ersetzt sie durch einen kompakten Seitenkopf mit Titel und kurzem Untertitel. (Änderungen in `src/containers/Settings/SettingsPage.tsx`)
- Ersetzt schmale weiße Karten durch die vorhandenen dunklen Panel-Stile und verwendet projektweite CSS-Variablen für Farben, Radien, Borders, Schatten, Typografie und Abstände; implementiert ein responsives 2‑spaltiges Grid (bricht unter 900px auf eine Spalte). (Änderungen in `src/containers/Settings/SettingsPage.css`)
- UI-Modus und Theme nutzen jetzt zugängliche Segmented Controls / Button-Groups, boolesche Werte sind als moderne Toggle-Kontrollen umgesetzt, Push-Status wird als kompakte Statuszeile mit kleinem Statuspunkt angezeigt, und vorhandene Sound-/Push-/Debug-Handler bleiben unverändert. (Änderungen in `src/containers/Settings/SettingsPage.tsx`)

### Testing

- `git diff --check` wurde ausgeführt und zeigte keine whitespace/errors in den Diffs (erfolgreich).
- Versuch, die Komponententests `src/containers/Settings/SettingsPage.test.tsx` und ein vollständiges Build laufen zu lassen, schlug fehl, weil die Projekt-Dependencies nicht installiert werden konnten; `npm ci` wurde von der Registry mit `403 Forbidden` abgewiesen, weshalb `npm test` / `npm run build` nicht vollständig ausgeführt werden konnten (blockiert durch fehlende `node_modules`).
- Funktionale Logik wurde bewusst nicht verändert; alle bestehenden Handler für Theme, UI-Mode, Debug, Push, Soundtests, Auto-Connect und Temperatureinheit wurden wiederverwendet und weiter verwendet (manuelle Code-Inspektion bestätigt).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a90925fb840832f8f5aa10c2d98f204)