### PR TITLE
Redesign dashboard: compact KPI row, 3‑column layout, recipe history & consumption stats

### DIFF
--- a/src/containers/Dashboard/DashboardPage.css
+++ b/src/containers/Dashboard/DashboardPage.css
@@ -1,310 +1,65 @@
-.dashboard-page {
-  box-sizing: border-box;
-  width: 100%;
-  min-height: 100%;
-  padding: var(--spacing-xl);
-  color: var(--color-text);
-}
-
-.dashboard-title-row {
-  display: flex;
-  align-items: flex-end;
-  justify-content: space-between;
-  gap: var(--spacing-md);
-  margin-bottom: var(--spacing-lg);
-}
-
-.dashboard-eyebrow {
-  margin: 0 0 var(--spacing-xs);
-  color: var(--color-text-secondary);
-  font-size: var(--font-size-small);
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-}
-
-.dashboard-title-row h1,
-.dashboard-card h2,
-.dashboard-card h3 {
-  margin: 0;
-}
-
-.dashboard-loading,
-.dashboard-warning,
-.dashboard-empty,
-.dashboard-muted {
-  color: var(--color-text-secondary);
-}
-
-.dashboard-warning {
-  color: var(--color-warning-text, #8a5a00);
-  background: var(--color-warning-bg, rgba(255, 193, 7, 0.16));
-  border-radius: var(--border-radius-small);
-  padding: var(--spacing-sm);
-}
-
-.dashboard-kpi-grid {
-  display: grid;
-  grid-template-columns: repeat(7, minmax(8rem, 1fr));
-  gap: var(--spacing-md);
-  margin-bottom: var(--spacing-lg);
-}
-
-.dashboard-card,
-.dashboard-kpi-card,
-.dashboard-ingredient-panel {
-  background: var(--color-panel-bg);
-  border: 1px solid var(--color-border);
-  border-radius: var(--border-radius-large);
-  box-shadow: 0 2px 6px var(--shadow-card-light);
-}
-
-.dashboard-card {
-  padding: var(--spacing-lg);
-}
-
-.dashboard-kpi-card {
-  min-width: 0;
-  padding: var(--spacing-md);
-  display: flex;
-  flex-direction: column;
-  gap: var(--spacing-xs);
-}
-
-.dashboard-kpi-label,
-.dashboard-kpi-unit {
-  color: var(--color-text-secondary);
-  font-size: var(--font-size-small);
-}
-
-.dashboard-kpi-value {
-  font-size: clamp(1.6rem, 3vw, 2.5rem);
-  line-height: 1;
-  color: var(--color-primary);
-}
-
-.dashboard-two-column {
-  display: grid;
-  grid-template-columns: minmax(0, 0.9fr) minmax(0, 1.1fr);
-  gap: var(--spacing-lg);
-  margin-bottom: var(--spacing-lg);
-}
-
-.dashboard-bottom-grid {
-  grid-template-columns: minmax(0, 1.3fr) minmax(18rem, 0.7fr);
-}
-
-.dashboard-section-header {
-  display: flex;
-  align-items: center;
-  gap: var(--spacing-sm);
-  margin-bottom: var(--spacing-md);
-}
-
-.dashboard-section-header svg {
-  color: var(--color-primary);
-}
-
-.dashboard-production-details {
-  display: flex;
-  flex-direction: column;
-  gap: var(--spacing-sm);
-}
-
-.dashboard-status-grid,
-.dashboard-active-row dl {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: var(--spacing-sm);
-  margin: 0;
-}
-
-.dashboard-status-grid div,
-.dashboard-active-row dl div {
-  background: var(--color-panel-contrast);
-  border-radius: var(--border-radius-medium);
-  padding: var(--spacing-sm);
-  min-width: 0;
-}
-
-.dashboard-status-grid dt,
-.dashboard-active-row dt {
-  color: var(--color-text-secondary);
-  font-size: var(--font-size-small);
-}
-
-.dashboard-status-grid dd,
-.dashboard-active-row dd {
-  margin: 0;
-  overflow-wrap: anywhere;
-}
-
-.dashboard-progress-slot {
-  min-height: 3.2rem;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  gap: var(--spacing-xs);
-}
-
-.dashboard-progress,
-.dashboard-history-track {
-  background: var(--color-panel-contrast);
-  border-radius: 999px;
-  overflow: hidden;
-}
-
-.dashboard-progress {
-  height: 0.7rem;
-}
-
-.dashboard-progress span {
-  display: block;
-  height: 100%;
-  background: var(--color-primary);
-}
-
-.dashboard-active-list {
-  display: grid;
-  gap: var(--spacing-md);
-}
-
-.dashboard-active-row {
-  border: 1px solid var(--color-border);
-  border-radius: var(--border-radius-medium);
-  padding: var(--spacing-md);
-}
-
-.dashboard-badge {
-  display: inline-flex;
-  width: fit-content;
-  margin: var(--spacing-xs) 0 var(--spacing-sm);
-  border-radius: 999px;
-  padding: 0.15rem 0.55rem;
-  background: var(--color-primary);
-  color: var(--color-white);
-  font-size: var(--font-size-small);
-}
-
-.dashboard-ingredients-grid {
-  display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
-  gap: var(--spacing-md);
-}
-
-.dashboard-ingredient-panel {
-  padding: var(--spacing-md);
-}
-
-.dashboard-ingredient-panel ol,
-.dashboard-care-card ul {
-  margin: var(--spacing-sm) 0 0;
-  padding-left: 1.25rem;
-}
-
-.dashboard-ingredient-panel li {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
-  gap: var(--spacing-xs) var(--spacing-sm);
-  padding: var(--spacing-xs) 0;
-  border-bottom: 1px solid var(--color-border);
-}
-
-.dashboard-ingredient-panel li:last-child {
-  border-bottom: 0;
-}
-
-.dashboard-ingredient-panel li span {
-  overflow-wrap: anywhere;
-}
-
-.dashboard-ingredient-panel li small {
-  grid-column: 1 / -1;
-  color: var(--color-text-secondary);
-}
-
-.dashboard-history-chart {
-  min-height: 14rem;
-  display: flex;
-  align-items: flex-end;
-  gap: var(--spacing-sm);
-  padding-top: var(--spacing-md);
-}
-
-.dashboard-history-bar {
-  flex: 1 1 4rem;
-  min-width: 3rem;
-  display: grid;
-  grid-template-rows: auto 10rem auto;
-  gap: var(--spacing-xs);
-  text-align: center;
-}
-
-.dashboard-history-track {
-  display: flex;
-  align-items: flex-end;
-  min-height: 10rem;
-}
-
-.dashboard-history-track span {
-  width: 100%;
-  background: var(--color-primary);
-  border-radius: 999px 999px 0 0;
-}
-
-.dashboard-history-value,
-.dashboard-history-label {
-  font-size: var(--font-size-small);
-  color: var(--color-text-secondary);
-}
-
-@media (max-width: 1200px) {
-  .dashboard-kpi-grid,
-  .dashboard-ingredients-grid {
-    grid-template-columns: repeat(3, minmax(0, 1fr));
-  }
-
-  .dashboard-two-column,
-  .dashboard-bottom-grid {
-    grid-template-columns: 1fr;
-  }
-}
-
-@media (max-width: 768px) {
-  .dashboard-page {
-    padding: var(--spacing-md);
-  }
-
-  .dashboard-title-row {
-    align-items: flex-start;
-    flex-direction: column;
-  }
-
-  .dashboard-kpi-grid,
-  .dashboard-ingredients-grid,
-  .dashboard-status-grid,
-  .dashboard-active-row dl {
-    grid-template-columns: 1fr;
-  }
-
-  .dashboard-history-chart {
-    overflow: visible;
-    align-items: stretch;
-    flex-direction: column;
-  }
-
-  .dashboard-history-bar {
-    grid-template-columns: 7rem minmax(0, 1fr) 4rem;
-    grid-template-rows: auto;
-    align-items: center;
-  }
-
-  .dashboard-history-track {
-    min-height: 1rem;
-    height: 1rem;
-    align-items: stretch;
-  }
-
-  .dashboard-history-track span {
-    height: 100% !important;
-  }
-}
+.dashboard-page { box-sizing: border-box; width: 100%; height: calc(100vh - var(--desktop-header-height)); height: calc(100dvh - var(--desktop-header-height)); min-height: 0; padding: var(--spacing-md) var(--spacing-lg); color: var(--color-text); display: grid; grid-template-rows: auto auto minmax(0, 1fr); gap: var(--spacing-md); overflow: hidden; }
+.dashboard-title-row { display: flex; align-items: center; justify-content: space-between; gap: var(--spacing-md); }
+.dashboard-title-row h1, .dashboard-card h2, .dashboard-card h3, .dashboard-title-row p { margin: 0; }
+.dashboard-title-row h1 { font-size: var(--font-size-page-title); line-height: 1.1; }
+.dashboard-title-row p, .dashboard-loading, .dashboard-empty, .dashboard-footnote { color: var(--color-text-secondary); font-size: var(--font-size-small); }
+.dashboard-card { min-width: 0; background: var(--color-panel-bg); border: 1px solid var(--color-border); border-radius: var(--border-radius-large); box-shadow: 0 2px 6px var(--shadow-card-light); }
+.dashboard-kpi-grid { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: var(--spacing-md); }
+.dashboard-kpi-card { padding: var(--spacing-md); display: grid; grid-template-columns: auto 1fr auto; grid-template-areas: "icon label value" "icon detail value"; align-items: center; column-gap: var(--spacing-md); }
+.dashboard-kpi-icon { grid-area: icon; width: 2.25rem; height: 2.25rem; display: grid; place-items: center; border-radius: var(--border-radius-medium); color: var(--color-primary); background: var(--color-accent-subtle); }
+.dashboard-kpi-label { grid-area: label; font-weight: 700; }
+.dashboard-kpi-value { grid-area: value; font-size: 2rem; line-height: 1; color: var(--color-primary); }
+.dashboard-kpi-detail { grid-area: detail; color: var(--color-text-secondary); font-size: var(--font-size-small); }
+.dashboard-content-grid { min-height: 0; display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); grid-template-rows: minmax(0, 1fr) auto; gap: var(--spacing-md); }
+.dashboard-main-card, .dashboard-compact-card { padding: var(--spacing-md); min-height: 0; }
+.dashboard-main-card { display: flex; flex-direction: column; overflow: hidden; }
+.dashboard-section-header { display: flex; align-items: center; gap: var(--spacing-sm); margin-bottom: var(--spacing-sm); flex: none; }
+.dashboard-section-header h2 { font-size: var(--font-size-section-title); }
+.dashboard-section-header svg { color: var(--color-primary); font-size: 1.25rem; }
+.dashboard-scroll-list { min-height: 0; overflow-y: auto; scrollbar-color: var(--color-primary) var(--color-panel-contrast); padding-right: var(--spacing-xs); }
+.dashboard-active-row { display: grid; grid-template-columns: auto minmax(0, 1fr) auto auto; align-items: center; gap: var(--spacing-sm); padding: var(--spacing-md) var(--spacing-xs); border-bottom: 1px solid var(--color-border-soft); }
+.dashboard-active-row:last-child { border-bottom: 0; }
+.dashboard-active-row h3 { font-size: var(--font-size-normal); }
+.dashboard-active-row p { margin: 2px 0 0; color: var(--color-text-secondary); font-size: var(--font-size-small); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.dashboard-state-dot { width: .55rem; height: .55rem; border-radius: 50%; background: var(--color-success); }
+.dashboard-state-dot.is-maturation { background: var(--color-info); }
+.dashboard-badge { border-radius: var(--border-radius-pill); padding: .16rem .55rem; background: var(--color-success-subtle); color: var(--color-success); font-size: .78rem; font-weight: 700; white-space: nowrap; }
+.dashboard-badge.is-maturation { color: var(--color-info); background: color-mix(in srgb, var(--color-info) 16%, transparent); }
+.dashboard-day { min-width: 3rem; text-align: right; font-size: var(--font-size-small); }
+.dashboard-production-card.is-active { border-color: var(--color-accent-border); }
+.dashboard-production-empty { margin: auto 0; display: flex; flex-direction: column; align-items: center; text-align: center; gap: var(--spacing-xs); color: var(--color-text-secondary); }
+.dashboard-production-empty strong { color: var(--color-text); }
+.dashboard-production-details { display: flex; flex-direction: column; gap: var(--spacing-sm); min-height: 0; }
+.dashboard-production-heading, .dashboard-temperature, .dashboard-time { display: flex; align-items: center; justify-content: space-between; gap: var(--spacing-sm); }
+.dashboard-production-heading h3 { font-size: 1.3rem; }
+.dashboard-badge-production { background: var(--color-accent-subtle); color: var(--color-primary); }
+.dashboard-step { margin: 0; font-weight: 700; }
+.dashboard-temperature strong { font-size: 1.65rem; color: var(--color-primary); }
+.dashboard-temperature span, .dashboard-time { color: var(--color-text-secondary); font-size: var(--font-size-small); }
+.dashboard-progress, .dashboard-history-track { height: .45rem; background: var(--color-panel-contrast); border-radius: var(--border-radius-pill); overflow: hidden; }
+.dashboard-progress > span, .dashboard-history-track > span { display: block; height: 100%; background: var(--color-primary); border-radius: inherit; }
+.dashboard-hardware { display: grid; grid-template-columns: repeat(2, 1fr); gap: var(--spacing-sm); margin: 0; }
+.dashboard-hardware div { display: flex; justify-content: space-between; padding: var(--spacing-sm); background: var(--color-panel-contrast); border-radius: var(--border-radius-medium); }
+.dashboard-hardware dd { margin: 0; font-weight: 700; color: var(--color-text-secondary); }
+.dashboard-hardware dd.is-on { color: var(--color-success); }
+.dashboard-warning { margin: 0; padding: var(--spacing-sm); color: var(--color-warning); background: var(--color-warning-subtle); border-radius: var(--border-radius-small); font-size: var(--font-size-small); }
+.dashboard-history-summary { display: grid; grid-template-columns: repeat(4, 1fr); gap: var(--spacing-xs); margin-bottom: var(--spacing-sm); }
+.dashboard-history-summary span { color: var(--color-text-secondary); font-size: .72rem; }
+.dashboard-history-summary strong { display: block; color: var(--color-primary); font-size: var(--font-size-normal); }
+.dashboard-history-row { display: grid; grid-template-columns: minmax(0, 1.3fr) auto auto; gap: var(--spacing-xs) var(--spacing-sm); align-items: center; padding: var(--spacing-sm) 0; border-bottom: 1px solid var(--color-border-soft); font-size: var(--font-size-small); }
+.dashboard-history-row > strong { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.dashboard-history-track { grid-column: 1 / -1; }
+.dashboard-consumption-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: var(--spacing-sm); }
+.dashboard-consumption-grid div { padding: var(--spacing-sm); background: var(--color-panel-contrast); border-radius: var(--border-radius-medium); }
+.dashboard-consumption-grid span, .dashboard-consumption-grid small { display: block; color: var(--color-text-secondary); font-size: .72rem; }
+.dashboard-consumption-grid strong { display: block; color: var(--color-primary); font-size: 1.15rem; }
+.dashboard-footnote { margin: var(--spacing-xs) 0 0; font-size: .7rem; }
+.dashboard-metric-list { display: grid; grid-template-columns: 1fr 1fr; gap: var(--spacing-xs) var(--spacing-md); margin: 0; }
+.dashboard-metric-list div { display: flex; justify-content: space-between; gap: var(--spacing-sm); padding: .2rem 0; border-bottom: 1px solid var(--color-border-soft); }
+.dashboard-metric-list dt { color: var(--color-text-secondary); }
+.dashboard-metric-list dd { margin: 0; font-weight: 700; }
+.dashboard-hint { margin: var(--spacing-xs) 0; font-size: var(--font-size-small); }
+.dashboard-hint.is-warning { color: var(--color-warning); }.dashboard-hint.is-clear { color: var(--color-success); }
+@media (max-width: 1400px) { .dashboard-page { height: auto; min-height: 100%; overflow: visible; } .dashboard-content-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); grid-template-rows: auto; } .dashboard-main-card { min-height: 20rem; } }
+@media (max-width: 900px) { .dashboard-kpi-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); } .dashboard-content-grid { grid-template-columns: 1fr; } .dashboard-main-card { min-height: auto; max-height: none; } .dashboard-scroll-list { max-height: 24rem; } }
+@media (max-width: 560px) { .dashboard-page { padding: var(--spacing-md); } .dashboard-kpi-grid { grid-template-columns: 1fr; } .dashboard-active-row { grid-template-columns: auto minmax(0, 1fr) auto; } .dashboard-active-row .dashboard-badge { grid-column: 2; width: fit-content; } .dashboard-day { grid-column: 3; grid-row: 1 / span 2; } .dashboard-history-summary, .dashboard-metric-list { grid-template-columns: repeat(2, 1fr); } }

--- a/src/containers/Dashboard/DashboardPage.test.tsx
+++ b/src/containers/Dashboard/DashboardPage.test.tsx
@@ -72,8 +72,8 @@ describe('DashboardPage', () => {
 
     expect(screen.getByRole('heading', { name: 'Dashboard' })).toBeInTheDocument();
     expect(screen.getByText('Rezepte')).toBeInTheDocument();
-    expect(screen.getByText('Gesamt gebraut')).toBeInTheDocument();
-    expect(screen.getByText('Kein aktiver Brauvorgang.')).toBeInTheDocument();
+    expect(screen.getByText('Sude gesamt')).toBeInTheDocument();
+    expect(screen.getByText('Keine aktive Produktion')).toBeInTheDocument();
     expect(screen.queryByText(/NaN/)).not.toBeInTheDocument();
   });
 
@@ -84,14 +84,14 @@ describe('DashboardPage', () => {
     expect(screen.getByText(/Maltoserast/)).toBeInTheDocument();
     expect(screen.getByText('Heizung')).toBeInTheDocument();
     expect(screen.getByText('Rührwerk')).toBeInTheDocument();
-    expect(screen.getByText('Fortschritt 50 %')).toBeInTheDocument();
+    expect(screen.getByText('50 %')).toBeInTheDocument();
   });
 
   it('keeps partial backend errors local to production card', () => {
     renderDashboard({ isBackendAvailable: false, brewingStatus: undefined });
 
     expect(screen.getByText('Der aktuelle Produktionsstatus konnte nicht geladen werden.')).toBeInTheDocument();
-    expect(screen.getByText('Top 5 Malze')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Gesamtverbrauch' })).toBeInTheDocument();
   });
 
   it('loads missing recipes and finished brews through existing actions', () => {

--- a/src/containers/Dashboard/DashboardPage.tsx
+++ b/src/containers/Dashboard/DashboardPage.tsx
@@ -1,16 +1,18 @@
 import React from 'react';
 import AssessmentIcon from '@mui/icons-material/Assessment';
+import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
+import Inventory2OutlinedIcon from '@mui/icons-material/Inventory2Outlined';
 import LocalDrinkIcon from '@mui/icons-material/LocalDrink';
+import MenuBookOutlinedIcon from '@mui/icons-material/MenuBookOutlined';
 import ScienceIcon from '@mui/icons-material/Science';
 import WarningAmberIcon from '@mui/icons-material/WarningAmber';
 import { Beer } from '../../model/Beer';
 import { FinishedBrew } from '../../model/FinishedBrew';
-import { BrewingStatus, ProcessMode, ProcessState } from '../../model/brewingStatus.types';
+import { BrewingStatus, ProcessMode } from '../../model/brewingStatus.types';
+import { eBrewState } from '../../enums/eBrewState';
 import { getBrewingStatusLabel, isProcessActive } from '../../utils/brewingStatus/selectors';
-import { buildActiveBrewRows, calculateCareHints, calculateDashboardKpis, calculateIngredientSummary, calculateMonthlyStats, formatDashboardQuantity, safeNumber } from '../../utils/Dashboard/dashboardCalculations';
-import { DashboardIngredientUsage, DashboardYeastUsage } from '../../utils/Dashboard/dashboardTypes';
+import { buildActiveBrewRows, calculateAdditionalStats, calculateCareHints, calculateConsumption, calculateDashboardKpis, calculateRecipeHistory, formatDashboardQuantity, safeNumber } from '../../utils/Dashboard/dashboardCalculations';
 import './DashboardPage.css';
-
 
 interface DashboardPageProps {
   beers?: Beer[];
@@ -23,39 +25,15 @@ interface DashboardPageProps {
   getFinishedBrews: (isFetching: boolean) => void;
 }
 
+const formatSeconds = (value: unknown): string => {
+  const seconds = Math.max(0, Math.round(safeNumber(value)));
+  return `${Math.floor(seconds / 60)}:${String(seconds % 60).padStart(2, '0')}`;
+};
+
 export class DashboardPage extends React.Component<DashboardPageProps> {
   componentDidMount(): void {
-    if (this.props.beers === undefined) {
-      this.props.getBeers(true);
-    }
-    if (this.props.finishedBrews === undefined) {
-      this.props.getFinishedBrews(true);
-    }
-  }
-
-  private renderKpis(): React.ReactNode {
-    const kpis = calculateDashboardKpis(this.props.beers ?? [], this.props.finishedBrews ?? []);
-    const cards = [
-      { label: 'Rezepte', value: kpis.recipeCount },
-      { label: 'Sude', value: kpis.brewCount },
-      { label: 'Gesamt gebraut', value: formatDashboardQuantity(kpis.totalLiters), unit: 'Liter' },
-      { label: 'Aktive Biere', value: kpis.activeBeerCount },
-      { label: 'In Hauptgärung', value: kpis.fermentationCount },
-      { label: 'In Reifung', value: kpis.maturationCount },
-      { label: 'Fertige Biere', value: kpis.finishedCount },
-    ];
-
-    return (
-      <section className="dashboard-kpi-grid" aria-label="Dashboard Kennzahlen">
-        {cards.map((card) => (
-          <article className="dashboard-card dashboard-kpi-card" key={card.label}>
-            <span className="dashboard-kpi-label">{card.label}</span>
-            <strong className="dashboard-kpi-value">{card.value}</strong>
-            {card.unit && <span className="dashboard-kpi-unit">{card.unit}</span>}
-          </article>
-        ))}
-      </section>
-    );
+    if (this.props.beers === undefined) this.props.getBeers(true);
+    if (this.props.finishedBrews === undefined) this.props.getFinishedBrews(true);
   }
 
   private renderProductionStatus(): React.ReactNode {
@@ -63,157 +41,67 @@ export class DashboardPage extends React.Component<DashboardPageProps> {
     const isActive = isProcessActive(brewingStatus);
     const currentTemp = safeNumber(brewingStatus?.temperature.current, NaN);
     const targetTemp = safeNumber(brewingStatus?.temperature.target, NaN);
-    const hasCurrentTemp = Number.isFinite(currentTemp);
-    const hasTargetTemp = Number.isFinite(targetTemp);
-    const isHeating = brewingStatus?.currentStep.mode === ProcessMode.HEATING;
-    const canShowProgress = brewingStatus?.currentStep.mode === ProcessMode.TIMER_RUNNING && safeNumber(brewingStatus.currentStep.duration) > 0;
-    const progress = canShowProgress ? Math.min(100, Math.max(0, Math.round(safeNumber(brewingStatus?.elapsedTime) * 100 / safeNumber(brewingStatus?.currentStep.duration)))) : 0;
+    const duration = safeNumber(brewingStatus?.currentStep.duration);
+    const elapsed = safeNumber(brewingStatus?.currentStep.elapsedTime);
+    const canShowProgress = brewingStatus?.currentStep.mode === ProcessMode.TIMER_RUNNING && duration > 0;
+    const progress = canShowProgress ? Math.min(100, Math.max(0, Math.round(elapsed * 100 / duration))) : 0;
 
     return (
-      <section className="dashboard-card dashboard-production-card" aria-labelledby="dashboard-production-title">
-        <div className="dashboard-section-header">
-          <AssessmentIcon aria-hidden="true" />
-          <h2 id="dashboard-production-title">Aktuelle Produktion</h2>
-        </div>
+      <section className={`dashboard-card dashboard-main-card dashboard-production-card${isActive ? ' is-active' : ''}`} aria-labelledby="dashboard-production-title">
+        <div className="dashboard-section-header"><AssessmentIcon aria-hidden="true" /><h2 id="dashboard-production-title">Aktuelle Produktion</h2></div>
         {!isBackendAvailable && <p className="dashboard-warning">Der aktuelle Produktionsstatus konnte nicht geladen werden.</p>}
-        {!isActive && <p className="dashboard-empty">Kein aktiver Brauvorgang.</p>}
-        {isActive && (
-          <div className="dashboard-production-details">
-            <h3>{beerToBrew?.name ?? 'Unbekanntes Bier'}</h3>
-            <p className="dashboard-muted">{getBrewingStatusLabel(brewingStatus)}</p>
-            <p>{brewingStatus?.currentStep.phase ?? '-'} · {brewingStatus?.currentStep.name ?? '-'}</p>
-            <dl className="dashboard-status-grid">
-              <div><dt>Ist</dt><dd>{hasCurrentTemp ? currentTemp.toLocaleString('de-DE', { maximumFractionDigits: 1 }) : '-'} °C</dd></div>
-              <div><dt>Soll</dt><dd>{hasTargetTemp ? targetTemp.toLocaleString('de-DE', { maximumFractionDigits: 1 }) : '-'} °C</dd></div>
-              <div><dt>Heizung</dt><dd>{brewingStatus?.hardware.heater === 'ON' ? 'aktiv' : 'aus'}</dd></div>
-              <div><dt>Rührwerk</dt><dd>{brewingStatus?.hardware.agitator === 'ON' ? 'aktiv' : 'aus'}</dd></div>
-              <div><dt>Warten</dt><dd>{brewingStatus?.waiting.canConfirm ? String(brewingStatus.waiting.waitingFor) : 'Nein'}</dd></div>
-            </dl>
-            <div className="dashboard-progress-slot">
-              {isHeating && <span>Zieltemperatur wird erreicht.</span>}
-              {canShowProgress && <><span>Fortschritt {progress} %</span><div className="dashboard-progress"><span style={{ width: `${progress}%` }} /></div></>}
-              {!isHeating && !canShowProgress && <span>{brewingStatus?.process.state === ProcessState.ACTIVE ? 'Prozess läuft.' : 'Bereit.'}</span>}
-            </div>
-          </div>
-        )}
+        {!isActive && isBackendAvailable && <div className="dashboard-production-empty"><strong>Keine aktive Produktion</strong><span>Die Brausteuerung wartet auf einen neuen Brauvorgang.</span></div>}
+        {isActive && <div className="dashboard-production-details">
+          <div className="dashboard-production-heading"><h3>{beerToBrew?.name ?? 'Unbekanntes Bier'}</h3><span className="dashboard-badge dashboard-badge-production">{getBrewingStatusLabel(brewingStatus)}</span></div>
+          <p className="dashboard-step">{brewingStatus?.currentStep.name || brewingStatus?.currentStep.phase || 'Aktueller Schritt'}</p>
+          <div className="dashboard-temperature"><strong>{Number.isFinite(currentTemp) ? currentTemp.toLocaleString('de-DE', { maximumFractionDigits: 1 }) : '–'} °C</strong><span>Ziel: {Number.isFinite(targetTemp) ? targetTemp.toLocaleString('de-DE', { maximumFractionDigits: 1 }) : '–'} °C</span></div>
+          <div className="dashboard-progress" aria-label={`Fortschritt ${progress} Prozent`}><span style={{ width: `${progress}%` }} /></div>
+          <div className="dashboard-time"><span>{canShowProgress ? `${formatSeconds(elapsed)} / ${formatSeconds(duration)}` : brewingStatus?.currentStep.mode === ProcessMode.HEATING ? 'Zieltemperatur wird erreicht' : 'Prozess läuft'}</span>{canShowProgress && <strong>{progress} %</strong>}</div>
+          <dl className="dashboard-hardware">
+            <div><dt>Heizung</dt><dd className={brewingStatus?.hardware.heater === 'ON' ? 'is-on' : ''}>{brewingStatus?.hardware.heater === 'ON' ? 'EIN' : 'AUS'}</dd></div>
+            <div><dt>Rührwerk</dt><dd className={brewingStatus?.hardware.agitator === 'ON' ? 'is-on' : ''}>{brewingStatus?.hardware.agitator === 'ON' ? 'EIN' : 'AUS'}</dd></div>
+          </dl>
+          {brewingStatus?.waiting.canConfirm && <p className="dashboard-warning">Bestätigung erforderlich: {String(brewingStatus.waiting.waitingFor)}</p>}
+        </div>}
       </section>
     );
-  }
-
-  private renderActiveBrews(): React.ReactNode {
-    const rows = buildActiveBrewRows(this.props.finishedBrews ?? []);
-    return (
-      <section className="dashboard-card" aria-labelledby="dashboard-active-brews-title">
-        <div className="dashboard-section-header"><LocalDrinkIcon aria-hidden="true" /><h2 id="dashboard-active-brews-title">Meine aktuellen Biere</h2></div>
-        {rows.length === 0 ? <p className="dashboard-empty">Keine Biere in Hauptgärung oder Reifung.</p> : (
-          <div className="dashboard-active-list">
-            {rows.map((row) => (
-              <article className="dashboard-active-row" key={row.id}>
-                <h3>{row.name}</h3>
-                <span className="dashboard-badge">{row.stateLabel}</span>
-                <dl>
-                  <div><dt>Start</dt><dd>{row.startDateLabel}</dd></div>
-                  <div><dt>Seit</dt><dd>{row.daysSinceStartLabel}</dd></div>
-                  <div><dt>Liter</dt><dd>{row.litersLabel}</dd></div>
-                  <div><dt>Stammwürze</dt><dd>{row.originalWortLabel}</dd></div>
-                  <div><dt>Restextrakt</dt><dd>{row.residualExtractLabel}</dd></div>
-                  <div><dt>Notiz</dt><dd>{row.noteLabel}</dd></div>
-                </dl>
-              </article>
-            ))}
-          </div>
-        )}
-      </section>
-    );
-  }
-
-  private renderIngredientList(title: string, items: DashboardIngredientUsage[] | DashboardYeastUsage[], unitFallback: string): React.ReactNode {
-    return (
-      <section className="dashboard-ingredient-panel" aria-label={title}>
-        <h3>{title}</h3>
-        {items.length === 0 ? <p className="dashboard-empty">Noch keine Zutatenstatistik verfügbar.</p> : (
-          <ol>
-            {items.map((item) => {
-              const quantityText = 'quantity' in item ? `${formatDashboardQuantity(item.quantity)} ${item.unit ?? unitFallback}` : `${item.brewCount} Sude`;
-              return <li key={`${item.name}-${'unit' in item ? item.unit ?? '' : ''}`}><span>{item.name}</span><strong>{quantityText}</strong><small>{item.brewCount} Sude{'type' in item && item.type ? ` · ${item.type}` : ''}</small></li>;
-            })}
-          </ol>
-        )}
-      </section>
-    );
-  }
-
-  private renderIngredients(): React.ReactNode {
-    const summary = calculateIngredientSummary(this.props.beers ?? [], this.props.finishedBrews ?? []);
-    return (
-      <section className="dashboard-card" aria-labelledby="dashboard-ingredients-title">
-        <div className="dashboard-section-header"><ScienceIcon aria-hidden="true" /><h2 id="dashboard-ingredients-title">Zutatenverbrauch</h2></div>
-        <p className="dashboard-muted">Mengen werden neutral als Rezeptmenge angezeigt, da die gespeicherte Mengeneinheit für Malz und Hopfen nicht eindeutig im Feldnamen codiert ist.</p>
-        {summary.linkedBrewCount === 0 && <p className="dashboard-empty">Noch keine Zutatenstatistik verfügbar.</p>}
-        <div className="dashboard-ingredients-grid">
-          {this.renderIngredientList('Top 5 Malze', summary.malts, 'Menge')}
-          {this.renderIngredientList('Top 5 Hopfen', summary.hops, 'Menge')}
-          {this.renderIngredientList('Meistverwendete Hefen', summary.yeasts, '')}
-          {this.renderIngredientList('Weitere Zutaten', summary.additionalIngredients, '')}
-        </div>
-      </section>
-    );
-  }
-
-  private renderHistory(): React.ReactNode {
-    const stats = calculateMonthlyStats(this.props.finishedBrews ?? []);
-    const maxLiters = Math.max(...stats.map((stat) => stat.liters), 1);
-    return (
-      <section className="dashboard-card" aria-labelledby="dashboard-history-title">
-        <h2 id="dashboard-history-title">Brauhistorie</h2>
-        {stats.length === 0 ? <p className="dashboard-empty">Noch keine Braudurchgänge vorhanden.</p> : (
-          <div className="dashboard-history-chart" role="list" aria-label="Liter und Sude pro Monat">
-            {stats.map((stat) => (
-              <div className="dashboard-history-bar" role="listitem" key={stat.key}>
-                <span className="dashboard-history-value">{formatDashboardQuantity(stat.liters)} L · {stat.brewCount} Sude</span>
-                <div className="dashboard-history-track"><span style={{ height: `${Math.max(8, stat.liters / maxLiters * 100)}%` }} /></div>
-                <span className="dashboard-history-label">{stat.label}</span>
-              </div>
-            ))}
-          </div>
-        )}
-      </section>
-    );
-  }
-
-  private renderCareHints(): React.ReactNode {
-    const hints = calculateCareHints(this.props.beers ?? [], this.props.finishedBrews ?? []);
-    const lines = [
-      `${hints.missingLiters} Sude ohne eingetragene Litermenge`,
-      `${hints.missingEndDate} Sude ohne Enddatum`,
-      `${hints.missingResidualExtract} Sude ohne sinnvollen Restextrakt`,
-      `${hints.activeInvalidStartDate} aktive Biere ohne gültiges Startdatum`,
-      `${hints.missingRecipeLink} Sude ohne Rezeptverknüpfung`,
-    ];
-    return <section className="dashboard-card dashboard-care-card" aria-labelledby="dashboard-care-title"><div className="dashboard-section-header"><WarningAmberIcon aria-hidden="true" /><h2 id="dashboard-care-title">Daten prüfen</h2></div><ul>{lines.map((line) => <li key={line}>{line}</li>)}</ul></section>;
   }
 
   render(): React.ReactNode {
-    return (
-      <main className="dashboard-page" aria-labelledby="dashboard-title">
-        <header className="dashboard-title-row">
-          <div>
-            <p className="dashboard-eyebrow">Brauhaus Übersicht</p>
-            <h1 id="dashboard-title">Dashboard</h1>
-          </div>
-          {this.props.isFetching && <span className="dashboard-loading">Dashboard-Daten werden geladen …</span>}
-        </header>
-        {this.renderKpis()}
-        <div className="dashboard-two-column">
-          {this.renderProductionStatus()}
-          {this.renderActiveBrews()}
-        </div>
-        {this.renderIngredients()}
-        <div className="dashboard-two-column dashboard-bottom-grid">
-          {this.renderHistory()}
-          {this.renderCareHints()}
-        </div>
-      </main>
-    );
+    const beers = this.props.beers ?? [];
+    const brews = this.props.finishedBrews ?? [];
+    const kpis = calculateDashboardKpis(beers, brews);
+    const activeRows = buildActiveBrewRows(brews);
+    const history = calculateRecipeHistory(beers, brews);
+    const consumption = calculateConsumption(beers, brews);
+    const stats = calculateAdditionalStats(brews);
+    const hints = calculateCareHints(beers, brews);
+    const maxHistoryBrews = Math.max(1, ...history.map((row) => row.brewCount));
+    const hintLines = [
+      hints.missingLiters > 0 ? `${hints.missingLiters} Sude ohne Litermenge` : '',
+      hints.missingEndDate > 0 ? `${hints.missingEndDate} Sude ohne Enddatum` : '',
+      hints.activeInvalidStartDate > 0 ? `${hints.activeInvalidStartDate} aktive Biere ohne Startdatum` : '',
+      hints.missingRecipeLink > 0 ? `${hints.missingRecipeLink} Sude ohne Rezeptverknüpfung` : '',
+    ].filter(Boolean);
+    const activeBreakdown = [kpis.fermentationCount ? `${kpis.fermentationCount} in Hauptgärung` : '', kpis.maturationCount ? `${kpis.maturationCount} in Reifung` : ''].filter(Boolean).join(' · ') || 'Keine aktiven Biere';
+    const cards = [
+      { label: 'Sude gesamt', value: kpis.brewCount, detail: `${formatDashboardQuantity(kpis.totalLiters)} Liter gebraut`, icon: <ScienceIcon /> },
+      { label: 'Aktive Biere', value: kpis.activeBeerCount, detail: activeBreakdown, icon: <LocalDrinkIcon /> },
+      { label: 'Fertige Biere', value: kpis.finishedCount, detail: 'abgeschlossene Sude', icon: <CheckCircleOutlineIcon /> },
+      { label: 'Rezepte', value: kpis.recipeCount, detail: 'verfügbar insgesamt', icon: <MenuBookOutlinedIcon /> },
+    ];
+
+    return <main className="dashboard-page" aria-labelledby="dashboard-title">
+      <header className="dashboard-title-row"><div><h1 id="dashboard-title">Dashboard</h1><p>Brauhaus auf einen Blick</p></div>{this.props.isFetching && <span className="dashboard-loading">Dashboard-Daten werden geladen …</span>}</header>
+      <section className="dashboard-kpi-grid" aria-label="Dashboard Kennzahlen">{cards.map((card) => <article className="dashboard-card dashboard-kpi-card" key={card.label}><span className="dashboard-kpi-icon" aria-hidden="true">{card.icon}</span><span className="dashboard-kpi-label">{card.label}</span><strong className="dashboard-kpi-value">{card.value}</strong><span className="dashboard-kpi-detail">{card.detail}</span></article>)}</section>
+      <div className="dashboard-content-grid">
+        <section className="dashboard-card dashboard-main-card dashboard-active-card" aria-labelledby="dashboard-active-title"><div className="dashboard-section-header"><LocalDrinkIcon aria-hidden="true" /><h2 id="dashboard-active-title">Aktive Biere</h2></div>{activeRows.length === 0 ? <p className="dashboard-empty">Keine Biere in Hauptgärung oder Reifung.</p> : <div className="dashboard-scroll-list">{activeRows.map((row) => <article className="dashboard-active-row" key={row.id}><span className={`dashboard-state-dot ${row.state === eBrewState.MATURATION ? 'is-maturation' : ''}`} /><div><h3>{row.name}</h3><p>{row.litersLabel} · {row.originalWortLabel} · {row.residualExtractLabel}</p></div><span className={`dashboard-badge ${row.state === eBrewState.MATURATION ? 'is-maturation' : ''}`}>{row.stateLabel}</span><strong className="dashboard-day">{row.daysSinceStartLabel === '-' ? '–' : `Tag ${row.daysSinceStartLabel.replace(' Tage', '')}`}</strong></article>)}</div>}</section>
+        {this.renderProductionStatus()}
+        <section className="dashboard-card dashboard-main-card dashboard-history-card" aria-labelledby="dashboard-history-title"><div className="dashboard-section-header"><AssessmentIcon aria-hidden="true" /><h2 id="dashboard-history-title">Brauhistorie nach Rezept</h2></div><div className="dashboard-history-summary"><span><strong>{kpis.brewCount}</strong>Sude</span><span><strong>{formatDashboardQuantity(kpis.totalLiters)} l</strong>gebraut</span><span><strong>{kpis.brewCount ? formatDashboardQuantity(kpis.totalLiters / kpis.brewCount) : '–'} l</strong>Ø pro Sud</span><span><strong>{history.length}</strong>verwendet</span></div>{history.length === 0 ? <p className="dashboard-empty">Keine verknüpfte Brauhistorie verfügbar.</p> : <div className="dashboard-scroll-list dashboard-history-list">{history.map((row) => <div className="dashboard-history-row" key={row.recipeId}><strong>{row.recipeName}</strong><span>{row.brewCount} {row.brewCount === 1 ? 'Sud' : 'Sude'}</span><span>{formatDashboardQuantity(row.liters)} l</span><div className="dashboard-history-track"><span style={{ width: `${row.brewCount / maxHistoryBrews * 100}%` }} /></div></div>)}</div>}</section>
+        <section className="dashboard-card dashboard-compact-card" aria-labelledby="dashboard-consumption-title"><div className="dashboard-section-header"><Inventory2OutlinedIcon aria-hidden="true" /><h2 id="dashboard-consumption-title">Gesamtverbrauch</h2></div>{consumption.linkedBrewCount ? <><div className="dashboard-consumption-grid"><div><span>Malz</span><strong>{formatDashboardQuantity(consumption.maltQuantity)}</strong><small>Rezeptmenge*</small></div><div><span>Hopfen</span><strong>{formatDashboardQuantity(consumption.hopQuantity)}</strong><small>Rezeptmenge*</small></div><div><span>Hefe</span><strong>{consumption.yeastUses}</strong><small>Sud-Einsätze</small></div></div><p className="dashboard-footnote">* Die gespeicherten Mengen haben keine verlässliche Einheit.</p></> : <p className="dashboard-empty">Keine verknüpften Rezeptdaten verfügbar.</p>}</section>
+        <section className="dashboard-card dashboard-compact-card" aria-labelledby="dashboard-stats-title"><div className="dashboard-section-header"><ScienceIcon aria-hidden="true" /><h2 id="dashboard-stats-title">Weitere Kennzahlen</h2></div><dl className="dashboard-metric-list"><div><dt>Ø Stammwürze ({stats.originalWortSampleCount})</dt><dd>{stats.averageOriginalWort === undefined ? '–' : `${formatDashboardQuantity(stats.averageOriginalWort)} °P`}</dd></div><div><dt>Größter Sud</dt><dd>{stats.largestBrew === undefined ? '–' : `${formatDashboardQuantity(stats.largestBrew)} l`}</dd></div><div><dt>Kleinster Sud</dt><dd>{stats.smallestBrew === undefined ? '–' : `${formatDashboardQuantity(stats.smallestBrew)} l`}</dd></div><div><dt>Letzter Sud</dt><dd>{stats.lastBrew ?? '–'}</dd></div></dl></section>
+        <section className="dashboard-card dashboard-compact-card dashboard-hints-card" aria-labelledby="dashboard-hints-title"><div className="dashboard-section-header">{!this.props.isBackendAvailable || hintLines.length ? <WarningAmberIcon aria-hidden="true" /> : <CheckCircleOutlineIcon aria-hidden="true" />}<h2 id="dashboard-hints-title">Hinweise</h2></div>{!this.props.isBackendAvailable && <p className="dashboard-hint is-warning">Backend nicht erreichbar</p>}{hintLines.map((line) => <p className="dashboard-hint" key={line}>• {line}</p>)}{this.props.isBackendAvailable && hintLines.length === 0 && <p className="dashboard-hint is-clear">Keine offenen Aktionen</p>}</section>
+      </div>
+    </main>;
   }
 }

--- a/src/utils/Dashboard/dashboardCalculations.test.ts
+++ b/src/utils/Dashboard/dashboardCalculations.test.ts
@@ -2,7 +2,7 @@ import { AdditionalIngredientPhase } from '../../model/Beer';
 import { Beer } from '../../model/Beer';
 import { FinishedBrew } from '../../model/FinishedBrew';
 import { eBrewState } from '../../enums/eBrewState';
-import { buildActiveBrewRows, calculateCareHints, calculateDashboardKpis, calculateIngredientSummary, calculateMonthlyStats } from './dashboardCalculations';
+import { buildActiveBrewRows, calculateAdditionalStats, calculateCareHints, calculateConsumption, calculateDashboardKpis, calculateIngredientSummary, calculateMonthlyStats, calculateRecipeHistory } from './dashboardCalculations';
 
 const makeBeer = (id: string, name: string): Beer => ({
   id,
@@ -84,13 +84,26 @@ describe('dashboard calculations', () => {
     expect(result[0]).toMatchObject({ brewCount: 1, liters: 20 });
   });
 
+  it('groups brew history by stable recipe id and calculates reliable summaries', () => {
+    const beers = [makeBeer('b1', 'Pils'), makeBeer('b2', 'Weizen')];
+    const brews = [
+      makeBrew('f1', 'b1', eBrewState.FINISHED, 20, '2026-01-01'),
+      makeBrew('f2', 'b1', eBrewState.FINISHED, 10, '2026-02-01'),
+      makeBrew('f3', 'b2', eBrewState.FINISHED, 15, '2026-03-01'),
+    ];
+
+    expect(calculateRecipeHistory(beers, brews)[0]).toMatchObject({ recipeId: 'b1', recipeName: 'Pils', brewCount: 2, liters: 30 });
+    expect(calculateConsumption(beers, brews)).toEqual({ maltQuantity: 15000, hopQuantity: 150, yeastUses: 3, linkedBrewCount: 3 });
+    expect(calculateAdditionalStats(brews)).toMatchObject({ averageOriginalWort: 12, originalWortSampleCount: 3, largestBrew: 20, smallestBrew: 10, lastBrew: '1.3.2026' });
+  });
+
   it('builds care hints and active brew rows defensively', () => {
     const brews = [
       makeBrew('f1', 'b1', eBrewState.FERMENTATION, 0, 'bad-date'),
       { ...makeBrew('f2', undefined, eBrewState.MATURATION, 10), endDate: undefined, residual_extract: null },
     ];
 
-    expect(calculateCareHints([makeBeer('b1', 'Pils')], brews)).toEqual({ missingLiters: 1, missingEndDate: 2, missingResidualExtract: 1, activeInvalidStartDate: 1, missingRecipeLink: 1 });
+    expect(calculateCareHints([makeBeer('b1', 'Pils')], brews)).toEqual({ missingLiters: 1, missingEndDate: 0, missingResidualExtract: 1, activeInvalidStartDate: 1, missingRecipeLink: 1 });
     expect(buildActiveBrewRows(brews, new Date('2026-07-22'))[0].daysSinceStartLabel).toBe('-');
   });
 });

--- a/src/utils/Dashboard/dashboardCalculations.ts
+++ b/src/utils/Dashboard/dashboardCalculations.ts
@@ -1,7 +1,7 @@
 import { Beer } from '../../model/Beer';
 import { FinishedBrew } from '../../model/FinishedBrew';
 import { eBrewState, BrewStateGerman } from '../../enums/eBrewState';
-import { DashboardActiveBrewRow, DashboardCareHints, DashboardIngredientSummary, DashboardIngredientUsage, DashboardKpis, DashboardMonthlyStat, DashboardYeastUsage } from './dashboardTypes';
+import { DashboardActiveBrewRow, DashboardAdditionalStats, DashboardCareHints, DashboardConsumption, DashboardIngredientSummary, DashboardIngredientUsage, DashboardKpis, DashboardMonthlyStat, DashboardRecipeHistory, DashboardYeastUsage } from './dashboardTypes';
 
 const TOP_LIMIT = 5;
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
@@ -38,7 +38,7 @@ export const calculateDashboardKpis = (beers: Beer[] = [], brews: FinishedBrew[]
   recipeCount: beers.length,
   brewCount: brews.length,
   totalLiters: brews.reduce((sum, brew) => sum + Math.max(0, safeNumber(brew.liters)), 0),
-  activeBeerCount: brews.filter((brew) => brew.active === true).length,
+  activeBeerCount: brews.filter((brew) => brew.state === eBrewState.FERMENTATION || brew.state === eBrewState.MATURATION).length,
   fermentationCount: brews.filter((brew) => brew.state === eBrewState.FERMENTATION).length,
   maturationCount: brews.filter((brew) => brew.state === eBrewState.MATURATION).length,
   finishedCount: brews.filter((brew) => brew.state === eBrewState.FINISHED).length,
@@ -124,11 +124,53 @@ export const calculateMonthlyStats = (brews: FinishedBrew[] = []): DashboardMont
   return Array.from(stats.values()).sort((a, b) => a.key.localeCompare(b.key));
 };
 
+export const calculateRecipeHistory = (beers: Beer[] = [], brews: FinishedBrew[] = []): DashboardRecipeHistory[] => {
+  const recipes = new Map(beers.map((beer) => [String(beer.id), beer]));
+  const history = new Map<string, DashboardRecipeHistory>();
+  brews.forEach((brew) => {
+    if (!brew.beer_id) return;
+    const recipe = recipes.get(String(brew.beer_id));
+    if (!recipe) return;
+    const recipeId = String(recipe.id);
+    const row = history.get(recipeId) ?? { recipeId, recipeName: recipe.name || 'Unbenanntes Rezept', brewCount: 0, liters: 0 };
+    row.brewCount += 1;
+    row.liters += Math.max(0, safeNumber(brew.liters));
+    history.set(recipeId, row);
+  });
+  return Array.from(history.values()).sort((a, b) => b.brewCount - a.brewCount || b.liters - a.liters || a.recipeName.localeCompare(b.recipeName, 'de'));
+};
+
+export const calculateAdditionalStats = (brews: FinishedBrew[] = []): DashboardAdditionalStats => {
+  const wortValues = brews.map((brew) => safeNumber(brew.originalwort)).filter((value) => value > 0);
+  const literValues = brews.map((brew) => safeNumber(brew.liters)).filter((value) => value > 0);
+  const dates = brews.map((brew) => parseDate(brew.startDate)).filter((date): date is Date => Boolean(date));
+  return {
+    averageOriginalWort: wortValues.length ? wortValues.reduce((sum, value) => sum + value, 0) / wortValues.length : undefined,
+    originalWortSampleCount: wortValues.length,
+    largestBrew: literValues.length ? Math.max(...literValues) : undefined,
+    smallestBrew: literValues.length ? Math.min(...literValues) : undefined,
+    lastBrew: dates.length ? formatDateGerman(new Date(Math.max(...dates.map((date) => date.getTime())))) : undefined,
+  };
+};
+
+export const calculateConsumption = (beers: Beer[] = [], brews: FinishedBrew[] = []): DashboardConsumption => {
+  const recipes = new Map(beers.map((beer) => [String(beer.id), beer]));
+  return brews.reduce<DashboardConsumption>((result, brew) => {
+    const recipe = brew.beer_id ? recipes.get(String(brew.beer_id)) : undefined;
+    if (!recipe) return result;
+    result.linkedBrewCount += 1;
+    result.maltQuantity += recipe.malts?.reduce((sum, malt) => sum + Math.max(0, safeNumber(malt.quantity)), 0) ?? 0;
+    result.hopQuantity += recipe.wortBoiling?.hops?.reduce((sum, hop) => sum + Math.max(0, safeNumber(hop.quantity)), 0) ?? 0;
+    if (recipe.fermentationMaturation?.yeast?.length) result.yeastUses += 1;
+    return result;
+  }, { maltQuantity: 0, hopQuantity: 0, yeastUses: 0, linkedBrewCount: 0 });
+};
+
 export const calculateCareHints = (beers: Beer[] = [], brews: FinishedBrew[] = []): DashboardCareHints => {
   const recipeIds = new Set(beers.map((beer) => String(beer.id)));
   return {
     missingLiters: brews.filter((brew) => safeNumber(brew.liters) <= 0).length,
-    missingEndDate: brews.filter((brew) => !parseDate(brew.endDate)).length,
+    missingEndDate: brews.filter((brew) => brew.state === eBrewState.FINISHED && !parseDate(brew.endDate)).length,
     missingResidualExtract: brews.filter((brew) => brew.residual_extract === null || safeNumber(brew.residual_extract) <= 0).length,
     activeInvalidStartDate: brews.filter((brew) => brew.active === true && !parseDate(brew.startDate)).length,
     missingRecipeLink: brews.filter((brew) => !brew.beer_id || !recipeIds.has(String(brew.beer_id))).length,
@@ -143,6 +185,7 @@ export const buildActiveBrewRows = (brews: FinishedBrew[] = [], now = new Date()
       id: brew.id,
       name: brew.name || 'Unbenannter Sud',
       stateLabel: BrewStateGerman[brew.state] ?? String(brew.state ?? '-'),
+      state: brew.state,
       startDateLabel: formatDateGerman(brew.startDate),
       daysSinceStartLabel: days === undefined ? '-' : `${days} Tage`,
       litersLabel: `${formatQuantity(Math.max(0, safeNumber(brew.liters)))} Liter`,

--- a/src/utils/Dashboard/dashboardTypes.ts
+++ b/src/utils/Dashboard/dashboardTypes.ts
@@ -36,6 +36,28 @@ export interface DashboardMonthlyStat {
   liters: number;
 }
 
+export interface DashboardRecipeHistory {
+  recipeId: string;
+  recipeName: string;
+  brewCount: number;
+  liters: number;
+}
+
+export interface DashboardAdditionalStats {
+  averageOriginalWort?: number;
+  originalWortSampleCount: number;
+  largestBrew?: number;
+  smallestBrew?: number;
+  lastBrew?: string;
+}
+
+export interface DashboardConsumption {
+  maltQuantity: number;
+  hopQuantity: number;
+  yeastUses: number;
+  linkedBrewCount: number;
+}
+
 export interface DashboardCareHints {
   missingLiters: number;
   missingEndDate: number;
@@ -48,6 +70,7 @@ export interface DashboardActiveBrewRow {
   id: string;
   name: string;
   stateLabel: string;
+  state: string;
   startDateLabel: string;
   daysSinceStartLabel: string;
   litersLabel: string;


### PR DESCRIPTION
### Motivation

- Modernize the Dashboard to match the supplied mockup: compact header, four KPI cards, and a three‑column main area while reusing existing design tokens and components. 
- Surface the most important information (active beers, current production, recipe history, consumption, and concise hints) in a single 1920×1080 viewport with internal scroll regions for variable lists. 

### Description

- Replaced the dashboard view with a compact, grid‑based layout and new component structure in `src/containers/Dashboard/DashboardPage.tsx` and styles in `src/containers/Dashboard/DashboardPage.css`, adding a 4‑card KPI row, left Active Brews list, center Production card, and right Recipe History card plus three compact lower cards (Consumption, Additional Stats, Hints). 
- Kept existing visual system (CSS variables, radii, colors, icons) and reused existing status labels and hardware fields; the Production card shows only frontend-available control fields (step name/phase, current/target temperature, progress, heater/agitator state, waiting info) and renders a compact message when inactive. 
- Extended dashboard calculations in `src/utils/Dashboard/dashboardCalculations.ts` and types in `src/utils/Dashboard/dashboardTypes.ts` with new helpers `calculateRecipeHistory`, `calculateAdditionalStats`, and `calculateConsumption`, adjusted `calculateDashboardKpis` to compute active beer counts from recipe states, tightened `calculateCareHints` to count missing end dates only for finished brews, and added `state` to active rows for precise badges. 
- Updated unit tests to reflect the new API (`src/utils/Dashboard/dashboardCalculations.test.ts` and `src/containers/Dashboard/DashboardPage.test.tsx`) and adapted assertions to the redesigned output and wording. Files changed include `DashboardPage.tsx`, `DashboardPage.css`, `dashboardCalculations.ts`, `dashboardTypes.ts`, and related tests. 

### Testing

- Ran repository checks: `git diff --check` passed with no whitespace errors. 
- Attempted to run unit tests for the modified modules (`dashboardCalculations.test.ts` and `DashboardPage.test.tsx`) via the project's test wrapper, but automated test execution could not complete because project dependencies could not be installed in this environment (npm registry HTTP 403 / dependency install blocked). 
- Attempted `npm run build` and `npm ci` which failed due to blocked access to the npm registry, so full build/test verification and a running UI screenshot were not possible here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a9099e9b8a4832f8a887c44fff134ae)