### PR TITLE
Finished-brew: use POST for create and PUT for update; add UI/reducer/epics support

### DIFF
--- a/docs/codex/compatibility/cross-repo-contracts.md
+++ b/docs/codex/compatibility/cross-repo-contracts.md
@@ -136,12 +136,11 @@ Before changing control output, check whether the UI uses it for:
 
 ## Known compatibility conflicts
 
-### Finished beer update
+### Finished beer create/update
 
-- UI currently documents/calls update through `POST finishedbeer`.
-- Database documentation says update is `PUT /finishedbeer`.
-
-Until this is resolved, do not change finished-brew update behavior without checking both repositories.
+- `POST /finishedbeer` always creates a new record, ignores any supplied `id`, and returns the backend-generated UUID.
+- `PUT /finishedbeer` updates an existing record identified by the body `id`; the UI sends the complete `FinishedBrew`, not a partial patch.
+- An update response must retain the requested ID and must never be inserted as a second Redux list entry.
 
 ### Control availability endpoint
 

--- a/docs/codex/external/database-context.md
+++ b/docs/codex/external/database-context.md
@@ -15,7 +15,7 @@ The database/backend is the source of truth for recipes, finished brews, and ing
 ## Important conflict notes
 
 - UI expects `POST beer` to return a `Beer`, but backend docs say it returns a message object.
-- UI documents finished-brew update through `POST finishedbeer`, but backend docs say update is `PUT /finishedbeer`.
+- Finished-brew create/update is confirmed: `POST /finishedbeer` always creates with a backend-generated UUID; `PUT /finishedbeer` performs a full-record update using the body `id`.
 - Backend has inconsistent error keys: route errors often use `error`; app handlers use `message`.
 - `cookingTemperatur` is misspelled but documented as stable compatibility field.
 
@@ -241,7 +241,6 @@ The UI uses the database/backend service for persistent brewing data, not hardwa
 ## Backend assumptions needing verification
 
 - Whether `GET beers` ordering is intentional.
-- Whether `POST finishedbeer` is intended for both create and update.
 - Whether `FinishedBrew` date fields should be ISO strings, localized strings, or `Date`-parseable values.
 - Whether recipe import returns a full `Beer` compatible with UI state.
 - Whether ingredient ID and numeric field casing/types should be normalized across standalone ingredients and recipe ingredients.

--- a/docs/codex/interfaces.md
+++ b/docs/codex/interfaces.md
@@ -14,8 +14,8 @@ Recipe scaling requires optional numeric `referenceVolume` (liters) and `referen
 | DELETE | `beer/{id}` | Delete recipe | no body |
 | POST | `importbeer` | Import recipe JSON (Recipe Import V2) | `{ format: 'BRAUHAUS' \| 'MMUM', recipe: Record<string, unknown>, idempotencyKey: string }`, returns `RecipeImportResult` with `recipe`, `warnings`, `ingredientMappings`, `createdMasterData`, and `replayed` |
 | GET | `finishedbeers` | Load finished brews | `FinishedBrew[]` |
-| POST | `finishedbeer` | Create finished brew | `FinishedBrew`, returns `FinishedBrew` |
-| POST | `finishedbeer` | Update finished brew | `FinishedBrew`, returns `FinishedBrew`; create/update distinction is backend-owned |
+| POST | `finishedbeer` | Create finished brew | Complete payload without `id`; backend generates the UUID and returns the created `FinishedBrew` |
+| PUT | `finishedbeer` | Update finished brew | Complete `FinishedBrew` including its existing `id`; returns the updated `FinishedBrew` |
 | DELETE | `finishedbeer/{id}` | Delete finished brew | no body |
 | GET | `hops` | Load hops | `Hops[]` |
 | POST | `hop` | Create hop | `Hops` |

--- a/docs/codex/known-risks.md
+++ b/docs/codex/known-risks.md
@@ -7,7 +7,7 @@
 - Recipe list default selection depends on the last item returned by `GET beers`. Backend ordering changes affect default preview.
 - Hop reminders assume recipe hop `time` is minutes before end of boil and status `currentStep.elapsedTime` is seconds within cooking phase.
 - `FinishedBrew` creation after production finish stores default numeric values (`liters`, `originalwort`, `residual_extract`) as `0`; real measurement ownership is unclear. Needs verification.
-- `finishedbeer` create and update both use `POST finishedbeer`; changing backend semantics could break update behavior.
+- Finished-brew create and update have distinct confirmed semantics: create uses `POST finishedbeer` without a client ID, while full-record update uses `PUT finishedbeer` with the existing ID.
 - Status normalization supports legacy fields; removing backend legacy fields is safe only if structured fields are complete.
 - The app mixes Material UI v4 and MUI v5 dependencies.
 - `build-deploy`/`deploy` assume SSH access to `boris@192.168.178.72:/srv/sites/braumeister`.

--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -7,7 +7,7 @@ import {BrewingData} from "../model/BrewingData";
 import {BrewingStatus} from "../model/BrewingStatus";
 import {ConfirmStates} from "../enums/eConfirmStates";
 import {WaterStatus} from "../components/Controlls/WaterControll/WaterControl";
-import {FinishedBrew} from "../model/FinishedBrew";
+import {FinishedBrew, FinishedBrewCreatePayload} from "../model/FinishedBrew";
 import {BackendAvailable} from "../reducers/productionReducer";
 import {scalingValues} from "../utils/BeerScaler/ScalingBeerRecipe";
 import {RecipeImportRequest, RecipeImportResult} from '../model/RecipeImport';
@@ -31,7 +31,10 @@ export namespace BeerActions {
         DELETE_FINISHED_BEER = 'BeerActions.DELETE_FINISHED_BEER',
         DELETE_FINISHED_BEER_SUCCESS = 'BeerActions.DELETE_FINISHED_BEER_SUCCESS',
         ADD_FINISHED_BREW = 'BeerActions.ADD_FINISHED_BREW',
+        ADD_FINISHED_BREW_SUCCESS = 'BeerActions.ADD_FINISHED_BREW_SUCCESS',
+        ADD_FINISHED_BREW_FAILURE = 'BeerActions.ADD_FINISHED_BREW_FAILURE',
         UPDATE_FINISHED_BREW_SUCCESS = 'BeerActions.UPDATE_FINISHED_BREW_SUCCESS',
+        UPDATE_FINISHED_BREW_FAILURE = 'BeerActions.UPDATE_FINISHED_BREW_FAILURE',
         SAVE_BEER_FORM_STATE = 'BeerActions.SAVE_BEER_FORM_STATE',
         LOAD_BEER_FORM_STATE = 'BeerActions.LOAD_BEER_FORM_STATE',
         GENERATE_FINISHED_BREWS_PDF = 'BeerActions.GENERATE_FINISHED_BREWS_PDF',
@@ -137,13 +140,28 @@ export namespace BeerActions {
     export interface AddFinishedBrew {
         readonly type: ActionTypes.ADD_FINISHED_BREW;
         payload: {
-            finishedBrew: FinishedBrew;
+            finishedBrew: FinishedBrewCreatePayload;
         };
     }
 
     export interface UpdateFinishedBrewSuccess {
         readonly type: ActionTypes.UPDATE_FINISHED_BREW_SUCCESS;
+        payload: { beer: FinishedBrew; requestedId: string };
+    }
+
+    export interface UpdateFinishedBrewFailure {
+        readonly type: ActionTypes.UPDATE_FINISHED_BREW_FAILURE;
+        payload: { requestedId: string; message: string };
+    }
+
+    export interface AddFinishedBrewSuccess {
+        readonly type: ActionTypes.ADD_FINISHED_BREW_SUCCESS;
         payload: { beer: FinishedBrew };
+    }
+
+    export interface AddFinishedBrewFailure {
+        readonly type: ActionTypes.ADD_FINISHED_BREW_FAILURE;
+        payload: { message: string };
     }
 
     export interface SaveBeerFormState {
@@ -240,7 +258,10 @@ export namespace BeerActions {
         DeleteFinishedBeer |
         DeleteFinishedBeerSuccess |
         AddFinishedBrew |
+        AddFinishedBrewSuccess |
+        AddFinishedBrewFailure |
         UpdateFinishedBrewSuccess |
+        UpdateFinishedBrewFailure |
         SaveBeerFormState |
         LoadBeerFormState |
         GenerateFinishedBrewsPdf |
@@ -381,17 +402,38 @@ export namespace BeerActions {
         }
     }
 
-    export function addFinishedBrew(finishedBrew: FinishedBrew): AddFinishedBrew {
+    export function addFinishedBrew(finishedBrew: FinishedBrewCreatePayload): AddFinishedBrew {
         return {
             type: ActionTypes.ADD_FINISHED_BREW,
             payload: {finishedBrew}
         };
     }
 
-    export function updateFinishedBrewSuccess(beer: FinishedBrew): UpdateFinishedBrewSuccess {
+    export function addFinishedBrewSuccess(beer: FinishedBrew): AddFinishedBrewSuccess {
+        return {
+            type: ActionTypes.ADD_FINISHED_BREW_SUCCESS,
+            payload: {beer}
+        };
+    }
+
+    export function addFinishedBrewFailure(message: string): AddFinishedBrewFailure {
+        return {
+            type: ActionTypes.ADD_FINISHED_BREW_FAILURE,
+            payload: {message}
+        };
+    }
+
+    export function updateFinishedBrewSuccess(beer: FinishedBrew, requestedId: string): UpdateFinishedBrewSuccess {
         return {
             type: ActionTypes.UPDATE_FINISHED_BREW_SUCCESS,
-            payload: {beer}
+            payload: {beer, requestedId}
+        };
+    }
+
+    export function updateFinishedBrewFailure(requestedId: string, message: string): UpdateFinishedBrewFailure {
+        return {
+            type: ActionTypes.UPDATE_FINISHED_BREW_FAILURE,
+            payload: {requestedId, message}
         };
     }
 

--- a/src/containers/MainView/FinishBrewsBeers/FinishedBrewsTable.connect.ts
+++ b/src/containers/MainView/FinishBrewsBeers/FinishedBrewsTable.connect.ts
@@ -1,17 +1,24 @@
 import {connect} from "react-redux";
-import {FinishedBrew} from "../../../model/FinishedBrew";
+import {FinishedBrew, FinishedBrewCreatePayload} from "../../../model/FinishedBrew";
 import {finishedBrewsTestData} from "../../../model/finishedBrewsTestData";
 import {BeerActions} from "../../../actions/actions";
 import {FinishedBrewsTable} from './FinishedBrewsTable';
 
 const mapStateToProps = (state: any) => ({
     brews: state.beerDataReducer.finishedBrews || finishedBrewsTestData,
-    beers: state.beerDataReducer.beers
+    beers: state.beerDataReducer.beers || [],
+    savingFinishedBrewIds: state.beerDataReducer.savingFinishedBrewIds || [],
+    finishedBrewUpdateErrors: state.beerDataReducer.finishedBrewUpdateErrors || {},
+    isAddingFinishedBrew: Boolean(state.beerDataReducer.isAddingFinishedBrew),
+    addFinishedBrewError: state.beerDataReducer.addFinishedBrewError,
 });
 
 const mapDispatchToProps = (dispatch: any) => ({
     onSave: (brew: FinishedBrew) => {
         dispatch(BeerActions.updateActiveBeer(brew));
+    },
+    onCreate: (brew: FinishedBrewCreatePayload) => {
+        dispatch(BeerActions.addFinishedBrew(brew));
     },
     exportPdf: (brews: FinishedBrew[]) => {
         dispatch(BeerActions.generateFinishedBrewsPdf(brews));

--- a/src/containers/MainView/FinishBrewsBeers/FinishedBrewsTable.css
+++ b/src/containers/MainView/FinishBrewsBeers/FinishedBrewsTable.css
@@ -1,16 +1,55 @@
-/* Entferne Hintergrundfarbe und Border-Radius von der allgemeinen Klasse */
-.FinishedBrewsTable {
-  width: 80%;
+.finished-brews-page {
+  box-sizing: border-box;
+  width: 100%;
+  height: 100%;
+  min-width: 0;
+  min-height: 0;
+  padding: var(--spacing-md) var(--spacing-lg);
+  color: var(--color-text);
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-sm);
+  overflow: hidden;
+}
 
+.finished-brews-table-area,
+.finished-brews-table-scroll,
+.finished-brews-table-scroll .simplebar-wrapper,
+.finished-brews-table-scroll .simplebar-mask,
+.finished-brews-table-scroll .simplebar-offset,
+.finished-brews-table-scroll .simplebar-content-wrapper {
+  min-width: 0;
+  min-height: 0;
+}
+
+.finished-brews-table-area {
+  flex: 1 1 auto;
+  overflow: hidden;
+}
+
+.finished-brews-table-scroll {
+  width: 100%;
+  height: 100%;
+}
+
+.finished-brews-table-scroll .simplebar-content-wrapper {
+  overflow: auto !important;
+}
+
+.FinishedBrewsTable {
+  width: 100%;
+  min-width: 88rem;
+  table-layout: fixed;
 }
 
 /* Setze Hintergrund und Ecken gezielt auf das MUI Paper-Element */
-.MuiPaper-root.FinishedBrewsTable {
+.MuiPaper-root.finished-brews-table-container {
   background-color: var(--color-brew-bg); /* wie Table.css */
   border-top-left-radius: 5px !important;
   border-top-right-radius: 5px !important;
-  margin: 0.6rem;
-  width: 99%;
+  width: 100%;
+  min-width: 88rem;
+  overflow: visible;
 }
 
 .FinishedBrewsTable .table-header {
@@ -139,8 +178,18 @@
 .filter-container {
   display: flex;
   align-items: center;
-  margin: 1rem 0 0.5rem 20px; /* Abstand für den gesamten Filter-Block */
-  gap: 2rem;
+  flex: 0 0 auto;
+  flex-wrap: wrap;
+  gap: var(--spacing-sm) var(--spacing-md);
+  min-height: var(--control-height-compact);
+}
+
+.filter-container > .finish-btn:first-of-type {
+  margin-left: auto !important;
+}
+
+.filter-container > .finish-btn {
+  margin-left: 0 !important;
 }
 
 .filter-label {
@@ -166,8 +215,7 @@
   accent-color: var(--color-accent);
   width: 1.1rem;
   height: 1.1rem;
-  /* vertikale Ausrichtung anpassen */
-  margin-top:0.7rem;
+  margin: 0;
 }
 
 .FinishedBrewsTable .finish-btn {
@@ -221,6 +269,22 @@
 .FinishedBrewsTable .table-cell.beschreibung {
   min-width: 50px;
   width: 30%;
+}
+
+.FinishedBrewsTable th:nth-child(1), .FinishedBrewsTable td:nth-child(1) { width: 11rem; }
+.FinishedBrewsTable th:nth-child(2), .FinishedBrewsTable td:nth-child(2),
+.FinishedBrewsTable th:nth-child(3), .FinishedBrewsTable td:nth-child(3) { width: 9rem; }
+.FinishedBrewsTable th:nth-child(4), .FinishedBrewsTable td:nth-child(4),
+.FinishedBrewsTable th:nth-child(5), .FinishedBrewsTable td:nth-child(5),
+.FinishedBrewsTable th:nth-child(6), .FinishedBrewsTable td:nth-child(6),
+.FinishedBrewsTable th:nth-child(7), .FinishedBrewsTable td:nth-child(7) { width: 7rem; }
+.FinishedBrewsTable th:nth-child(8), .FinishedBrewsTable td:nth-child(8) { width: 9rem; }
+.FinishedBrewsTable th:nth-child(9), .FinishedBrewsTable td:nth-child(9) { width: auto; }
+.FinishedBrewsTable th:nth-child(10), .FinishedBrewsTable td:nth-child(10) { width: 12rem; }
+
+@media (max-width: 900px) {
+  .finished-brews-page { padding: var(--spacing-md); }
+  .filter-container > .finish-btn:first-of-type { margin-left: 0 !important; }
 }
 
 .FinishedBrewsTable .table-edit-field:focus {

--- a/src/containers/MainView/FinishBrewsBeers/FinishedBrewsTable.tsx
+++ b/src/containers/MainView/FinishBrewsBeers/FinishedBrewsTable.tsx
@@ -2,21 +2,26 @@ import React from 'react';
 import { Paper, Table, TableBody, TableCell, TableContainer, TableHead, TableRow, TextField } from '@mui/material';
 import SimpleBar from 'simplebar-react';
 import './FinishedBrewsTable.css';
-import {FinishedBrew} from "../../../model/FinishedBrew";
+import {FinishedBrew, FinishedBrewCreatePayload} from "../../../model/FinishedBrew";
 import {isNil} from "lodash";
-import { v4 as uuidv4 } from 'uuid';
 import { eBrewState, BrewStateGerman } from '../../../enums/eBrewState';
 import Panel from '../../Panel/Panel';
 import FinishedBrewDetails from './FinishedBrewDetails';
+import {completeFinishedBrew, mergeFinishedBrewChanges} from '../../../utils/finishedBrewChanges';
 
 
 interface FinishedBrewsTableProps {
     brews: FinishedBrew[];
     onSave: (brew: FinishedBrew) => void;
+    onCreate: (brew: FinishedBrewCreatePayload) => void;
     exportPdf: (brews: FinishedBrew[]) => void;
     getFinishedBrews: (isFetching: boolean) => void;
     beers: { id: string; name: string }[]; // id als string (UUID)
     onDelete: (id: string) => void;
+    savingFinishedBrewIds: string[];
+    finishedBrewUpdateErrors: Record<string, string>;
+    isAddingFinishedBrew: boolean;
+    addFinishedBrewError?: string;
 }
 
 interface FinishedBrewsTableState {
@@ -28,6 +33,8 @@ interface FinishedBrewsTableState {
     newRowActive?: boolean;
     newRowData?: Partial<FinishedBrew>;
     panelBrewId?: string | null;
+    submittingRows: Record<string, boolean>;
+    newRowSubmitting: boolean;
 }
 
 const calcAlcohol = (w1: number, w2: number | null) => {
@@ -39,12 +46,37 @@ const calcAlcohol = (w1: number, w2: number | null) => {
 export class FinishedBrewsTable extends React.Component<FinishedBrewsTableProps, FinishedBrewsTableState> {
     constructor(props: FinishedBrewsTableProps) {
         super(props);
-        this.state = { editRows: {}, filterYear: '', showOnlyActive: false, filterOutActive: false, clickedFinishBtn: {}, panelBrewId: null };
+        this.state = { editRows: {}, filterYear: '', showOnlyActive: false, filterOutActive: false, clickedFinishBtn: {}, panelBrewId: null, submittingRows: {}, newRowSubmitting: false };
     }
 
     componentDidMount() {
         const { getFinishedBrews } = this.props;
         getFinishedBrews(true);
+    }
+
+    componentDidUpdate(prevProps: FinishedBrewsTableProps) {
+        const completedIds = prevProps.savingFinishedBrewIds.filter(id => !this.props.savingFinishedBrewIds.includes(id));
+        const successfulIds = completedIds.filter(id => !this.props.finishedBrewUpdateErrors[id]);
+
+        if (completedIds.length > 0) {
+            this.setState(prevState => {
+                const editRows = {...prevState.editRows};
+                const submittingRows = {...prevState.submittingRows};
+                const clickedFinishBtn = {...prevState.clickedFinishBtn};
+                successfulIds.forEach(id => delete editRows[id]);
+                completedIds.forEach(id => {
+                    delete submittingRows[id];
+                    delete clickedFinishBtn[id];
+                });
+                return {editRows, submittingRows, clickedFinishBtn};
+            });
+        }
+
+        if (prevProps.isAddingFinishedBrew && !this.props.isAddingFinishedBrew) {
+            this.setState(this.props.addFinishedBrewError
+                ? {newRowSubmitting: false}
+                : {newRowActive: false, newRowData: {}, newRowSubmitting: false});
+        }
     }
 
     handleChange = (id: string, field: keyof FinishedBrew, value: string) => {
@@ -71,13 +103,9 @@ export class FinishedBrewsTable extends React.Component<FinishedBrewsTableProps,
     handleSave = (id: string) => {
         const brew = this.props.brews.find(b => b.id === id);
         if (!brew) return;
-        const updated = { ...brew, beer_id: brew.beer_id,state : brew.state ,...this.state.editRows[id] } as FinishedBrew;
-        this.props.onSave(updated);
-        this.setState(prevState => {
-            const editRows = { ...prevState.editRows };
-            delete editRows[id];
-            return { editRows };
-        });
+        const updated = mergeFinishedBrewChanges(brew, this.state.editRows[id]);
+        if (this.state.submittingRows[id] || this.props.savingFinishedBrewIds.includes(id)) return;
+        this.setState(prevState => ({submittingRows: {...prevState.submittingRows, [id]: true}}), () => this.props.onSave(updated));
     };
 
     handleFilterYearChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
@@ -123,17 +151,12 @@ export class FinishedBrewsTable extends React.Component<FinishedBrewsTableProps,
     };
 
     handleFinishClick = (brew: FinishedBrew) => {
+        if (this.state.submittingRows[brew.id] || this.props.savingFinishedBrewIds.includes(brew.id)) return;
+        const updated = completeFinishedBrew(brew);
         this.setState(prev => ({
-            clickedFinishBtn: { ...prev.clickedFinishBtn, [brew.id]: true }
-        }), () => {
-            setTimeout(() => {
-                this.setState(prev => ({
-                    clickedFinishBtn: { ...prev.clickedFinishBtn, [brew.id]: false }
-                }));
-                const updated = { ...brew, active: false, beer_id: brew.beer_id };
-                this.props.onSave(updated);
-            }, 150);
-        });
+            clickedFinishBtn: { ...prev.clickedFinishBtn, [brew.id]: true },
+            submittingRows: {...prev.submittingRows, [brew.id]: true},
+        }), () => this.props.onSave(updated));
     };
 
     handleDelete = (id: string) => {
@@ -223,7 +246,7 @@ export class FinishedBrewsTable extends React.Component<FinishedBrewsTableProps,
     }
 
     renderNewRow(beers: { id: string; name: string }[]) {
-        const { newRowActive, newRowData } = this.state;
+        const { newRowActive, newRowData, newRowSubmitting } = this.state;
         if (!newRowActive) return null;
         return (
             <TableRow className="table-row">
@@ -324,11 +347,17 @@ export class FinishedBrewsTable extends React.Component<FinishedBrewsTableProps,
                         <button
                             className="finish-btn"
                             onClick={() => {
-                                const newId = uuidv4();
-                                const newBrew: FinishedBrew = { ...newRowData, id: newId, beer_id: newRowData?.beer_id, active: true } as FinishedBrew;
-                                this.props.onSave(newBrew);
-                                this.setState({ newRowActive: false, newRowData: {} });
+                                if (newRowSubmitting || this.props.isAddingFinishedBrew) return;
+                                const newBrew: FinishedBrewCreatePayload = {
+                                    ...newRowData,
+                                    beer_id: newRowData?.beer_id,
+                                    state: newRowData?.state || eBrewState.FERMENTATION,
+                                    note: newRowData?.note || '',
+                                    active: true,
+                                } as FinishedBrewCreatePayload;
+                                this.setState({newRowSubmitting: true}, () => this.props.onCreate(newBrew));
                             }}
+                            disabled={newRowSubmitting || this.props.isAddingFinishedBrew}
                             title="Speichern"
                         >
                             <span role="img" aria-label="Speichern" style={{ fontSize: 22, verticalAlign: 'middle',  display: 'inline-block', position: 'relative', top: '3px' }}>💾</span>
@@ -336,6 +365,7 @@ export class FinishedBrewsTable extends React.Component<FinishedBrewsTableProps,
                         <button
                             className="cancel-btn"
                             onClick={() => this.setState({ newRowActive: false, newRowData: {} })}
+                            disabled={newRowSubmitting || this.props.isAddingFinishedBrew}
                             title="Abbrechen"
                         >
                             <span role="img" aria-label="Abbrechen" style={{ fontSize: 22, verticalAlign: 'middle',  display: 'inline-block', position: 'relative', top: '3px' }}>✖️</span>
@@ -347,11 +377,12 @@ export class FinishedBrewsTable extends React.Component<FinishedBrewsTableProps,
     }
 
     renderBrewRow(brew: FinishedBrew, beers: { id: string; name: string }[]) {
-        const { editRows, clickedFinishBtn } = this.state;
+        const { editRows, clickedFinishBtn, submittingRows } = this.state;
         const brewId = brew.id;
         const isEdited = !!editRows[brewId];
         const row = { ...brew, ...editRows[brewId] };
         const isActive = brew.active;
+        const isSaving = Boolean(submittingRows[brewId]) || this.props.savingFinishedBrewIds.includes(brewId);
         return (
             <TableRow key={brewId} className={`table-row${isActive ? ' active-row' : ''}`}>
                 <TableCell className="table-cell">{brew.name}</TableCell>
@@ -448,6 +479,7 @@ export class FinishedBrewsTable extends React.Component<FinishedBrewsTableProps,
                             <button
                                 className="finish-btn"
                                 onClick={() => this.handleSave(brewId)}
+                                disabled={isSaving}
                                 title="Speichern"
                             >
                                 <span role="img" aria-label="Speichern" style={{ fontSize: 22, verticalAlign: 'middle',  display: 'inline-block', position: 'relative', top: '3px' }}>💾</span>
@@ -457,8 +489,8 @@ export class FinishedBrewsTable extends React.Component<FinishedBrewsTableProps,
                             <button
                                 className={`finish-btn${clickedFinishBtn[brewId] ? ' clicked' : ''}`}
                                 title="Endgültig fertigstellen"
-                                onClick={() => this.handleFinishClick(brew)}
-                                disabled={row.residual_extract === null || row.residual_extract === undefined}
+                                onClick={() => this.handleFinishClick(row as FinishedBrew)}
+                                disabled={isSaving || row.residual_extract === null || row.residual_extract === undefined}
                             >
                                 <span role="img" aria-label="Fertig" style={{ fontSize: 22, verticalAlign: 'middle',  display: 'inline-block', position: 'relative', top: '3px' }}>✅</span>
                             </button>
@@ -486,8 +518,8 @@ export class FinishedBrewsTable extends React.Component<FinishedBrewsTableProps,
 
     renderTable(filteredBrews: FinishedBrew[], beers: { id: string; name: string }[]) {
         return (
-            <SimpleBar style={{ maxHeight: 600 }}>
-                <TableContainer component={Paper} className="FinishedBrewsTable">
+            <SimpleBar className="finished-brews-table-scroll">
+                <TableContainer component={Paper} className="finished-brews-table-container">
                     <Table className="FinishedBrewsTable">
                         <TableHead className="table-header">
                             <TableRow>
@@ -520,9 +552,9 @@ export class FinishedBrewsTable extends React.Component<FinishedBrewsTableProps,
         const filteredBrews = this.filterBrewsByYearAndActive(brews, filterYear, showOnlyActive, filterOutActive);
         const selectedBrew = panelBrewId ? brews.find(b => b.id === panelBrewId) : null;
         return (
-            <>
+            <main className="finished-brews-page">
                 {this.renderFilterControls(years)}
-                {this.renderTable(filteredBrews, beers)}
+                <div className="finished-brews-table-area">{this.renderTable(filteredBrews, beers)}</div>
                 {/* Panel als Overlay am Ende */}
                 {selectedBrew && (
                     <div style={{ position: 'fixed', left: 0, top: 0, width: '100vw', height: '100vh', zIndex: 2000, pointerEvents: 'none' }}>
@@ -533,7 +565,7 @@ export class FinishedBrewsTable extends React.Component<FinishedBrewsTableProps,
                         </div>
                     </div>
                 )}
-            </>
+            </main>
         );
     }
 }

--- a/src/containers/Production/Production.connect.ts
+++ b/src/containers/Production/Production.connect.ts
@@ -3,7 +3,7 @@ import {Dispatch} from "redux";
 import {BeerActions, ProductionActions} from "../../actions/actions";
 import {MashAgitatorStates} from "../../model/MashAgitator";
 import {BrewingData} from "../../model/BrewingData";
-import {FinishedBrew} from "../../model/FinishedBrew";
+import {FinishedBrewCreatePayload} from "../../model/FinishedBrew";
 import {RootState} from "../../reducers/rootReducer";
 import {Production} from './Production';
 import {ConfirmStates} from '../../enums/eConfirmStates';
@@ -31,7 +31,7 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
         dispatch(ProductionActions.stopPolling())
     },
 
-    addFinishedBrew: (finishedBrew: FinishedBrew) => {
+    addFinishedBrew: (finishedBrew: FinishedBrewCreatePayload) => {
         dispatch(BeerActions.addFinishedBrew(finishedBrew))
     },
     nextProcedureStep: () => {

--- a/src/containers/Production/Production.tsx
+++ b/src/containers/Production/Production.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import {isUndefined} from 'lodash';
 import {Beer} from "../../model/Beer";
-import {v4 as uuidv4} from 'uuid';
 import '@fortawesome/fontawesome-free/css/all.css'; // Stile
 import './Production.css'
 
@@ -22,7 +21,7 @@ import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
 import {faRepeat} from '@fortawesome/free-solid-svg-icons';
 import Switch from "react-switch";
 import {IconProp} from "@fortawesome/fontawesome-svg-core";
-import {FinishedBrew} from "../../model/FinishedBrew";
+import {FinishedBrewCreatePayload} from "../../model/FinishedBrew";
 import {eBrewState} from "../../enums/eBrewState";
 import {BackendAvailable} from "../../reducers/productionReducer";
 import {ProcessList} from "./ProcessList/ProcessList";
@@ -60,7 +59,7 @@ export interface ProductionProps {
     stopPolling: () => void;
     isBackenAvailable: BackendAvailable | boolean;
     waterStatus: WaterStatus;
-    addFinishedBrew: (finishedBrew: FinishedBrew) => void;
+    addFinishedBrew: (finishedBrew: FinishedBrewCreatePayload) => void;
     nextProcedureStep: () => void;
     isPollingRunning: boolean;
     confirm: (confirmState: ConfirmStates) => void;
@@ -711,8 +710,7 @@ export class Production extends React.Component<ProductionProps, ProductionState
         const jsonString = dataCollector.getAllDataAsJSONString();
         // FinishedBrew erzeugen und speichern
         if (selectedBeer) {
-            const finishedBrew : FinishedBrew = {
-                id: uuidv4(),
+            const finishedBrew : FinishedBrewCreatePayload = {
                 name: selectedBeer.name || 'Unknown Beer',
                 liters: 0,
                 originalwort:  0,

--- a/src/containers/index.tsx
+++ b/src/containers/index.tsx
@@ -55,9 +55,7 @@ export class Index extends React.Component<indexMainProps> {
                     {activeView === Views.INGREDIENTS && <IngredientsFormPage />}
                 </div>
                 {activeView === Views.SETTINGS && <SettingsPage />}
-                <SimpleBar style={{maxHeight: '100%', overflowY: 'auto'}}>
-                    {activeView === Views.FINISHED_BREWS && <FinishedBrewsTable></FinishedBrewsTable>}
-                </SimpleBar>
+                {activeView === Views.FINISHED_BREWS && <FinishedBrewsTable />}
                 {activeView === Views.BREWING_CALCULATIONS && <BrewingCalculations />}
                 {activeView === Views.VERSION && <VersionPage />}
             </div>

--- a/src/epics/beerEpics.ts
+++ b/src/epics/beerEpics.ts
@@ -104,8 +104,9 @@ export const updateFinishedBeerEpic = (action$: any) =>
     ofType(BeerActions.ActionTypes.UPDATE_ACTIVE_BEER),
     mergeMap((action: any) =>
       from(FinishedBeerRepository.updateFinishedBeer(action.payload.beer)).pipe(
-        map((beer) => BeerActions.updateFinishedBrewSuccess(beer)),
+        map((beer) => BeerActions.updateFinishedBrewSuccess({...action.payload.beer, ...beer}, action.payload.beer.id)),
         catchError((aError: Error) =>  from([
+            BeerActions.updateFinishedBrewFailure(action.payload.beer.id, aError.message),
             ApplicationActions.openErrorDialog(
                 true,
                 "Bier fehler",
@@ -123,11 +124,12 @@ export const sendNewFinishedBeerEpic = (action$: any) =>
     ofType(BeerActions.ActionTypes.ADD_FINISHED_BREW),
     mergeMap((action: any) =>
       from(FinishedBeerRepository.sendNewFinishedBeer(action.payload.finishedBrew)).pipe(
-        map(() => {
+        map((beer) => {
           dataCollector.reset();
-          return BeerActions.getFinishedBeers(true);
+          return BeerActions.addFinishedBrewSuccess({...action.payload.finishedBrew, ...beer});
         }),
         catchError((aError: Error) =>  from([
+            BeerActions.addFinishedBrewFailure(aError.message),
             ApplicationActions.openErrorDialog(
                 true,
                 "Bier fehler",

--- a/src/model/FinishedBrew.ts
+++ b/src/model/FinishedBrew.ts
@@ -14,3 +14,5 @@ export interface FinishedBrew {
     state: eBrewState;
     brewValues?: string;
 }
+
+export type FinishedBrewCreatePayload = Omit<FinishedBrew, 'id'>;

--- a/src/reducers/beerReducer.test.ts
+++ b/src/reducers/beerReducer.test.ts
@@ -2,6 +2,8 @@ import {BeerActions} from '../actions/actions';
 import {Beer} from '../model/Beer';
 import {RecipeImportResult} from '../model/RecipeImport';
 import {beerDataReducer, initialBeerState} from './beerReducer';
+import {FinishedBrew} from '../model/FinishedBrew';
+import {eBrewState} from '../enums/eBrewState';
 
 const result = (replayed: boolean): RecipeImportResult => ({
     recipe: {id: 'beer-1', name: replayed ? 'Replay' : 'Import'} as Beer,
@@ -29,8 +31,33 @@ describe('beerDataReducer recipe import', () => {
 });
 
 describe('beerDataReducer finished brews', () => {
+    const brew: FinishedBrew = {
+        id: 'ABC', name: 'Testbier', startDate: '2026-08-27', liters: 20,
+        originalwort: 12, residual_extract: 3, note: '', active: true,
+        beer_id: 'recipe-1', state: eBrewState.FERMENTATION,
+    };
+
     it('normalizes a null response to an undefined list', () => {
         const state = beerDataReducer(initialBeerState, BeerActions.getFinishedBeersSuccess(null));
         expect(state.finishedBrews).toBeUndefined();
+    });
+
+    it('adds the backend-generated record after create success', () => {
+        const state = beerDataReducer({...initialBeerState, finishedBrews: []}, BeerActions.addFinishedBrewSuccess(brew));
+        expect(state.finishedBrews).toEqual([brew]);
+    });
+
+    it('replaces the existing id after update success', () => {
+        const pending = beerDataReducer({...initialBeerState, finishedBrews: [brew]}, BeerActions.updateActiveBeer({...brew, state: eBrewState.MATURATION}));
+        const state = beerDataReducer(pending, BeerActions.updateFinishedBrewSuccess({...brew, state: eBrewState.MATURATION}, 'ABC'));
+        expect(state.finishedBrews).toHaveLength(1);
+        expect(state.finishedBrews?.[0]).toMatchObject({id: 'ABC', state: eBrewState.MATURATION});
+    });
+
+    it('does not append an update response with another id', () => {
+        const pending = beerDataReducer({...initialBeerState, finishedBrews: [brew]}, BeerActions.updateActiveBeer(brew));
+        const state = beerDataReducer(pending, BeerActions.updateFinishedBrewSuccess({...brew, id: 'NEW'}, 'ABC'));
+        expect(state.finishedBrews).toEqual([brew]);
+        expect(state.finishedBrewUpdateErrors?.ABC).toBeDefined();
     });
 });

--- a/src/reducers/beerReducer.ts
+++ b/src/reducers/beerReducer.ts
@@ -25,6 +25,10 @@ export interface BeerDataReducerState {
     isImportingBeer?: boolean
     importResult?: RecipeImportResult
     importError?: string
+    savingFinishedBrewIds?: string[]
+    finishedBrewUpdateErrors?: Record<string, string>
+    isAddingFinishedBrew?: boolean
+    addFinishedBrewError?: string
 }
 
 export const initialBeerState: BeerDataReducerState =
@@ -39,6 +43,9 @@ export const initialBeerState: BeerDataReducerState =
         importedBeer: undefined,
         isSavingBeer: false,
         isImportingBeer: false,
+        savingFinishedBrewIds: [],
+        finishedBrewUpdateErrors: {},
+        isAddingFinishedBrew: false,
     }
 
 const beerDataReducer = (
@@ -126,7 +133,11 @@ const beerDataReducer = (
       return { ...aState, finishedBrews: aAction.payload.finishedBeers ?? undefined };
     }
     case BeerActions.ActionTypes.UPDATE_ACTIVE_BEER: {
-      return { ...aState };
+      const requestedId = aAction.payload.beer.id;
+      const savingFinishedBrewIds = Array.from(new Set([...(aState.savingFinishedBrewIds ?? []), requestedId]));
+      const finishedBrewUpdateErrors = {...(aState.finishedBrewUpdateErrors ?? {})};
+      delete finishedBrewUpdateErrors[requestedId];
+      return { ...aState, savingFinishedBrewIds, finishedBrewUpdateErrors };
     }
     case BeerActions.ActionTypes.DELETE_FINISHED_BEER: {
       return { ...aState };
@@ -137,18 +148,57 @@ const beerDataReducer = (
       return { ...aState, finishedBrews };
     }
     case BeerActions.ActionTypes.ADD_FINISHED_BREW: {
-      return { ...aState };
+      return { ...aState, isAddingFinishedBrew: true, addFinishedBrewError: undefined };
+    }
+    case BeerActions.ActionTypes.ADD_FINISHED_BREW_SUCCESS: {
+      const createdBrew = aAction.payload.beer;
+      const finishedBrews = aState.finishedBrews ?? [];
+      if (!createdBrew?.id) {
+        return {...aState, isAddingFinishedBrew: false, addFinishedBrewError: 'Die Create-Antwort enthält keine FinishedBeer-ID.'};
+      }
+      return {
+        ...aState,
+        isAddingFinishedBrew: false,
+        addFinishedBrewError: undefined,
+        finishedBrews: [...finishedBrews, createdBrew],
+      };
+    }
+    case BeerActions.ActionTypes.ADD_FINISHED_BREW_FAILURE: {
+      return { ...aState, isAddingFinishedBrew: false, addFinishedBrewError: aAction.payload.message };
     }
     case BeerActions.ActionTypes.UPDATE_FINISHED_BREW_SUCCESS: {
         const updatedBrew = aAction.payload.beer;
+          const requestedId = aAction.payload.requestedId;
           const finishedBrews = aState.finishedBrews ?? [];
-          const found = finishedBrews.some(b => b.id === updatedBrew.id);
+          const savingFinishedBrewIds = (aState.savingFinishedBrewIds ?? []).filter(id => id !== requestedId);
+
+          if (!updatedBrew?.id || updatedBrew.id !== requestedId || !finishedBrews.some(b => b.id === requestedId)) {
+              return {
+                  ...aState,
+                  savingFinishedBrewIds,
+                  finishedBrewUpdateErrors: {
+                      ...(aState.finishedBrewUpdateErrors ?? {}),
+                      [requestedId]: 'Die Update-Antwort enthält keine passende FinishedBeer-ID.',
+                  },
+              };
+          }
+
+          const finishedBrewUpdateErrors = {...(aState.finishedBrewUpdateErrors ?? {})};
+          delete finishedBrewUpdateErrors[requestedId];
 
           return {
               ...aState,
-              finishedBrews: found
-                  ? finishedBrews.map(b => b.id === updatedBrew.id ? updatedBrew : b)
-                  : [...finishedBrews, updatedBrew],
+              savingFinishedBrewIds,
+              finishedBrewUpdateErrors,
+              finishedBrews: finishedBrews.map(b => b.id === requestedId ? updatedBrew : b),
+          };
+      }
+      case BeerActions.ActionTypes.UPDATE_FINISHED_BREW_FAILURE: {
+          const {requestedId, message} = aAction.payload;
+          return {
+              ...aState,
+              savingFinishedBrewIds: (aState.savingFinishedBrewIds ?? []).filter(id => id !== requestedId),
+              finishedBrewUpdateErrors: {...(aState.finishedBrewUpdateErrors ?? {}), [requestedId]: message},
           };
       }
 

--- a/src/repositorys/FinishedBeerRepository.test.ts
+++ b/src/repositorys/FinishedBeerRepository.test.ts
@@ -1,0 +1,61 @@
+import {api} from './BaseRepository';
+import {FinishedBeerRepository} from './FinishedBeerRepository';
+import {eBrewState} from '../enums/eBrewState';
+import {FinishedBrew, FinishedBrewCreatePayload} from '../model/FinishedBrew';
+
+jest.mock('./BaseRepository', () => {
+    const post = jest.fn();
+    const put = jest.fn();
+    return {
+        api: {post, put},
+        BaseRepository: class {
+            protected static async post<T>(aUrl: string, aBody: unknown): Promise<T> {
+                const response = await post(aUrl, aBody);
+                return response.data;
+            }
+            protected static async put<T>(aUrl: string, aBody: unknown): Promise<T> {
+                const response = await put(aUrl, aBody);
+                return response.data;
+            }
+        },
+    };
+});
+
+const mockedApi = api as unknown as {post: jest.Mock; put: jest.Mock};
+const createPayload: FinishedBrewCreatePayload = {
+    name: 'Testbier',
+    startDate: '2026-08-27',
+    liters: 20,
+    originalwort: 12,
+    residual_extract: 3,
+    note: '',
+    active: true,
+    beer_id: 'recipe-1',
+    state: eBrewState.FERMENTATION,
+};
+
+describe('FinishedBeerRepository', () => {
+    beforeEach(() => {
+        mockedApi.post.mockReset();
+        mockedApi.put.mockReset();
+    });
+
+    it('creates without a client id through POST finishedbeer', async () => {
+        mockedApi.post.mockResolvedValueOnce({data: {...createPayload, id: 'generated-id'}});
+
+        await FinishedBeerRepository.sendNewFinishedBeer(createPayload);
+
+        expect(mockedApi.post).toHaveBeenCalledWith('finishedbeer', expect.not.objectContaining({id: expect.anything()}));
+        expect(mockedApi.put).not.toHaveBeenCalled();
+    });
+
+    it('updates the complete existing record through PUT finishedbeer', async () => {
+        const existing: FinishedBrew = {...createPayload, id: 'existing-id', state: eBrewState.MATURATION};
+        mockedApi.put.mockResolvedValueOnce({data: existing});
+
+        await FinishedBeerRepository.updateFinishedBeer(existing);
+
+        expect(mockedApi.put).toHaveBeenCalledWith('finishedbeer', existing);
+        expect(mockedApi.post).not.toHaveBeenCalled();
+    });
+});

--- a/src/repositorys/FinishedBeerRepository.ts
+++ b/src/repositorys/FinishedBeerRepository.ts
@@ -1,5 +1,5 @@
 import {BaseRepository} from "./BaseRepository";
-import {FinishedBrew} from "../model/FinishedBrew";
+import {FinishedBrew, FinishedBrewCreatePayload} from "../model/FinishedBrew";
 
 export class FinishedBeerRepository extends BaseRepository {
 
@@ -7,12 +7,12 @@ export class FinishedBeerRepository extends BaseRepository {
         return this.get<FinishedBrew[]>("finishedbeers");
     }
 
-    static sendNewFinishedBeer(aBeer: FinishedBrew): Promise<FinishedBrew> {
+    static sendNewFinishedBeer(aBeer: FinishedBrewCreatePayload): Promise<FinishedBrew> {
         return this.post<FinishedBrew>("finishedbeer", aBeer);
     }
 
     static updateFinishedBeer(aBeer: FinishedBrew): Promise<FinishedBrew> {
-        return this.post<FinishedBrew>("finishedbeer", aBeer);
+        return this.put<FinishedBrew>("finishedbeer", aBeer);
     }
 
     static deleteFinishedBeer(aBeerId: string): Promise<void> {

--- a/src/utils/finishedBrewChanges.test.ts
+++ b/src/utils/finishedBrewChanges.test.ts
@@ -1,0 +1,31 @@
+import {eBrewState} from '../enums/eBrewState';
+import {FinishedBrew} from '../model/FinishedBrew';
+import {completeFinishedBrew, mergeFinishedBrewChanges} from './finishedBrewChanges';
+
+const brew: FinishedBrew = {
+    id: 'ABC', name: 'Testbier', startDate: '2026-08-20', liters: 20,
+    originalwort: 12, residual_extract: 3, note: 'bestehend', active: true,
+    beer_id: 'recipe-1', state: eBrewState.FERMENTATION, brewValues: '{"temperature":20}',
+};
+
+describe('finished brew changes', () => {
+    it('changes fermentation to maturation while retaining the complete record and id', () => {
+        const updated = mergeFinishedBrewChanges(brew, {state: eBrewState.MATURATION});
+
+        expect(updated).toEqual({...brew, state: eBrewState.MATURATION});
+        expect(updated.id).toBe('ABC');
+    });
+
+    it('finishes the currently edited record and sets a missing end date', () => {
+        const visibleRow = mergeFinishedBrewChanges(brew, {state: eBrewState.MATURATION, note: 'bearbeitet'});
+        const updated = completeFinishedBrew(visibleRow, new Date('2026-08-27T20:00:00.000Z'));
+
+        expect(updated).toMatchObject({id: 'ABC', state: eBrewState.FINISHED, active: false, note: 'bearbeitet'});
+        expect(updated.endDate).toBe('2026-08-27T20:00:00.000Z');
+    });
+
+    it('does not overwrite an explicitly supplied end date', () => {
+        const updated = completeFinishedBrew({...brew, endDate: '2026-08-26'});
+        expect(updated.endDate).toBe('2026-08-26');
+    });
+});

--- a/src/utils/finishedBrewChanges.ts
+++ b/src/utils/finishedBrewChanges.ts
@@ -1,0 +1,15 @@
+import {eBrewState} from '../enums/eBrewState';
+import {FinishedBrew} from '../model/FinishedBrew';
+
+export const mergeFinishedBrewChanges = (brew: FinishedBrew, changes?: Partial<FinishedBrew>): FinishedBrew => ({
+    ...brew,
+    ...changes,
+    id: brew.id,
+});
+
+export const completeFinishedBrew = (brew: FinishedBrew, now: Date = new Date()): FinishedBrew => ({
+    ...brew,
+    state: eBrewState.FINISHED,
+    active: false,
+    endDate: brew.endDate || now.toISOString(),
+});


### PR DESCRIPTION
### Motivation
- Ensure backend/UX compatibility by making finished-brew create/update semantics explicit: `POST /finishedbeer` must create without a client `id` and `PUT /finishedbeer` must perform full-record updates using the body `id`.
- Prevent duplicated list entries and race conditions when the backend returns an ID different from a client's temporary value by tracking pending saves and matching responses to requested IDs.
- Improve the finished-brews UI to support adding new brews, disable controls while requests are in flight, and provide clearer success/failure handling.

### Description
- Document updates: clarified `POST /finishedbeer` vs `PUT /finishedbeer` in multiple docs (`cross-repo-contracts.md`, `database-context.md`, `interfaces.md`, `known-risks.md`).
- API/repository: changed `FinishedBeerRepository.sendNewFinishedBeer` to accept `FinishedBrewCreatePayload` and post to `finishedbeer`, and changed `updateFinishedBeer` to use `PUT finishedbeer`.
- Model and utilities: added `FinishedBrewCreatePayload` type and new helpers `mergeFinishedBrewChanges` and `completeFinishedBrew` in `src/utils/finishedBrewChanges.ts`.
- Actions/epics: added action types and creators for add/update success/failure (`ADD_FINISHED_BREW_SUCCESS`, `ADD_FINISHED_BREW_FAILURE`, `UPDATE_FINISHED_BREW_FAILURE`) and updated epics to return success/failure actions and include the `requestedId` when resolving update responses.
- Reducer/UI: track `savingFinishedBrewIds`, `finishedBrewUpdateErrors`, `isAddingFinishedBrew`, and `addFinishedBrewError` in `beerReducer`; append created records only on create success and match update responses to the original requested ID; propagate UI state to disable controls while requests are pending.
- UI components: updated `FinishedBrewsTable` and `Production` flows to use the create payload (no client-generated `id`), show a new-entry form, manage per-row submitting state, and apply CSS/layout improvements for the finished-brews page.
- Tests: added unit tests for the repository (`FinishedBeerRepository.test.ts`) and utils (`finishedBrewChanges.test.ts`) and extended `beerReducer.test.ts` to cover create/update behaviors.

### Testing
- Ran focused unit tests `src/repositorys/FinishedBeerRepository.test.ts`, `src/utils/finishedBrewChanges.test.ts`, and updated `src/reducers/beerReducer.test.ts`, and they passed locally.
- Executed the full automated test suite (`npm test`) and all tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a909ef68e24832f9455241223914bbe)