### PR TITLE
Serialize epic requests, surface pending/failure states and improve finished-brew lifecycle & UI feedback

### DIFF
--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -22,14 +22,17 @@ export namespace BeerActions {
         SUBMIT_BEER_SUCCESS = 'BeerActions.SUBMIT_BEER_SUCCESS',
         GET_BEERS = 'BeerActions.GET_BEERS',
         GET_BEERS_SUCCESS = 'BeerActions.GET_BEERS_SUCCESS',
+        GET_BEERS_FAILURE = 'BeerActions.GET_BEERS_FAILURE',
         SET_SELECTED_BEER = 'BeerActions.SET_SELECTED_BEER',
         SET_IS_SUBMIT_SUCCESSFUL = 'BeerActions.SET_IS_SUBMIT_SUCCESSFUL',
         SET_BEER_TO_BREW = 'BeerActions.SET_BEER_TO_BREW',
         UPDATE_ACTIVE_BEER = 'BeerActions.UPDATE_ACTIVE_BEER',
         GET_FINISHED_BEERS = 'BeerActions.GET_FINISHED_BEERS',
         GET_FINISHED_BEERS_SUCCESS = 'BeerActions.GET_FINISHED_BEERS_SUCCESS',
+        GET_FINISHED_BEERS_FAILURE = 'BeerActions.GET_FINISHED_BEERS_FAILURE',
         DELETE_FINISHED_BEER = 'BeerActions.DELETE_FINISHED_BEER',
         DELETE_FINISHED_BEER_SUCCESS = 'BeerActions.DELETE_FINISHED_BEER_SUCCESS',
+        DELETE_FINISHED_BEER_FAILURE = 'BeerActions.DELETE_FINISHED_BEER_FAILURE',
         ADD_FINISHED_BREW = 'BeerActions.ADD_FINISHED_BREW',
         ADD_FINISHED_BREW_SUCCESS = 'BeerActions.ADD_FINISHED_BREW_SUCCESS',
         ADD_FINISHED_BREW_FAILURE = 'BeerActions.ADD_FINISHED_BREW_FAILURE',
@@ -65,6 +68,7 @@ export namespace BeerActions {
             beers: Beer[]
         }
     }
+    export interface GetBeersFailure { readonly type: ActionTypes.GET_BEERS_FAILURE }
 
     export interface SetIsSubmitSuccessful {
         readonly type: ActionTypes.SET_IS_SUBMIT_SUCCESSFUL
@@ -121,6 +125,7 @@ export namespace BeerActions {
             finishedBeers: FinishedBrew[] | null
         }
     }
+    export interface GetFinishedBeersFailure { readonly type: ActionTypes.GET_FINISHED_BEERS_FAILURE }
 
     export interface DeleteFinishedBeer {
         readonly type: ActionTypes.DELETE_FINISHED_BEER
@@ -136,6 +141,7 @@ export namespace BeerActions {
             deletedFinishedBrewId: string
         }
     }
+    export interface DeleteFinishedBeerFailure { readonly type: ActionTypes.DELETE_FINISHED_BEER_FAILURE; payload: {deletedFinishedBrewId: string; message: string} }
 
     export interface AddFinishedBrew {
         readonly type: ActionTypes.ADD_FINISHED_BREW;
@@ -249,14 +255,17 @@ export namespace BeerActions {
         SubmitBeerSuccess |
         GetBeers |
         GetBeersSuccess |
+        GetBeersFailure |
         SetIsSubmitSuccessful |
         SetSelectedBeer |
         SetBeerToBrew |
         UpdateActiveBeer |
         GetFinishedBeers |
         GetFinishedBeersSuccess |
+        GetFinishedBeersFailure |
         DeleteFinishedBeer |
         DeleteFinishedBeerSuccess |
+        DeleteFinishedBeerFailure |
         AddFinishedBrew |
         AddFinishedBrewSuccess |
         AddFinishedBrewFailure |
@@ -291,6 +300,7 @@ export namespace BeerActions {
             payload: {beers: aBeers}
         }
     }
+    export function getBeersFailure(): GetBeersFailure { return {type: ActionTypes.GET_BEERS_FAILURE} }
 
     export function submitBeer(aBeer: BeerDTO): SubmitBeer {
         return {
@@ -387,6 +397,7 @@ export namespace BeerActions {
             payload: {finishedBeers: aFinishedBeers}
         }
     }
+    export function getFinishedBeersFailure(): GetFinishedBeersFailure { return {type: ActionTypes.GET_FINISHED_BEERS_FAILURE} }
 
     export function deleteFinishedBeer(aFinishedBrewId: string): DeleteFinishedBeer {
         return {
@@ -400,6 +411,9 @@ export namespace BeerActions {
             type: BeerActions.ActionTypes.DELETE_FINISHED_BEER_SUCCESS,
             payload: {isDeleteFinishedBeerSuccessful: aIsSuccessful, deletedFinishedBrewId: aDeletedFinishedBrewId}
         }
+    }
+    export function deleteFinishedBeerFailure(aDeletedFinishedBrewId: string, message: string): DeleteFinishedBeerFailure {
+        return {type: ActionTypes.DELETE_FINISHED_BEER_FAILURE, payload: {deletedFinishedBrewId: aDeletedFinishedBrewId, message}}
     }
 
     export function addFinishedBrew(finishedBrew: FinishedBrewCreatePayload): AddFinishedBrew {
@@ -602,10 +616,13 @@ export namespace ProductionActions {
         START_WATER_FILLING = 'ProductionActions.START_WATER_FILLING',
         START_WATER_FILLING_SUCCESS = 'ProductionActions.START_WATER_FILLING_SUCCESS',
         SEND_BREWING_DATA = 'ProductionActions.SEND_BREWING_DATA',
+        BREWING_START_FAILURE = 'ProductionActions.BREWING_START_FAILURE',
         SET_BREWING_STATUS = 'ProductionActions.SET_BREWING_STATUS',
         START_POLLING = 'ProductionActions.START_POLLING',
         STOP_POLLING = 'ProductionActions.STOP_POLLING',
         CONFIRM = 'ProductionActions.CONFIRM',
+        CONFIRM_SUCCESS = 'ProductionActions.CONFIRM_SUCCESS',
+        CONFIRM_FAILURE = 'ProductionActions.CONFIRM_FAILURE',
         CHECK_IS_BACKEND_AVAILABLE = 'ProductionActions.CHECK_IS_BACKEND_AVAILABLE',
         IS_BACKEND_AVAILABLE = 'ProductionActions.IS_BACKEND_AVAILABLE',
         SET_WATER_STATUS = 'ProductionActions.SET_WATER_STATUS',
@@ -637,6 +654,15 @@ export namespace ProductionActions {
         payload: { confirmState: ConfirmStates }
     }
 
+    export interface ConfirmSuccess {
+        readonly type: ActionTypes.CONFIRM_SUCCESS
+    }
+
+    export interface ConfirmFailure {
+        readonly type: ActionTypes.CONFIRM_FAILURE
+        payload: { error: string }
+    }
+
     export interface StartPolling {
         readonly type: ActionTypes.START_POLLING
     }
@@ -654,6 +680,7 @@ export namespace ProductionActions {
         readonly type: ActionTypes.SEND_BREWING_DATA
         payload: { brewingData: BrewingData }
     }
+    export interface BrewingStartFailure { readonly type: ActionTypes.BREWING_START_FAILURE; payload: {error: string} }
 
     export interface ToggleAgitatorSuccess {
         readonly type: ActionTypes.TOGGLE_AGITATOR_SUCCESS
@@ -734,7 +761,10 @@ export namespace ProductionActions {
         StartPolling |
         StopPolling |
         Confirm |
+        ConfirmSuccess |
+        ConfirmFailure |
         SendBrewingData |
+        BrewingStartFailure |
         CheckIsBackendAvailable |
         IsBackendAvailable |
         SetWaterStatus |
@@ -774,6 +804,14 @@ export namespace ProductionActions {
         }
     }
 
+    export function confirmSuccess(): ProductionActions.ConfirmSuccess {
+        return {type: ActionTypes.CONFIRM_SUCCESS}
+    }
+
+    export function confirmFailure(aError: string): ProductionActions.ConfirmFailure {
+        return {type: ActionTypes.CONFIRM_FAILURE, payload: {error: aError}}
+    }
+
     export function startPolling(): StartPolling {
         return {
             type: ActionTypes.START_POLLING,
@@ -799,6 +837,7 @@ export namespace ProductionActions {
             payload: {brewingData: aBrewingData}
         }
     }
+    export function brewingStartFailure(error: string): BrewingStartFailure { return {type: ActionTypes.BREWING_START_FAILURE, payload: {error}} }
 
     export function toggleAgitatorSuccess(aIsSuccess: boolean): ToggleAgitatorSuccess {
         return {

--- a/src/containers/DatabaseOverview/BeerForm.test.tsx
+++ b/src/containers/DatabaseOverview/BeerForm.test.tsx
@@ -71,6 +71,14 @@ const fillValidRecipe = () => {
     fireEvent.change(yeastQuantity, {target: {value: '1'}});
 };
 
+it('synchronizes one form-state action per local field change', () => {
+    const saveBeerFormState = jest.fn();
+    renderBeerForm({saveBeerFormState});
+    fireEvent.change(screen.getByLabelText(/Name:/), {target: {value: 'Helles'}});
+    expect(saveBeerFormState).toHaveBeenCalledTimes(1);
+    expect(saveBeerFormState).toHaveBeenLastCalledWith(expect.objectContaining({name: 'Helles'}));
+});
+
 const expectProcedureTypeOptions = (select: HTMLElement) => {
     const options = within(select).getAllByRole('option');
     expect(options).toHaveLength(2);

--- a/src/containers/DatabaseOverview/BeerForm.tsx
+++ b/src/containers/DatabaseOverview/BeerForm.tsx
@@ -145,10 +145,7 @@ export class BeerForm extends React.Component<BeerFormProps, BeerFormState> {
 
     handleChange = (e: ChangeEvent<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>) => {
         const { name, value } = e.target;
-        this.setState({[name]: value} as unknown as Pick<BeerFormState, keyof BeerFormState>, () => {
-            // Nach jeder Statusänderung den aktuellen Formularstatus speichern
-            this.props.saveBeerFormState(this.state);
-        });
+        this.setState({[name]: value} as unknown as Pick<BeerFormState, keyof BeerFormState>);
     };
 
     componentDidMount() {
@@ -196,7 +193,6 @@ export class BeerForm extends React.Component<BeerFormProps, BeerFormState> {
                 isSubmitSuccessful: undefined,
             }, () => {
                 this.updateFermentationStepValidationErrors(this.state.fermentationSteps);
-                this.props.saveBeerFormState(this.state);
             });
         }
 
@@ -249,8 +245,6 @@ export class BeerForm extends React.Component<BeerFormProps, BeerFormState> {
           return { fermentationSteps };
        }, () => {
             this.updateFermentationStepValidationErrors(this.state.fermentationSteps);
-            // Nach jeder Statusänderung den aktuellen Formularstatus speichern
-            this.props.saveBeerFormState(this.state);
        });
     };
 
@@ -292,9 +286,6 @@ export class BeerForm extends React.Component<BeerFormProps, BeerFormState> {
             // @ts-ignore
             step[name] = value;
             return { maltsDTO };
-        }, () => {
-            // Nach jeder Statusänderung den aktuellen Formularstatus speichern
-            this.props.saveBeerFormState(this.state);
         });
     }
 
@@ -318,8 +309,6 @@ export class BeerForm extends React.Component<BeerFormProps, BeerFormState> {
             }
 
             return { hopsDTO };
-        }, () => {
-            this.props.saveBeerFormState(this.state);
         });
     }
 
@@ -330,9 +319,6 @@ export class BeerForm extends React.Component<BeerFormProps, BeerFormState> {
             // @ts-ignore
             step[name] = value;
             return { yeastsDTO };
-        }, () => {
-            // Nach jeder Statusänderung den aktuellen Formularstatus speichern
-            this.props.saveBeerFormState(this.state);
         });
     }
 
@@ -379,8 +365,6 @@ export class BeerForm extends React.Component<BeerFormProps, BeerFormState> {
             }
 
             return { additionalIngredientsDTO };
-        }, () => {
-            this.props.saveBeerFormState(this.state);
         });
     }
 
@@ -628,9 +612,6 @@ export class BeerForm extends React.Component<BeerFormProps, BeerFormState> {
                 yeast: false,
                 additional: false,
             },
-        }, () => {
-            // Nach dem Zurücksetzen des Formulars aktualisieren wir den gespeicherten Status
-            this.props.saveBeerFormState(this.state);
         });
     };
 
@@ -665,7 +646,6 @@ export class BeerForm extends React.Component<BeerFormProps, BeerFormState> {
             validationErrors: {},
         }, () => {
             this.updateFermentationStepValidationErrors(this.state.fermentationSteps);
-            this.props.saveBeerFormState(this.state);
         });
     };
 
@@ -794,7 +774,6 @@ export class BeerForm extends React.Component<BeerFormProps, BeerFormState> {
                 isSubmitSuccessful: undefined,
             }, () => {
                 this.updateFermentationStepValidationErrors(this.state.fermentationSteps);
-                this.props.saveBeerFormState(this.state);
             });
         }
     };

--- a/src/containers/MainView/BeerRecipes/Table.test.tsx
+++ b/src/containers/MainView/BeerRecipes/Table.test.tsx
@@ -17,3 +17,19 @@ it('uses the temporary scaled selection when the user starts brewing', () => {
     expect(setBeerToBrew).toHaveBeenCalledWith(plannedBrew);
     expect(storedRecipe.malts[0].quantity).toBe(1000);
 });
+
+it('does not delete the recipe used by an active brewing process', () => {
+    const deleteBeer = jest.fn();
+    const props = {
+        beers: [storedRecipe], selectedBeer: plannedBrew, beerToBrew: plannedBrew,
+        isPollingRunning: true, setBeerToBrew: jest.fn(), setSelectedBeer: jest.fn(),
+        exportShoppingListPdf: jest.fn(), deleteBeer,
+    } as BeerTableProps;
+    const table = new BeerTableComponent(props);
+    table.state.beerPendingDelete = storedRecipe;
+
+    table.confirmDeleteBeer();
+
+    expect(deleteBeer).not.toHaveBeenCalled();
+    expect(table.state.beerPendingDelete).toBe(storedRecipe);
+});

--- a/src/containers/MainView/BeerRecipes/Table.tsx
+++ b/src/containers/MainView/BeerRecipes/Table.tsx
@@ -104,6 +104,8 @@ export class BeerTableComponent extends React.Component<BeerTableProps, BeerTabl
         const {beerPendingDelete} = this.state;
         if (!beerPendingDelete) return;
 
+        if (this.props.isPollingRunning && this.props.beerToBrew?.id === beerPendingDelete.id) return;
+
         this.props.deleteBeer(beerPendingDelete.id);
         this.setState({beerPendingDelete: undefined});
     }
@@ -243,6 +245,7 @@ export class BeerTableComponent extends React.Component<BeerTableProps, BeerTabl
                                                         this.handleDeleteBeer(item);
                                                     }}
                                                     title="Rezept löschen"
+                                                    disabled={Boolean(isPollingRunning && beerToBrew?.id === item.id)}
                                                 >
                                                     <span role="img" aria-label="Rezept löschen" style={{fontSize: '1.4rem', marginTop: '0.3rem'}}>🗑️</span>
                                                 </button>

--- a/src/containers/MainView/FinishBrewsBeers/FinishedBrewsTable.connect.ts
+++ b/src/containers/MainView/FinishBrewsBeers/FinishedBrewsTable.connect.ts
@@ -11,6 +11,7 @@ const mapStateToProps = (state: any) => ({
     finishedBrewUpdateErrors: state.beerDataReducer.finishedBrewUpdateErrors || {},
     isAddingFinishedBrew: Boolean(state.beerDataReducer.isAddingFinishedBrew),
     addFinishedBrewError: state.beerDataReducer.addFinishedBrewError,
+    deletingFinishedBrewIds: state.beerDataReducer.deletingFinishedBrewIds || [],
 });
 
 const mapDispatchToProps = (dispatch: any) => ({

--- a/src/containers/MainView/FinishBrewsBeers/FinishedBrewsTable.tsx
+++ b/src/containers/MainView/FinishBrewsBeers/FinishedBrewsTable.tsx
@@ -8,6 +8,7 @@ import { eBrewState, BrewStateGerman } from '../../../enums/eBrewState';
 import Panel from '../../Panel/Panel';
 import FinishedBrewDetails from './FinishedBrewDetails';
 import {completeFinishedBrew, mergeFinishedBrewChanges} from '../../../utils/finishedBrewChanges';
+import ModalDialog, {DialogType} from '../../../components/ModalDialog/ModalDialog';
 
 
 interface FinishedBrewsTableProps {
@@ -22,6 +23,7 @@ interface FinishedBrewsTableProps {
     finishedBrewUpdateErrors: Record<string, string>;
     isAddingFinishedBrew: boolean;
     addFinishedBrewError?: string;
+    deletingFinishedBrewIds: string[];
 }
 
 interface FinishedBrewsTableState {
@@ -35,6 +37,7 @@ interface FinishedBrewsTableState {
     panelBrewId?: string | null;
     submittingRows: Record<string, boolean>;
     newRowSubmitting: boolean;
+    brewPendingDelete?: FinishedBrew;
 }
 
 const calcAlcohol = (w1: number, w2: number | null) => {
@@ -55,6 +58,9 @@ export class FinishedBrewsTable extends React.Component<FinishedBrewsTableProps,
     }
 
     componentDidUpdate(prevProps: FinishedBrewsTableProps) {
+        if (this.state.brewPendingDelete && prevProps.brews.some(brew => brew.id === this.state.brewPendingDelete?.id) && !this.props.brews.some(brew => brew.id === this.state.brewPendingDelete?.id)) {
+            this.setState({brewPendingDelete: undefined});
+        }
         const completedIds = prevProps.savingFinishedBrewIds.filter(id => !this.props.savingFinishedBrewIds.includes(id));
         const successfulIds = completedIds.filter(id => !this.props.finishedBrewUpdateErrors[id]);
 
@@ -152,7 +158,7 @@ export class FinishedBrewsTable extends React.Component<FinishedBrewsTableProps,
 
     handleFinishClick = (brew: FinishedBrew) => {
         if (this.state.submittingRows[brew.id] || this.props.savingFinishedBrewIds.includes(brew.id)) return;
-        const updated = completeFinishedBrew(brew);
+        const updated = completeFinishedBrew(mergeFinishedBrewChanges(brew, this.state.editRows[brew.id]));
         this.setState(prev => ({
             clickedFinishBtn: { ...prev.clickedFinishBtn, [brew.id]: true },
             submittingRows: {...prev.submittingRows, [brew.id]: true},
@@ -160,8 +166,14 @@ export class FinishedBrewsTable extends React.Component<FinishedBrewsTableProps,
     };
 
     handleDelete = (id: string) => {
-        const { onDelete } = this.props;
-        onDelete(id);
+        if (this.props.deletingFinishedBrewIds.includes(id)) return;
+        this.setState({brewPendingDelete: this.props.brews.find(brew => brew.id === id)});
+    };
+
+    confirmDelete = () => {
+        const brew = this.state.brewPendingDelete;
+        if (!brew || this.props.deletingFinishedBrewIds.includes(brew.id)) return;
+        this.props.onDelete(brew.id);
     };
 
     handleShowDetails = (brewId: string | null) => {
@@ -371,6 +383,7 @@ export class FinishedBrewsTable extends React.Component<FinishedBrewsTableProps,
                             <span role="img" aria-label="Abbrechen" style={{ fontSize: 22, verticalAlign: 'middle',  display: 'inline-block', position: 'relative', top: '3px' }}>✖️</span>
                         </button>
                     </div>
+                    {this.props.finishedBrewUpdateErrors[brewId] && <p role="alert">Speichern fehlgeschlagen: {this.props.finishedBrewUpdateErrors[brewId]}</p>}
                 </TableCell>
             </TableRow>
         );
@@ -552,6 +565,8 @@ export class FinishedBrewsTable extends React.Component<FinishedBrewsTableProps,
         const filteredBrews = this.filterBrewsByYearAndActive(brews, filterYear, showOnlyActive, filterOutActive);
         const selectedBrew = panelBrewId ? brews.find(b => b.id === panelBrewId) : null;
         return (
+            <>
+            <ModalDialog type={DialogType.CONFIRM} open={Boolean(this.state.brewPendingDelete)} header="Sud löschen" content={`Soll ${this.state.brewPendingDelete?.name ?? 'dieser Sud'} endgültig gelöscht werden?`} onConfirm={this.confirmDelete} onCancel={() => this.setState({brewPendingDelete: undefined})} showCancelButton={true} actionsDisabled={Boolean(this.state.brewPendingDelete && this.props.deletingFinishedBrewIds.includes(this.state.brewPendingDelete.id))} />
             <main className="finished-brews-page">
                 {this.renderFilterControls(years)}
                 <div className="finished-brews-table-area">{this.renderTable(filteredBrews, beers)}</div>
@@ -566,6 +581,7 @@ export class FinishedBrewsTable extends React.Component<FinishedBrewsTableProps,
                     </div>
                 )}
             </main>
+            </>
         );
     }
 }

--- a/src/containers/Mobile/MobileActiveFinishedBrewView/MobileActiveFinishedBrewView.connect.ts
+++ b/src/containers/Mobile/MobileActiveFinishedBrewView/MobileActiveFinishedBrewView.connect.ts
@@ -5,7 +5,9 @@ import { BeerActions } from '../../../actions/actions';
 import {MobileActiveFinishedBrewView} from './MobileActiveFinishedBrewView';
 
 const mapStateToProps = (state: any) => ({
-    finishedBrews: state.beerDataReducer?.finishedBrews?.filter((brew: FinishedBrew) => brew.active) || finishedBrewsTestData.filter((brew: FinishedBrew) => brew.active)
+    finishedBrews: state.beerDataReducer?.finishedBrews?.filter((brew: FinishedBrew) => brew.active) || finishedBrewsTestData.filter((brew: FinishedBrew) => brew.active),
+    savingFinishedBrewIds: state.beerDataReducer?.savingFinishedBrewIds || [],
+    finishedBrewUpdateErrors: state.beerDataReducer?.finishedBrewUpdateErrors || {},
 });
 
 const mapDispatchToProps = (dispatch: any) => ({

--- a/src/containers/Mobile/MobileActiveFinishedBrewView/MobileActiveFinishedBrewView.test.tsx
+++ b/src/containers/Mobile/MobileActiveFinishedBrewView/MobileActiveFinishedBrewView.test.tsx
@@ -1,0 +1,34 @@
+import {fireEvent, render, screen} from '@testing-library/react';
+import {eBrewState} from '../../../enums/eBrewState';
+import {FinishedBrew} from '../../../model/FinishedBrew';
+import {MobileActiveFinishedBrewView} from './MobileActiveFinishedBrewView';
+
+const brew: FinishedBrew = {id: 'brew-1', name: 'Test', startDate: '2026-08-27', liters: 10, originalwort: 12, residual_extract: 3, note: '', active: true, state: eBrewState.FERMENTATION};
+
+it('submits numeric mobile fields as numbers and an empty residual extract as null', () => {
+    const saveFinishedBrew = jest.fn();
+    render(<MobileActiveFinishedBrewView finishedBrews={[brew]} saveFinishedBrew={saveFinishedBrew} />);
+    fireEvent.click(screen.getByRole('button', {name: 'Bearbeiten'}));
+    const numberInputs = screen.getAllByRole('spinbutton');
+    fireEvent.change(numberInputs[0], {target: {name: 'originalwort', value: '13.5'}});
+    fireEvent.change(numberInputs[1], {target: {name: 'residual_extract', value: ''}});
+    fireEvent.change(numberInputs[2], {target: {name: 'liters', value: '19.5'}});
+    fireEvent.click(screen.getByRole('button', {name: 'Speichern'}));
+    expect(saveFinishedBrew).toHaveBeenCalledWith(expect.objectContaining({originalwort: 13.5, residual_extract: null, liters: 19.5}));
+});
+
+it('keeps edits open on failure and closes only after updated server data arrives', () => {
+    const saveFinishedBrew = jest.fn();
+    const {rerender} = render(<MobileActiveFinishedBrewView finishedBrews={[brew]} saveFinishedBrew={saveFinishedBrew} savingFinishedBrewIds={[]} finishedBrewUpdateErrors={{}} />);
+    fireEvent.click(screen.getByRole('button', {name: 'Bearbeiten'}));
+    fireEvent.change(screen.getAllByRole('spinbutton')[2], {target: {name: 'liters', value: '20'}});
+    fireEvent.click(screen.getByRole('button', {name: 'Speichern'}));
+    expect(screen.getByRole('button', {name: 'Speichern'})).toBeInTheDocument();
+
+    rerender(<MobileActiveFinishedBrewView finishedBrews={[brew]} saveFinishedBrew={saveFinishedBrew} savingFinishedBrewIds={[]} finishedBrewUpdateErrors={{'brew-1': 'HTTP 500'}} />);
+    expect(screen.getByRole('alert')).toHaveTextContent('HTTP 500');
+    expect(screen.getByDisplayValue('20')).toBeInTheDocument();
+
+    rerender(<MobileActiveFinishedBrewView finishedBrews={[{...brew, liters: 20}]} saveFinishedBrew={saveFinishedBrew} savingFinishedBrewIds={[]} finishedBrewUpdateErrors={{}} />);
+    expect(screen.getByRole('button', {name: 'Bearbeiten'})).toBeInTheDocument();
+});

--- a/src/containers/Mobile/MobileActiveFinishedBrewView/MobileActiveFinishedBrewView.tsx
+++ b/src/containers/Mobile/MobileActiveFinishedBrewView/MobileActiveFinishedBrewView.tsx
@@ -6,6 +6,8 @@ interface Props {
     finishedBrews?: FinishedBrew[];
     getFinishedBrews?: (isFetching: boolean) => void;
     saveFinishedBrew?: (brew: FinishedBrew) => void;
+    savingFinishedBrewIds?: string[];
+    finishedBrewUpdateErrors?: Record<string, string>;
 }
 
 interface State {
@@ -31,10 +33,12 @@ export class MobileActiveFinishedBrewView extends React.Component<Props, State> 
     }
 
     componentDidUpdate(prevProps: Props, prevState: State) {
-        if (prevProps.finishedBrews !== this.props.finishedBrews) {
+        const previousSelectedBrew = prevProps.finishedBrews?.[this.state.currentIndex];
+        const currentSelectedBrew = this.props.finishedBrews?.[this.state.currentIndex];
+        if (previousSelectedBrew !== currentSelectedBrew) {
             this.setState({
-                currentIndex: 0,
-                editedBrew: this.props.finishedBrews && this.props.finishedBrews.length > 0 ? { ...this.props.finishedBrews[0] } : undefined,
+                currentIndex: currentSelectedBrew ? this.state.currentIndex : 0,
+                editedBrew: currentSelectedBrew ? {...currentSelectedBrew} : (this.props.finishedBrews?.[0] ? {...this.props.finishedBrews[0]} : undefined),
                 editMode: false
             });
         }
@@ -52,21 +56,24 @@ export class MobileActiveFinishedBrewView extends React.Component<Props, State> 
 
     handleSave = () => {
         const { editedBrew } = this.state;
-        if (editedBrew) {
+        if (editedBrew && !this.props.savingFinishedBrewIds?.includes(editedBrew.id)) {
             // Redux-Action zum Speichern des Suds
             if (this.props.saveFinishedBrew) {
                 this.props.saveFinishedBrew(editedBrew);
             }
             console.log('Sud gespeichert:', editedBrew);
         }
-        this.setState({ editMode: false });
     };
 
     handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
         const { name, value } = e.target;
+        const numericFields = ['liters', 'originalwort', 'residual_extract'];
+        const parsedValue = numericFields.includes(name)
+            ? (value === '' && name === 'residual_extract' ? null : Number(value))
+            : value;
         this.setState(prevState => ({
             editedBrew: prevState.editedBrew
-                ? { ...prevState.editedBrew, [name]: value }
+                ? { ...prevState.editedBrew, [name]: parsedValue }
                 : undefined
         }));
     };
@@ -224,9 +231,10 @@ export class MobileActiveFinishedBrewView extends React.Component<Props, State> 
                         <div className="mobile-value">{editedBrew.note || '-'}</div>
                     )}
                 </div>
-                <button className="mobile-polling-btn" onClick={editMode ? this.handleSave : this.handleEdit}>
-                    {editMode ? 'Speichern' : 'Bearbeiten'}
+                <button className="mobile-polling-btn" onClick={editMode ? this.handleSave : this.handleEdit} disabled={Boolean(editedBrew && this.props.savingFinishedBrewIds?.includes(editedBrew.id))}>
+                    {editedBrew && this.props.savingFinishedBrewIds?.includes(editedBrew.id) ? 'Speichert …' : (editMode ? 'Speichern' : 'Bearbeiten')}
                 </button>
+                {editedBrew && this.props.finishedBrewUpdateErrors?.[editedBrew.id] && <p role="alert">Speichern fehlgeschlagen: {this.props.finishedBrewUpdateErrors[editedBrew.id]}</p>}
             </div>
         );
     }

--- a/src/containers/Mobile/MobileStatusView/MobileProductionView.connect.ts
+++ b/src/containers/Mobile/MobileStatusView/MobileProductionView.connect.ts
@@ -6,7 +6,10 @@ import {ConfirmStates} from '../../../enums/eConfirmStates';
 const mapStateToProps = (state: any) => ({
     temperature: state.productionReducer.temperature,
     brewingStatus: state.productionReducer.brewingStatus,
-    isPollingRunning: state.productionReducer.isPollingRunning
+    isPollingRunning: state.productionReducer.isPollingRunning,
+    isConfirmPending: state.productionReducer.isConfirmPending,
+    confirmError: state.productionReducer.confirmError,
+    isBrewingStatusStale: state.productionReducer.isBrewingStatusStale
 });
 
 const mapDispatchToProps = (dispatch: any) => ({

--- a/src/containers/Mobile/MobileStatusView/MobileProductionView.test.tsx
+++ b/src/containers/Mobile/MobileStatusView/MobileProductionView.test.tsx
@@ -38,6 +38,8 @@ const renderMobileView = (overrides: Partial<React.ComponentProps<typeof MobileP
         brewingStatus: makeStatus(),
         startPolling: jest.fn(),
         stopPolling: jest.fn(),
+        isConfirmPending: false,
+        isBrewingStatusStale: false,
         isPollingRunning: false,
         confirm: jest.fn(),
         ...overrides,
@@ -91,13 +93,56 @@ describe('MobileProductionView confirmations', () => {
         status.currentStep.mode = ProcessMode.WAITING;
         status.waiting = {waitingFor: WaitingFor.IODINE_TEST, canConfirm: true};
         const confirm = jest.fn();
-        renderMobileView({brewingStatus: status, confirm});
+        const {props, rerender} = renderMobileView({brewingStatus: status, confirm});
 
         fireEvent.click(screen.getByRole('button', {name: 'Jodprobe abgeschlossen'}));
         expect(confirm).toHaveBeenCalledWith(ConfirmStates.IODINE);
+        rerender(
+            <Provider store={configureStore({reducer: rootReducer})}>
+                <MobileProductionView {...props} brewingStatus={status} confirm={confirm} isConfirmPending={true} />
+            </Provider>
+        );
         expect(screen.getByRole('button', {name: 'Wird verarbeitet …'})).toBeDisabled();
+        fireEvent.click(screen.getByRole('button', {name: 'Wird verarbeitet …'}));
+        expect(confirm).toHaveBeenCalledTimes(1);
         expect(screen.getByText('24 °C')).toBeInTheDocument();
         expect(screen.getByText('65 °C')).toBeInTheDocument();
+    });
+
+    it('allows retry with the same waiting state after pending is cleared', () => {
+        const status = makeStatus();
+        status.currentStep.mode = ProcessMode.WAITING;
+        status.waiting = {waitingFor: WaitingFor.IODINE_TEST, canConfirm: true};
+        const confirm = jest.fn();
+        const {props, rerender} = renderMobileView({brewingStatus: status, confirm, isConfirmPending: true});
+
+        expect(screen.getByRole('button', {name: 'Wird verarbeitet …'})).toBeDisabled();
+        rerender(
+            <Provider store={configureStore({reducer: rootReducer})}>
+                <MobileProductionView {...props} brewingStatus={status} confirm={confirm} isConfirmPending={false} />
+            </Provider>
+        );
+        fireEvent.click(screen.getByRole('button', {name: 'Jodprobe abgeschlossen'}));
+        expect(confirm).toHaveBeenCalledWith(ConfirmStates.IODINE);
+    });
+
+    it('shows a confirm failure while keeping retry available', () => {
+        const status = makeStatus();
+        status.currentStep.mode = ProcessMode.WAITING;
+        status.waiting = {waitingFor: WaitingFor.IODINE_TEST, canConfirm: true};
+        renderMobileView({brewingStatus: status, isConfirmPending: false, confirmError: 'Netzwerkfehler'});
+
+        expect(screen.getByRole('alert')).toHaveTextContent('Bestätigung fehlgeschlagen: Netzwerkfehler');
+        expect(screen.getByRole('button', {name: 'Jodprobe abgeschlossen'})).toBeEnabled();
+    });
+});
+
+describe('MobileProductionView stale status', () => {
+    it('does not present stale hardware and temperature values as current', () => {
+        renderMobileView({isBrewingStatusStale: true});
+        expect(screen.getByText('Status veraltet – Controller nicht erreichbar')).toBeInTheDocument();
+        expect(screen.getByText('Unbekannt')).toBeInTheDocument();
+        expect(screen.queryByText('24 °C')).not.toBeInTheDocument();
     });
 });
 

--- a/src/containers/Mobile/MobileStatusView/MobileProductionView.tsx
+++ b/src/containers/Mobile/MobileStatusView/MobileProductionView.tsx
@@ -15,11 +15,13 @@ interface MobileProductionViewProps {
     stopPolling: () => void;
     isPollingRunning: boolean;
     confirm: (confirmState: ConfirmStates) => void;
+    isConfirmPending: boolean;
+    confirmError?: string;
+    isBrewingStatusStale: boolean;
 }
 
 interface MobileProductionViewState {
     activeTab: MobileTab;
-    confirmationPendingFor?: string;
 }
 
 type MobileTab = 'status' | 'finishedBrew' | 'calculations' | 'settings';
@@ -27,7 +29,7 @@ type MobileTab = 'status' | 'finishedBrew' | 'calculations' | 'settings';
 export class MobileProductionView extends React.Component<MobileProductionViewProps, MobileProductionViewState> {
     constructor(props: MobileProductionViewProps) {
         super(props);
-        this.state = { activeTab: 'status', confirmationPendingFor: undefined };
+        this.state = { activeTab: 'status' };
     }
 
     handleTabChange = (tab: MobileTab) => {
@@ -53,16 +55,11 @@ export class MobileProductionView extends React.Component<MobileProductionViewPr
                 navigator.vibrate(200); // 200ms Vibration
             }
         }
-        if (this.state.confirmationPendingFor && (prevProps.brewingStatus?.waiting?.waitingFor !== this.props.brewingStatus?.waiting?.waitingFor
-            || prevProps.brewingStatus?.currentStep?.mode !== this.props.brewingStatus?.currentStep?.mode)) {
-            this.setState({confirmationPendingFor: undefined});
-        }
     }
 
     confirmCurrentWaitingState = () => {
         const request = getConfirmationRequestViewModel(this.props.brewingStatus);
-        if (!request?.canConfirm || !request.confirmState || this.state.confirmationPendingFor) return;
-        this.setState({confirmationPendingFor: String(request.waitingFor)});
+        if (!request?.canConfirm || !request.confirmState || this.props.isConfirmPending) return;
         this.props.confirm(request.confirmState);
     };
 
@@ -97,7 +94,7 @@ export class MobileProductionView extends React.Component<MobileProductionViewPr
     render() {
         const { brewingStatus, startPolling, isPollingRunning } = this.props;
         const { activeTab } = this.state;
-        const statusText = getBrewingStatusLabel(brewingStatus);
+        const statusText = this.props.isBrewingStatusStale ? 'Status veraltet – Controller nicht erreichbar' : getBrewingStatusLabel(brewingStatus);
         const confirmationRequest = getConfirmationRequestViewModel(brewingStatus);
         return (
             <div
@@ -119,11 +116,11 @@ export class MobileProductionView extends React.Component<MobileProductionViewPr
                         <div className="mobile-info-list">
                             <div className="mobile-info-block">
                                 <span className="mobile-label">Temperatur:</span>
-                                <span className="mobile-value">{brewingStatus?.temperature?.current ?? '-'} °C</span>
+                                <span className="mobile-value">{this.props.isBrewingStatusStale ? '-' : (brewingStatus?.temperature?.current ?? '-')} °C</span>
                             </div>
                             <div className="mobile-info-block">
                                 <span className="mobile-label">Zieltemperatur:</span>
-                                <span className="mobile-value">{brewingStatus?.temperature?.target ?? '-'} °C</span>
+                                <span className="mobile-value">{this.props.isBrewingStatusStale ? '-' : (brewingStatus?.temperature?.target ?? '-')} °C</span>
                             </div>
                             <div className="mobile-info-block">
                                 <span className="mobile-label">Typ:</span>
@@ -139,7 +136,7 @@ export class MobileProductionView extends React.Component<MobileProductionViewPr
                             </div>
                             <div className="mobile-info-block">
                                 <span className="mobile-label">Rührwerk:</span>
-                                <span className="mobile-value">{brewingStatus?.hardware?.agitator === 'ON' ? 'An' : 'Aus'}</span>
+                                <span className="mobile-value">{this.props.isBrewingStatusStale ? 'Unbekannt' : (brewingStatus?.hardware?.agitator === 'ON' ? 'An' : 'Aus')}</span>
                             </div>
                             <div className="mobile-info-block">
                                 <span className="mobile-label">Laufzeit:</span>
@@ -156,7 +153,7 @@ export class MobileProductionView extends React.Component<MobileProductionViewPr
                         </div>
                         {confirmationRequest && (
                             <div className="mobile-confirmation-wrapper">
-                                <ControlConfirmationNotice request={confirmationRequest} pending={Boolean(this.state.confirmationPendingFor)} onConfirm={this.confirmCurrentWaitingState} />
+                                <ControlConfirmationNotice request={confirmationRequest} pending={this.props.isConfirmPending} errorMessage={this.props.confirmError} onConfirm={this.confirmCurrentWaitingState} />
                             </div>
                         )}
                         <button className="mobile-polling-btn" onClick={startPolling} disabled={isPollingRunning}>

--- a/src/containers/Production/ProcessList/ProcessList.tsx
+++ b/src/containers/Production/ProcessList/ProcessList.tsx
@@ -57,6 +57,7 @@ export interface ProcessListProps {
     remainingSeconds?: number;
     displayMode?: 'combined' | 'overview' | 'current';
     confirmationPending?: boolean;
+    confirmationError?: string;
     onConfirmWaiting?: () => void;
     hopReminderName?: string;
     onCompleteHopReminder?: () => void;
@@ -290,7 +291,7 @@ export class ProcessList extends React.Component<ProcessListProps, ProcessListSt
             const heldMashTemperature = this.props.brewingStatus?.currentStep?.phase === ProcessPhase.DECOCTION
                 ? this.props.brewingStatus?.temperature?.target ?? this.getRelatedRastTemperature(undefined)
                 : undefined;
-            return <ControlConfirmationNotice request={confirmationRequest} pending={this.props.confirmationPending === true} onConfirm={this.props.onConfirmWaiting} heldMashTemperature={heldMashTemperature} />;
+            return <ControlConfirmationNotice request={confirmationRequest} pending={this.props.confirmationPending === true} onConfirm={this.props.onConfirmWaiting} heldMashTemperature={heldMashTemperature} errorMessage={this.props.confirmationError} />;
         }
         if (this.props.hopReminderName && this.props.onCompleteHopReminder) {
             return <HopReminderNotice hopName={this.props.hopReminderName} onDone={this.props.onCompleteHopReminder} />;

--- a/src/containers/Production/Production.connect.ts
+++ b/src/containers/Production/Production.connect.ts
@@ -55,6 +55,15 @@ const mapStateToProps = (state: RootState) => (
         isBackenAvailable: state.productionReducer.isBackenAvailable,
         waterStatus: state.productionReducer.waterStatus,
         isPollingRunning: state.productionReducer.isPollingRunning,
+        isConfirmPending: state.productionReducer.isConfirmPending,
+        confirmError: state.productionReducer.confirmError,
+        isAddingFinishedBrew: Boolean(state.beerDataReducer.isAddingFinishedBrew),
+        addFinishedBrewError: state.beerDataReducer.addFinishedBrewError,
+        pendingFinishedBrewPayload: state.beerDataReducer.pendingFinishedBrewPayload,
+        isNextProcedureStepPending: state.productionReducer.isNextProcedureStepPending,
+        nextProcedureStepError: state.productionReducer.nextProcedureStepError,
+        isBrewingStatusStale: state.productionReducer.isBrewingStatusStale,
+        brewingStartError: state.productionReducer.brewingStartError,
         debug: state.applicationReducer.debug
 
     });

--- a/src/containers/Production/Production.test.tsx
+++ b/src/containers/Production/Production.test.tsx
@@ -5,6 +5,7 @@ import {Beer} from '../../model/Beer';
 import {ToggleState} from '../../enums/eToggleState';
 import {AlarmType, BrewingStatus, ProcessMode, ProcessPhase, ProcessState, WaitingFor} from '../../model/brewingStatus.types';
 import {ConfirmStates} from '../../enums/eConfirmStates';
+import {dataCollector} from '../../utils/DataCollector/dataCollector';
 
 const createBeer = (aMashVolume: number | undefined = 18, aSpargeVolume: number | undefined = 12, aId: string = '1'): Beer => ({
     id: aId,
@@ -72,15 +73,99 @@ const renderProduction = (aOverrides: Partial<React.ComponentProps<typeof Produc
         isBackenAvailable: {isBackenAvailable: true, statusText: 'OK'},
         waterStatus: {filledLiters: 0, targetLiters: 0, openClose: false},
         addFinishedBrew: jest.fn(),
+        isAddingFinishedBrew: false,
+        addFinishedBrewError: undefined,
+        pendingFinishedBrewPayload: undefined,
         nextProcedureStep: jest.fn(),
+        isNextProcedureStepPending: false,
+        isBrewingStatusStale: false,
         confirm: jest.fn(),
+        isConfirmPending: false,
         debug: true,
         ...aOverrides
     };
     return {props, ...render(<Production {...props} />)};
 };
 
+describe('Production finished-brew persistence', () => {
+    beforeEach(() => dataCollector.reset());
+    afterEach(() => dataCollector.reset());
+
+    const openFinishDialog = (overrides: Partial<React.ComponentProps<typeof Production>> = {}) => {
+        const activeStatus = createBrewingStatus(ProcessState.ACTIVE);
+        const finishedStatus = createBrewingStatus(ProcessState.FINISHED);
+        dataCollector.setBrewingStatus(finishedStatus);
+        const rendered = renderProduction({brewingStatus: activeStatus, ...overrides});
+        rendered.rerender(<Production {...rendered.props} brewingStatus={finishedStatus} />);
+        return {...rendered, finishedStatus};
+    };
+
+    it('keeps the dialog open while saving and completes only after create success', async () => {
+        const addFinishedBrew = jest.fn();
+        const stopPolling = jest.fn();
+        const {props, rerender, finishedStatus} = openFinishDialog({addFinishedBrew, stopPolling});
+
+        fireEvent.click(await screen.findByRole('button', {name: 'Sud speichern'}));
+        fireEvent.click(screen.getByRole('button', {name: 'Sud speichern'}));
+        expect(addFinishedBrew).toHaveBeenCalledTimes(1);
+        const actualPayload = addFinishedBrew.mock.calls[0][0];
+
+        rerender(<Production {...props} brewingStatus={finishedStatus} isAddingFinishedBrew={true} pendingFinishedBrewPayload={actualPayload} />);
+        expect(screen.getByRole('button', {name: 'Speichert …'})).toBeDisabled();
+        expect(stopPolling).not.toHaveBeenCalled();
+        expect(dataCollector.getMeasurementCount()).toBe(1);
+
+        rerender(<Production {...props} brewingStatus={finishedStatus} isAddingFinishedBrew={false} pendingFinishedBrewPayload={undefined} />);
+        await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
+        expect(stopPolling).toHaveBeenCalledTimes(1);
+        expect(dataCollector.getMeasurementCount()).toBe(0);
+    });
+
+    it('preserves payload and measurements after failure and retries the exact payload', async () => {
+        const addFinishedBrew = jest.fn();
+        const {props, rerender, finishedStatus} = openFinishDialog({addFinishedBrew});
+
+        fireEvent.click(screen.getByRole('button', {name: 'Sud speichern'}));
+        const payload = addFinishedBrew.mock.calls[0][0];
+        rerender(<Production {...props} brewingStatus={finishedStatus} isAddingFinishedBrew={true} pendingFinishedBrewPayload={payload} />);
+        rerender(<Production {...props} brewingStatus={finishedStatus} isAddingFinishedBrew={false} addFinishedBrewError="HTTP 500" pendingFinishedBrewPayload={payload} />);
+
+        expect(await screen.findByText(/HTTP 500/)).toBeInTheDocument();
+        expect(dataCollector.getMeasurementCount()).toBe(1);
+        fireEvent.click(screen.getByRole('button', {name: 'Erneut versuchen'}));
+
+        expect(addFinishedBrew).toHaveBeenCalledTimes(2);
+        expect(addFinishedBrew.mock.calls[1][0]).toBe(payload);
+        expect(addFinishedBrew.mock.calls[1][0].brewValues).toBe(payload.brewValues);
+
+        rerender(<Production {...props} brewingStatus={finishedStatus} addFinishedBrew={addFinishedBrew} isAddingFinishedBrew={true} pendingFinishedBrewPayload={payload} />);
+        rerender(<Production {...props} brewingStatus={finishedStatus} addFinishedBrew={addFinishedBrew} isAddingFinishedBrew={false} pendingFinishedBrewPayload={undefined} />);
+        await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
+        expect(dataCollector.getMeasurementCount()).toBe(0);
+    });
+});
+
 describe('Production start button', () => {
+
+    it('starts status polling when the desktop production view is restored', () => {
+        const startPolling = jest.fn();
+        renderProduction({startPolling, isPollingRunning: false});
+        expect(startPolling).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not start a duplicate poller when polling is already active', () => {
+        const startPolling = jest.fn();
+        renderProduction({startPolling, isPollingRunning: true});
+        expect(startPolling).not.toHaveBeenCalled();
+    });
+
+    it('warns about stale controller data and suppresses the stale heater flame', () => {
+        const status = createBrewingStatus(ProcessState.ACTIVE);
+        status.hardware.heater = 'ON';
+        const {container} = renderProduction({brewingStatus: status, isBrewingStatusStale: true});
+        expect(screen.getByRole('alert')).toHaveTextContent('Braustatus ist veraltet');
+        expect(container.querySelector('.flame-strip')).toBeNull();
+    });
 
     it('places the current step above the sole temperature gauge and keeps the process column focused on the upcoming flow', () => {
         const {container} = renderProduction({brewingStatus: createBrewingStatus(ProcessState.IDLE)});
@@ -159,6 +244,7 @@ describe('Production start button', () => {
         const {props, container} = renderProduction({brewingStatus: createBrewingStatus(ProcessState.ACTIVE), isPollingRunning: false});
         const startPollingButton = container.querySelector('.startPollingBtn') as HTMLButtonElement;
 
+        (props.startPolling as jest.Mock).mockClear();
         fireEvent.click(startPollingButton);
 
         expect(props.startPolling).toHaveBeenCalledTimes(1);
@@ -191,13 +277,15 @@ describe('Production inline confirmations', () => {
         [WaitingFor.COOKING_CONFIRMATION, ProcessPhase.COOKING, 'Kochen bestätigen', ConfirmStates.COOKING],
     ] as const)('renders %s inline and dispatches the existing confirm state', (waitingFor, phase, buttonLabel, confirmState) => {
         const confirm = jest.fn();
-        const {container} = renderProduction({brewingStatus: waitingStatus(waitingFor, phase), confirm});
+        const status = waitingStatus(waitingFor, phase);
+        const {container, props, rerender} = renderProduction({brewingStatus: status, confirm});
 
         expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
         expect(screen.getByLabelText('Aktion erforderlich')).toBeInTheDocument();
         expect(container.querySelector('.Temp')).toBeInTheDocument();
         fireEvent.click(screen.getByRole('button', {name: buttonLabel}));
         expect(confirm).toHaveBeenCalledWith(confirmState);
+        rerender(<Production {...props} brewingStatus={status} confirm={confirm} isConfirmPending={true} />);
         expect(screen.getByRole('button', {name: 'Wird verarbeitet …'})).toBeDisabled();
     });
 
@@ -205,6 +293,30 @@ describe('Production inline confirmations', () => {
         renderProduction({brewingStatus: waitingStatus(WaitingFor.USER_CONFIRMATION, ProcessPhase.RAST)});
         expect(screen.getByText('Wartet auf Benutzeraktion')).toBeInTheDocument();
         expect(screen.getByLabelText('Aktion erforderlich').querySelector('button')).toBeNull();
+    });
+
+    it('uses the shared pending state and allows retry when failure clears it', () => {
+        const confirm = jest.fn();
+        const status = waitingStatus(WaitingFor.IODINE_TEST, ProcessPhase.RAST);
+        const {props, rerender} = renderProduction({brewingStatus: status, confirm});
+
+        rerender(<Production {...props} brewingStatus={status} confirm={confirm} isConfirmPending={true} />);
+        expect(screen.getByRole('button', {name: 'Wird verarbeitet …'})).toBeDisabled();
+
+        rerender(<Production {...props} brewingStatus={status} confirm={confirm} isConfirmPending={false} />);
+        fireEvent.click(screen.getByRole('button', {name: 'Jodprobe abgeschlossen'}));
+        expect(confirm).toHaveBeenCalledWith(ConfirmStates.IODINE);
+    });
+
+    it('shows a confirm failure without removing the current waiting action', () => {
+        renderProduction({
+            brewingStatus: waitingStatus(WaitingFor.IODINE_TEST, ProcessPhase.RAST),
+            isConfirmPending: false,
+            confirmError: 'HTTP 500',
+        });
+
+        expect(screen.getByRole('alert')).toHaveTextContent('Bestätigung fehlgeschlagen: HTTP 500');
+        expect(screen.getByRole('button', {name: 'Jodprobe abgeschlossen'})).toBeEnabled();
     });
 
     it('labels the decoction target as the held main-mash rest temperature', () => {
@@ -338,6 +450,17 @@ describe('Production next button', () => {
         expect(nextButton).not.toBeDisabled();
         fireEvent.click(nextButton);
         expect(props.nextProcedureStep).toHaveBeenCalledTimes(1);
+    });
+
+    it('disables the next button while a next-step request is pending', () => {
+        const {props} = renderProduction({
+            brewingStatus: createBrewingStatus(ProcessState.ACTIVE),
+            isNextProcedureStepPending: true,
+        });
+        const nextButton = getNextButton();
+        expect(nextButton).toBeDisabled();
+        fireEvent.click(nextButton);
+        expect(props.nextProcedureStep).not.toHaveBeenCalled();
     });
 
     it('disables the next button while the controller is offline and does not dispatch next', () => {

--- a/src/containers/Production/Production.tsx
+++ b/src/containers/Production/Production.tsx
@@ -60,9 +60,18 @@ export interface ProductionProps {
     isBackenAvailable: BackendAvailable | boolean;
     waterStatus: WaterStatus;
     addFinishedBrew: (finishedBrew: FinishedBrewCreatePayload) => void;
+    isAddingFinishedBrew: boolean;
+    addFinishedBrewError?: string;
+    pendingFinishedBrewPayload?: FinishedBrewCreatePayload;
     nextProcedureStep: () => void;
+    isNextProcedureStepPending: boolean;
+    nextProcedureStepError?: string;
+    isBrewingStatusStale: boolean;
+    brewingStartError?: string;
     isPollingRunning: boolean;
     confirm: (confirmState: ConfirmStates) => void;
+    isConfirmPending: boolean;
+    confirmError?: string;
     debug: boolean;
 }
 
@@ -91,11 +100,11 @@ interface ProductionState {
     recipeWaterFill: RecipeWaterFillStatus;
     displayedRemainingSeconds: number | undefined;
     equipmentAlarmDismissed: boolean;
-    confirmationPendingFor?: string;
 }
 
 export class Production extends React.Component<ProductionProps, ProductionState> {
     private isBrewingStartRequestPending = false;
+    private isFinishedBrewSaveRequestPending = false;
     private readonly MAX_AGITATOR_SPEED = 40;
     private readonly MAX_WATER_LEVEL = 70;
     private readonly MAX_BREAK_TIME = 10;
@@ -130,18 +139,20 @@ export class Production extends React.Component<ProductionProps, ProductionState
             announcedHopTimes: [],
             recipeWaterFill: createInitialRecipeWaterFillStatus(),
             displayedRemainingSeconds: undefined,
-            equipmentAlarmDismissed: false,
-            confirmationPendingFor: undefined
+            equipmentAlarmDismissed: false
         }
     }
 
     componentDidMount() {
         this.isMountedComponent = true;
-        const {getTemperatures, selectedBeer} = this.props;
+        const {getTemperatures, selectedBeer, isPollingRunning, startPolling} = this.props;
         if (!isUndefined(selectedBeer)) {
             this.calculateTheHopTimes();
         }
         getTemperatures();
+        if (!isPollingRunning) {
+            startPolling();
+        }
         this.syncRemainingTimeFromStatus();
         this.remainingTimeInterval = setInterval(this.tickRemainingTime, 1000);
     }
@@ -164,12 +175,6 @@ export class Production extends React.Component<ProductionProps, ProductionState
 
         if (prevProps.brewingStatus !== brewingStatus) {
             this.syncRemainingTimeFromStatus();
-        }
-
-        const previousWaitingFor = prevProps.brewingStatus?.waiting?.waitingFor;
-        const currentWaitingFor = brewingStatus?.waiting?.waitingFor;
-        if (this.state.confirmationPendingFor && (currentWaitingFor !== previousWaitingFor || brewingStatus?.currentStep?.mode !== prevProps.brewingStatus?.currentStep?.mode)) {
-            this.setState({confirmationPendingFor: undefined});
         }
 
         if (isEquipmentAlarmActive(prevProps.brewingStatus) && !isEquipmentAlarmActive(brewingStatus)) {
@@ -240,6 +245,18 @@ export class Production extends React.Component<ProductionProps, ProductionState
         if (brewingStatus?.process?.state === ProcessState.FINISHED && !showFinishDialog && !this.state.brewingFinished)
         {
             this.setState({showFinishDialog: true})
+        }
+
+        const aFinishedBrewSaveCompleted = prevProps.isAddingFinishedBrew && !this.props.isAddingFinishedBrew;
+        if (aFinishedBrewSaveCompleted && prevProps.pendingFinishedBrewPayload) {
+            this.isFinishedBrewSaveRequestPending = false;
+            if (this.props.addFinishedBrewError) {
+                this.setState({showFinishDialog: true, brewingFinished: false});
+            } else {
+                dataCollector.reset();
+                this.props.stopPolling();
+                this.setState({showFinishDialog: false, brewingFinished: true});
+            }
         }
 
     }
@@ -523,7 +540,7 @@ export class Production extends React.Component<ProductionProps, ProductionState
     }
 
     isNextProcedureStepAvailable = (): boolean => {
-        return this.isControllerAvailable() && isBrewingProcessActive(this.props.brewingStatus);
+        return this.isControllerAvailable() && isBrewingProcessActive(this.props.brewingStatus) && !this.props.isNextProcedureStepPending;
     }
 
     handleNextProcedureStep = (): void => {
@@ -542,7 +559,7 @@ export class Production extends React.Component<ProductionProps, ProductionState
 
         return (
             <div className='Flame'>
-              {isHeaterActive(brewingStatus) && (
+              {!this.props.isBrewingStatusStale && isHeaterActive(brewingStatus) && (
                     <div className="flame-strip" aria-label="Heizung aktiv">
                         <Flame/>
                         <Flame/>
@@ -569,7 +586,9 @@ export class Production extends React.Component<ProductionProps, ProductionState
     renderTemperature() {
         const {brewingStatus, temperature} = this.props;
         let value: number;
-        if (brewingStatus?.temperature?.current === undefined || Number(brewingStatus?.temperature?.current) === 0) {
+        if (this.props.isBrewingStatusStale) {
+            value = 0;
+        } else if (brewingStatus?.temperature?.current === undefined || Number(brewingStatus?.temperature?.current) === 0) {
             value = temperature;
         } else {
             value = isNaN(Number(brewingStatus?.temperature?.current)) ? 0 : Number(brewingStatus?.temperature?.current);
@@ -696,21 +715,19 @@ export class Production extends React.Component<ProductionProps, ProductionState
 
     confirmCurrentWaitingState = () => {
         const request = getConfirmationRequestViewModel(this.props.brewingStatus);
-        if (!request?.canConfirm || !request.confirmState || this.state.confirmationPendingFor) return;
-        this.setState({confirmationPendingFor: String(request.waitingFor)});
+        if (!request?.canConfirm || !request.confirmState || this.props.isConfirmPending) return;
         this.props.confirm(request.confirmState);
     }
 
 
     confirmFinishDialog = async () => {
-        const { stopPolling, selectedBeer, addFinishedBrew } = this.props;
-        this.setState({ showFinishDialog: false, brewingFinished: true });
-        stopPolling();
-        // Messdaten als Blob holen
-        const jsonString = dataCollector.getAllDataAsJSONString();
-        // FinishedBrew erzeugen und speichern
-        if (selectedBeer) {
-            const finishedBrew : FinishedBrewCreatePayload = {
+        const {selectedBeer, addFinishedBrew, isAddingFinishedBrew, pendingFinishedBrewPayload} = this.props;
+        if (!selectedBeer || isAddingFinishedBrew || this.isFinishedBrewSaveRequestPending) {
+            return;
+        }
+
+        this.isFinishedBrewSaveRequestPending = true;
+        const finishedBrew = pendingFinishedBrewPayload ?? {
                 name: selectedBeer.name || 'Unknown Beer',
                 liters: 0,
                 originalwort:  0,
@@ -720,17 +737,16 @@ export class Production extends React.Component<ProductionProps, ProductionState
                 beer_id: selectedBeer.id.toString(), // Assuming beer_id is a string
                 active: true,
                 state: eBrewState.FERMENTATION,
-                brewValues: jsonString // Attach measurement data
+                brewValues: dataCollector.getAllDataAsJSONString()
             };
-            addFinishedBrew(finishedBrew);
-        }
+        addFinishedBrew(finishedBrew);
     };
     renderProcessList() {
         const { selectedBeer, brewingStatus } = this.props;
         if (selectedBeer === undefined) {
             return null;
         }
-        const isNextStepDisabled = !this.isControllerAvailable() || !this.isNextProcedureStepAvailable();
+        const isNextStepDisabled = !this.isNextProcedureStepAvailable();
         return (
             <ProcessList displayMode="overview" selectedBeer={selectedBeer} currentStepIndex={brewingStatus?.currentStep?.index ?? 0} currentStep={brewingStatus?.currentStep} brewingStatus={brewingStatus} remainingSeconds={this.state.displayedRemainingSeconds} onNextStep={this.props.debug ? this.handleNextProcedureStep : undefined} isNextStepDisabled={isNextStepDisabled} />
         );
@@ -741,7 +757,7 @@ export class Production extends React.Component<ProductionProps, ProductionState
         if (selectedBeer === undefined) {
             return null;
         }
-        return <ProcessList displayMode="current" selectedBeer={selectedBeer} currentStepIndex={brewingStatus?.currentStep?.index ?? 0} currentStep={brewingStatus?.currentStep} brewingStatus={brewingStatus} remainingSeconds={this.state.displayedRemainingSeconds} confirmationPending={Boolean(this.state.confirmationPendingFor)} onConfirmWaiting={this.confirmCurrentWaitingState} hopReminderName={this.state.showHopsDialog ? this.state.hopName : undefined} onCompleteHopReminder={this.confirmHopDialog} />;
+        return <ProcessList displayMode="current" selectedBeer={selectedBeer} currentStepIndex={brewingStatus?.currentStep?.index ?? 0} currentStep={brewingStatus?.currentStep} brewingStatus={brewingStatus} remainingSeconds={this.state.displayedRemainingSeconds} confirmationPending={this.props.isConfirmPending} confirmationError={this.props.confirmError} onConfirmWaiting={this.confirmCurrentWaitingState} hopReminderName={this.state.showHopsDialog ? this.state.hopName : undefined} onCompleteHopReminder={this.confirmHopDialog} />;
     }
 
 
@@ -750,9 +766,13 @@ export class Production extends React.Component<ProductionProps, ProductionState
         const equipmentAlarmActive = isEquipmentAlarmActive(this.props.brewingStatus);
         return (
             <div className="containerProduction ">
+                {this.props.isBrewingStatusStale && <div role="alert" className="production-stale-status">Controller nicht erreichbar – angezeigter Braustatus ist veraltet.</div>}
+                {this.props.brewingStartError && <div role="alert">Braustart fehlgeschlagen: {this.props.brewingStartError}</div>}
                 <ProductionDialogs
                     showFinishDialog={showFinishDialog}
                     onConfirmFinish={this.confirmFinishDialog}
+                    isSavingFinishedBrew={this.props.isAddingFinishedBrew}
+                    finishedBrewSaveError={this.props.addFinishedBrewError}
                     showEquipmentAlarmDialog={equipmentAlarmActive && !this.state.equipmentAlarmDismissed}
                     equipmentAlarmTitle={equipmentAlarmDisplay.title}
                     equipmentAlarmMessage={equipmentAlarmDisplay.message}

--- a/src/containers/Production/components/InlineProcessNotice.tsx
+++ b/src/containers/Production/components/InlineProcessNotice.tsx
@@ -8,6 +8,7 @@ interface ControlConfirmationNoticeProps {
     pending: boolean;
     onConfirm?: () => void;
     heldMashTemperature?: number;
+    errorMessage?: string;
 }
 
 const compactCopyByWaitingState: Partial<Record<WaitingFor, {title: string; buttonLabel?: string}>> = {
@@ -19,7 +20,7 @@ const compactCopyByWaitingState: Partial<Record<WaitingFor, {title: string; butt
     [WaitingFor.BOILING_CONFIRMATION]: {title: 'Siedepunkt bestätigen', buttonLabel: 'Siedepunkt erreicht'},
 };
 
-export const ControlConfirmationNotice: React.FC<ControlConfirmationNoticeProps> = ({request, pending, onConfirm, heldMashTemperature}) => (
+export const ControlConfirmationNotice: React.FC<ControlConfirmationNoticeProps> = ({request, pending, onConfirm, heldMashTemperature, errorMessage}) => (
     <section className="inline-process-notice inline-process-notice--action" aria-label="Aktion erforderlich" aria-live="polite">
         <div className="inline-process-notice__content">
             <div className="inline-process-notice__heading">
@@ -38,6 +39,7 @@ export const ControlConfirmationNotice: React.FC<ControlConfirmationNoticeProps>
                 <p className="inline-process-notice__detail">Hauptmaische wird weiterhin auf {heldMashTemperature.toLocaleString('de-DE', {maximumFractionDigits: 1})} °C gehalten.</p>
             )}
             {!request.canConfirm && <p className="inline-process-notice__detail">{request.message}</p>}
+            {errorMessage && <p className="inline-process-notice__detail" role="alert">Bestätigung fehlgeschlagen: {errorMessage}</p>}
         </div>
     </section>
 );

--- a/src/containers/Production/components/ProductionDialogs.tsx
+++ b/src/containers/Production/components/ProductionDialogs.tsx
@@ -4,6 +4,8 @@ import ModalDialog, {DialogType} from '../../../components/ModalDialog/ModalDial
 export interface ProductionDialogsProps {
     showFinishDialog: boolean;
     onConfirmFinish: () => void;
+    isSavingFinishedBrew: boolean;
+    finishedBrewSaveError?: string;
     showEquipmentAlarmDialog: boolean;
     equipmentAlarmTitle: string;
     equipmentAlarmMessage: string;
@@ -12,11 +14,20 @@ export interface ProductionDialogsProps {
 
 export class ProductionDialogs extends React.Component<ProductionDialogsProps> {
     render(): React.ReactNode {
-        const {showFinishDialog, onConfirmFinish,
+        const {showFinishDialog, onConfirmFinish, isSavingFinishedBrew, finishedBrewSaveError,
             showEquipmentAlarmDialog, equipmentAlarmTitle, equipmentAlarmMessage, onDismissEquipmentAlarm} = this.props;
         return (
             <>
-                <ModalDialog onConfirm={onConfirmFinish} type={DialogType.INFO} open={showFinishDialog} content="Das Bier ist fertig!" header="Fertig!" />
+                <ModalDialog
+                    onConfirm={onConfirmFinish}
+                    type={finishedBrewSaveError ? DialogType.ERROR : DialogType.INFO}
+                    open={showFinishDialog}
+                    content={finishedBrewSaveError ? `Der Sud konnte nicht gespeichert werden: ${finishedBrewSaveError}` : (isSavingFinishedBrew ? 'Der fertige Sud wird gespeichert …' : 'Das Bier ist fertig!')}
+                    header={finishedBrewSaveError ? 'Speichern fehlgeschlagen' : 'Fertig!'}
+                    confirmLabel={finishedBrewSaveError ? 'Erneut versuchen' : (isSavingFinishedBrew ? 'Speichert …' : 'Sud speichern')}
+                    actionsDisabled={isSavingFinishedBrew}
+                    disableClose={isSavingFinishedBrew}
+                />
                 <ModalDialog
                     onConfirm={onDismissEquipmentAlarm}
                     type={DialogType.ERROR}

--- a/src/containers/index.connect.ts
+++ b/src/containers/index.connect.ts
@@ -15,6 +15,9 @@ const mapDispatchToProps = (dispatch: any) => ({
 
     webSocketConnect: () => {
         dispatch(ProductionActions.webSocketConnect());
+    },
+    webSocketDisconnect: () => {
+        dispatch(ProductionActions.webSocketDisconnect());
     }
 
 

--- a/src/containers/index.test.tsx
+++ b/src/containers/index.test.tsx
@@ -28,17 +28,26 @@ const makeStatus = (overrides: Partial<BrewingStatus> = {}): BrewingStatus => ({
     ...overrides,
 });
 
-const renderIndex = (brewingStatus: BrewingStatus, viewState = Views.VERSION) => {
+const renderIndex = (brewingStatus: BrewingStatus, viewState = Views.VERSION, lifecycle = {connect: jest.fn(), disconnect: jest.fn()}) => {
     const result = render(
         <Index
             viewState={viewState}
             brewingStatus={brewingStatus}
             checkIsBackenAvailable={jest.fn()}
-            webSocketConnect={jest.fn()}
+            webSocketConnect={lifecycle.connect}
+            webSocketDisconnect={lifecycle.disconnect}
         />
     );
     return result;
 };
+
+it('connects overheat events for the app lifetime and disconnects on unmount', () => {
+    const lifecycle = {connect: jest.fn(), disconnect: jest.fn()};
+    const rendered = renderIndex(makeStatus(), Views.VERSION, lifecycle);
+    expect(lifecycle.connect).toHaveBeenCalledTimes(1);
+    rendered.unmount();
+    expect(lifecycle.disconnect).toHaveBeenCalledTimes(1);
+});
 
 describe('Index view routing', () => {
     it('points the dashboard view to the dashboard page', (): void => {

--- a/src/containers/index.tsx
+++ b/src/containers/index.tsx
@@ -20,12 +20,18 @@ interface indexMainProps {
     brewingStatus: BrewingStatus;
     checkIsBackenAvailable : () => void;
     webSocketConnect: () => void;
+    webSocketDisconnect: () => void;
 }
 
 export class Index extends React.Component<indexMainProps> {
     componentDidMount() {
-        const {checkIsBackenAvailable} = this.props;
+        const {checkIsBackenAvailable, webSocketConnect} = this.props;
         checkIsBackenAvailable();
+        webSocketConnect();
+    }
+
+    componentWillUnmount() {
+        this.props.webSocketDisconnect();
     }
 
     componentDidUpdate(prevProps: Readonly<indexMainProps>, prevState: Readonly<{}>, snapshot?: any) {

--- a/src/epics/beerCreateEpic.test.ts
+++ b/src/epics/beerCreateEpic.test.ts
@@ -1,0 +1,70 @@
+import {Subject} from 'rxjs';
+import {BeerActions} from '../actions/actions';
+import {eBrewState} from '../enums/eBrewState';
+import {FinishedBrew, FinishedBrewCreatePayload} from '../model/FinishedBrew';
+import {FinishedBeerRepository} from '../repositorys/FinishedBeerRepository';
+import {sendNewFinishedBeerEpic} from './beerEpics';
+
+jest.mock('../repositorys/FinishedBeerRepository', () => ({
+    FinishedBeerRepository: {sendNewFinishedBeer: jest.fn()},
+}));
+
+const repository = FinishedBeerRepository as jest.Mocked<typeof FinishedBeerRepository>;
+const payload: FinishedBrewCreatePayload = {
+    name: 'Testbier', startDate: '2026-08-27', liters: 0, originalwort: 0,
+    residual_extract: 0, note: '', active: true, beer_id: 'recipe-1',
+    state: eBrewState.FERMENTATION, brewValues: '{"groupedData":{"FINISHED":[1]}}',
+};
+
+const deferred = <T,>() => {
+    let resolve!: (value: T) => void;
+    let reject!: (error: Error) => void;
+    const promise = new Promise<T>((aResolve, aReject) => { resolve = aResolve; reject = aReject; });
+    return {promise, resolve, reject};
+};
+
+const flush = async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+};
+
+describe('sendNewFinishedBeerEpic', () => {
+    beforeEach(() => jest.clearAllMocks());
+
+    it('allows only one create while a request is running', async () => {
+        const request = deferred<FinishedBrew>();
+        repository.sendNewFinishedBeer.mockReturnValue(request.promise);
+        const action$ = new Subject<BeerActions.AddFinishedBrew>();
+        const subscription = sendNewFinishedBeerEpic(action$).subscribe();
+
+        action$.next(BeerActions.addFinishedBrew(payload));
+        action$.next(BeerActions.addFinishedBrew(payload));
+        expect(repository.sendNewFinishedBeer).toHaveBeenCalledTimes(1);
+        expect(repository.sendNewFinishedBeer).toHaveBeenCalledWith(payload);
+
+        request.resolve({...payload, id: 'brew-1'});
+        await flush();
+        subscription.unsubscribe();
+    });
+
+    it('emits failure, then retries with the same payload', async () => {
+        repository.sendNewFinishedBeer
+            .mockRejectedValueOnce(new Error('network error'))
+            .mockResolvedValueOnce({...payload, id: 'brew-1'});
+        const action$ = new Subject<BeerActions.AddFinishedBrew>();
+        const emitted: BeerActions.AllBeerActions[] = [];
+        const subscription = sendNewFinishedBeerEpic(action$).subscribe(action => emitted.push(action as BeerActions.AllBeerActions));
+
+        action$.next(BeerActions.addFinishedBrew(payload));
+        await flush();
+        action$.next(BeerActions.addFinishedBrew(payload));
+        await flush();
+
+        expect(repository.sendNewFinishedBeer).toHaveBeenNthCalledWith(1, payload);
+        expect(repository.sendNewFinishedBeer).toHaveBeenNthCalledWith(2, payload);
+        expect(emitted).toContainEqual(BeerActions.addFinishedBrewFailure('network error'));
+        expect(emitted).toContainEqual(BeerActions.addFinishedBrewSuccess({...payload, id: 'brew-1'}));
+        subscription.unsubscribe();
+    });
+});

--- a/src/epics/beerEpics.ts
+++ b/src/epics/beerEpics.ts
@@ -1,6 +1,6 @@
 import { ofType } from 'redux-observable';
 import {of, from} from 'rxjs';
-import { catchError, exhaustMap, map, mergeMap } from 'rxjs/operators';
+import { catchError, exhaustMap, groupBy, map, mergeMap, switchMap } from 'rxjs/operators';
 import {ApplicationActions, BeerActions} from '../actions/actions';
 import { BeerRepository } from '../repositorys/BeerRepository';
 import {Beer} from "../model/Beer";
@@ -10,7 +10,6 @@ import { FinishedBrewListPdfStrategy } from '../utils/pdf/finishedBrewStrategy';
 import {PdfGenerator} from "../utils/pdf/PdfGenerator";
 import { BeerPdfStrategy } from '../utils/pdf/shoppingListPdfStrategy';
 import {FinishedBeerRepository} from "../repositorys/FinishedBeerRepository";
-import {dataCollector} from "../utils/DataCollector/dataCollector";
 import {getRecipeImportErrorMessage} from '../utils/recipeImport';
 
 /**
@@ -20,10 +19,11 @@ import {getRecipeImportErrorMessage} from '../utils/recipeImport';
 export const getBeersEpic = (action$: any) =>
     action$.pipe(
         ofType(BeerActions.ActionTypes.GET_BEERS),
-        mergeMap(() =>
+        switchMap(() =>
             from(BeerRepository.getBeers()).pipe(map((beers: Beer[]) =>BeerActions.getBeersSuccess(beers)),
                 catchError((aError: Error) =>
                     from([
+                        BeerActions.getBeersFailure(),
                         ApplicationActions.openErrorDialog(
                             true,
                             "Bier fehler",
@@ -38,10 +38,11 @@ export const getBeersEpic = (action$: any) =>
 export const getFinishedBeersEpic = (action$: any) =>
     action$.pipe(
         ofType(BeerActions.ActionTypes.GET_FINISHED_BEERS),
-        mergeMap(() =>
+        switchMap(() =>
         from(FinishedBeerRepository.getFinishedBeers()).pipe(
             map((finishedBeers: FinishedBrew[]) => BeerActions.getFinishedBeersSuccess(finishedBeers)),
             catchError((aError) => from([
+                BeerActions.getFinishedBeersFailure(),
                 ApplicationActions.openErrorDialog(
                     true,
                     "Bier fehler",
@@ -83,11 +84,13 @@ export const submitBeerEpic = (aAction$: any) =>
 export const deleteFinishedBeerEpic = (action$: any) =>
   action$.pipe(
     ofType(BeerActions.ActionTypes.DELETE_FINISHED_BEER),
-    mergeMap((action: any) =>
+    groupBy((action: any) => action.payload.finishedBrewId),
+    mergeMap(actionsForBrew$ => actionsForBrew$.pipe(exhaustMap((action: any) =>
       from(FinishedBeerRepository.deleteFinishedBeer(action.payload.finishedBrewId)).pipe(
         map(() => BeerActions.deleteFinishedBeerSuccess(true, action.payload.finishedBrewId)),
           catchError((aError: Error) =>
               from([
+                  BeerActions.deleteFinishedBeerFailure(action.payload.finishedBrewId, aError.message),
                   ApplicationActions.openErrorDialog(
                       true,
                       "Fertige Bier fehler",
@@ -95,39 +98,34 @@ export const deleteFinishedBeerEpic = (action$: any) =>
                   )
               ])
           )
-      )
-    )
+      ))
+    ))
   );
 
 export const updateFinishedBeerEpic = (action$: any) =>
   action$.pipe(
     ofType(BeerActions.ActionTypes.UPDATE_ACTIVE_BEER),
-    mergeMap((action: any) =>
-      from(FinishedBeerRepository.updateFinishedBeer(action.payload.beer)).pipe(
-        map((beer) => BeerActions.updateFinishedBrewSuccess({...action.payload.beer, ...beer}, action.payload.beer.id)),
-        catchError((aError: Error) =>  from([
-            BeerActions.updateFinishedBrewFailure(action.payload.beer.id, aError.message),
-            ApplicationActions.openErrorDialog(
-                true,
-                "Bier fehler",
-                "Submit Bier: " + aError.message
-            )
-        ])
+    groupBy((action: any) => action.payload.beer.id),
+    mergeMap((actionsForBrew$) => actionsForBrew$.pipe(
+      exhaustMap((action: any) =>
+        from(FinishedBeerRepository.updateFinishedBeer(action.payload.beer)).pipe(
+          map((beer) => BeerActions.updateFinishedBrewSuccess({...action.payload.beer, ...beer}, action.payload.beer.id)),
+          catchError((aError: Error) => from([
+              BeerActions.updateFinishedBrewFailure(action.payload.beer.id, aError.message),
+              ApplicationActions.openErrorDialog(true, "Bier fehler", "Submit Bier: " + aError.message)
+          ]))
+        )
       )
-    )
-  )
+    ))
   )
 ;
 
 export const sendNewFinishedBeerEpic = (action$: any) =>
   action$.pipe(
     ofType(BeerActions.ActionTypes.ADD_FINISHED_BREW),
-    mergeMap((action: any) =>
+    exhaustMap((action: any) =>
       from(FinishedBeerRepository.sendNewFinishedBeer(action.payload.finishedBrew)).pipe(
-        map((beer) => {
-          dataCollector.reset();
-          return BeerActions.addFinishedBrewSuccess({...action.payload.finishedBrew, ...beer});
-        }),
+        map((beer) => BeerActions.addFinishedBrewSuccess({...action.payload.finishedBrew, ...beer})),
         catchError((aError: Error) =>  from([
             BeerActions.addFinishedBrewFailure(aError.message),
             ApplicationActions.openErrorDialog(

--- a/src/epics/beerFetchEpic.test.ts
+++ b/src/epics/beerFetchEpic.test.ts
@@ -1,0 +1,26 @@
+import {Subject} from 'rxjs';
+import {BeerActions} from '../actions/actions';
+import {Beer} from '../model/Beer';
+import {BeerRepository} from '../repositorys/BeerRepository';
+import {getBeersEpic} from './beerEpics';
+
+jest.mock('../repositorys/BeerRepository', () => ({BeerRepository: {getBeers: jest.fn()}}));
+const repository = BeerRepository as jest.Mocked<typeof BeerRepository>;
+const deferred = () => { let resolve!: (beers: Beer[]) => void; const promise = new Promise<Beer[]>(r => {resolve = r;}); return {promise, resolve}; };
+
+it('emits only the newest recipe response when refresh requests overlap', async () => {
+    const oldRequest = deferred();
+    const newRequest = deferred();
+    repository.getBeers.mockReturnValueOnce(oldRequest.promise).mockReturnValueOnce(newRequest.promise);
+    const action$ = new Subject<BeerActions.GetBeers>();
+    const emitted: BeerActions.AllBeerActions[] = [];
+    const subscription = getBeersEpic(action$).subscribe(action => emitted.push(action as BeerActions.AllBeerActions));
+    action$.next(BeerActions.getBeers(true));
+    action$.next(BeerActions.getBeers(true));
+    newRequest.resolve([{id: 'new'} as Beer]);
+    await Promise.resolve(); await Promise.resolve();
+    oldRequest.resolve([{id: 'old'} as Beer]);
+    await Promise.resolve(); await Promise.resolve();
+    expect(emitted).toEqual([BeerActions.getBeersSuccess([{id: 'new'} as Beer])]);
+    subscription.unsubscribe();
+});

--- a/src/epics/finishedBrewUpdateEpic.test.ts
+++ b/src/epics/finishedBrewUpdateEpic.test.ts
@@ -1,0 +1,25 @@
+import {Subject} from 'rxjs';
+import {BeerActions} from '../actions/actions';
+import {eBrewState} from '../enums/eBrewState';
+import {FinishedBrew} from '../model/FinishedBrew';
+import {FinishedBeerRepository} from '../repositorys/FinishedBeerRepository';
+import {updateFinishedBeerEpic} from './beerEpics';
+
+jest.mock('../repositorys/FinishedBeerRepository', () => ({FinishedBeerRepository: {updateFinishedBeer: jest.fn()}}));
+const repository = FinishedBeerRepository as jest.Mocked<typeof FinishedBeerRepository>;
+const brew = (id: string, note: string): FinishedBrew => ({id, name: id, startDate: '2026-08-27', liters: 10, originalwort: 12, residual_extract: 3, note, active: true, state: eBrewState.FERMENTATION});
+
+describe('updateFinishedBeerEpic', () => {
+  it('serializes updates per id while allowing different ids', () => {
+    repository.updateFinishedBeer.mockReturnValue(new Promise(() => undefined));
+    const action$ = new Subject<BeerActions.UpdateActiveBeer>();
+    const subscription = updateFinishedBeerEpic(action$).subscribe();
+    action$.next(BeerActions.updateActiveBeer(brew('A', 'first')));
+    action$.next(BeerActions.updateActiveBeer(brew('A', 'stale')));
+    action$.next(BeerActions.updateActiveBeer(brew('B', 'other')));
+    expect(repository.updateFinishedBeer).toHaveBeenCalledTimes(2);
+    expect(repository.updateFinishedBeer).toHaveBeenNthCalledWith(1, brew('A', 'first'));
+    expect(repository.updateFinishedBeer).toHaveBeenNthCalledWith(2, brew('B', 'other'));
+    subscription.unsubscribe();
+  });
+});

--- a/src/epics/productionEpics.test.ts
+++ b/src/epics/productionEpics.test.ts
@@ -1,10 +1,11 @@
 import { Subject } from 'rxjs';
 import { ProductionActions } from '../actions/actions';
-import { BREWING_STATUS_REQUEST_TIMEOUT, sendBrewingDataEpic$, startPollingEpic$, startWaterFillingEpic$, WATER_FILLING_MAX_DURATION, WATER_STATUS_REQUEST_TIMEOUT } from './productionEpics';
+import { BREWING_STATUS_REQUEST_TIMEOUT, confirmEpic$, mapControlSocketEvent, nextProcedureStepEpic$, sendBrewingDataEpic$, startPollingEpic$, startWaterFillingEpic$, WATER_FILLING_MAX_DURATION, WATER_STATUS_REQUEST_TIMEOUT } from './productionEpics';
 import { ProductionRepository } from '../repositorys/ProductionRepository';
 import {BackendAvailable} from '../reducers/productionReducer';
 import {BrewingData} from '../model/BrewingData';
 import {BrewingStatus, ProcessMode, ProcessPhase, ProcessState, WaitingFor} from '../model/brewingStatus.types';
+import {ConfirmStates} from '../enums/eConfirmStates';
 
 jest.mock('../repositorys/ProductionRepository', () => ({
   ProductionRepository: {
@@ -13,6 +14,8 @@ jest.mock('../repositorys/ProductionRepository', () => ({
     sendBrewingData: jest.fn(),
     startBrewing: jest.fn(),
     getBrewingStatus: jest.fn(),
+    confirm: jest.fn(),
+    nextProcedureStep: jest.fn(),
   },
 }));
 
@@ -68,6 +71,100 @@ const createBrewingData = (): BrewingData => ({
   CookingTemperature: 99,
   CookingTime: 60,
   Rasten: [],
+});
+
+describe('confirmEpic$', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('emits success after a successful confirm request', async () => {
+    mockedProductionRepository.confirm.mockResolvedValue(undefined);
+    const action$ = new Subject<ProductionActions.Confirm>();
+    const emitted: any[] = [];
+    const subscription = confirmEpic$(action$).subscribe((action: any) => emitted.push(action));
+
+    action$.next(ProductionActions.confirm(ConfirmStates.IODINE));
+    await flushPromises();
+
+    expect(emitted).toEqual([ProductionActions.confirmSuccess()]);
+    subscription.unsubscribe();
+  });
+
+  it('emits failure and a visible error when the request fails', async () => {
+    mockedProductionRepository.confirm.mockRejectedValue(new Error('HTTP 500'));
+    const action$ = new Subject<ProductionActions.Confirm>();
+    const emitted: any[] = [];
+    const subscription = confirmEpic$(action$).subscribe((action: any) => emitted.push(action));
+
+    action$.next(ProductionActions.confirm(ConfirmStates.IODINE));
+    await flushPromises();
+
+    expect(emitted[0]).toEqual(ProductionActions.confirmFailure('HTTP 500'));
+    expect(emitted[1]).toMatchObject({type: 'ApplicationActions.OPEN_ERROR_DIALOG', payload: {open: true}});
+    subscription.unsubscribe();
+  });
+
+  it('ignores parallel confirms and accepts a retry after failure', async () => {
+    const first = createDeferred<void>();
+    mockedProductionRepository.confirm
+      .mockReturnValueOnce(first.promise)
+      .mockResolvedValueOnce(undefined);
+    const action$ = new Subject<ProductionActions.Confirm>();
+    const emitted: any[] = [];
+    const subscription = confirmEpic$(action$).subscribe((action: any) => emitted.push(action));
+
+    action$.next(ProductionActions.confirm(ConfirmStates.IODINE));
+    action$.next(ProductionActions.confirm(ConfirmStates.IODINE));
+    expect(mockedProductionRepository.confirm).toHaveBeenCalledTimes(1);
+
+    first.reject(new Error('network unavailable'));
+    await flushPromises();
+    action$.next(ProductionActions.confirm(ConfirmStates.IODINE));
+    await flushPromises();
+
+    expect(mockedProductionRepository.confirm).toHaveBeenCalledTimes(2);
+    expect(emitted).toContainEqual(ProductionActions.confirmFailure('network unavailable'));
+    expect(emitted).toContainEqual(ProductionActions.confirmSuccess());
+    subscription.unsubscribe();
+  });
+});
+
+describe('nextProcedureStepEpic$', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('allows only one next-step request while the first is pending', async () => {
+    const request = createDeferred<boolean>();
+    mockedProductionRepository.nextProcedureStep.mockReturnValue(request.promise);
+    const action$ = new Subject<ProductionActions.NextProcedureStep>();
+    const emitted: ProductionActions.AllProductionActions[] = [];
+    const subscription = nextProcedureStepEpic$(action$).subscribe(action => emitted.push(action as ProductionActions.AllProductionActions));
+
+    action$.next(ProductionActions.nextProcedureStep());
+    action$.next(ProductionActions.nextProcedureStep());
+    expect(mockedProductionRepository.nextProcedureStep).toHaveBeenCalledTimes(1);
+
+    request.resolve(true);
+    await flushPromises();
+    expect(emitted).toEqual([ProductionActions.nextProcedureStepSuccess()]);
+    subscription.unsubscribe();
+  });
+});
+
+describe('sendBrewingDataEpic$ failures', () => {
+  it('emits a visible lifecycle failure when recipe transfer fails', async () => {
+    mockedProductionRepository.sendBrewingData.mockResolvedValue(false);
+    const action$ = new Subject<ProductionActions.SendBrewingData>();
+    const emitted: ProductionActions.AllProductionActions[] = [];
+    const subscription = sendBrewingDataEpic$(action$).subscribe(action => emitted.push(action as ProductionActions.AllProductionActions));
+    action$.next(ProductionActions.sendBrewingData(createBrewingData()));
+    await flushPromises();
+    expect(emitted).toEqual([ProductionActions.brewingStartFailure('Das Rezept konnte nicht an den Controller übertragen werden.')]);
+    subscription.unsubscribe();
+  });
+});
+
+it('maps the structured socket.io overheat event without JSON parsing', () => {
+  expect(mapControlSocketEvent({event: 'overheat', data: {temperature: 101}})).toEqual(ProductionActions.overheatReceived({temperature: 101}));
+  expect(mapControlSocketEvent({event: 'other', data: {}})).toBeUndefined();
 });
 
 describe('startWaterFillingEpic$', () => {

--- a/src/epics/productionEpics.ts
+++ b/src/epics/productionEpics.ts
@@ -1,7 +1,7 @@
 import { ofType } from 'redux-observable';
 import {from, of, interval, EMPTY, filter, takeWhile, startWith, Observable} from 'rxjs';
 import { catchError, exhaustMap, map, mergeMap, switchMap, takeUntil } from 'rxjs/operators';
-import { ProductionActions } from '../actions/actions';
+import { ApplicationActions, ProductionActions } from '../actions/actions';
 import { ProductionRepository } from '../repositorys/ProductionRepository';
 import { dataCollector } from '../utils/DataCollector/dataCollector';
 import { WebSocketController } from '../utils/WebSocketController';
@@ -17,6 +17,10 @@ export const WATER_STATUS_REQUEST_TIMEOUT = 8000;
 export const WATER_FILLING_MAX_DURATION = 30 * 60 * 1000;
 const WS_URL = (typeof BaseURL !== 'undefined' ? BaseURL : '').replace(/^http/, 'ws');
 let wsController: WebSocketController | null = null;
+
+export const mapControlSocketEvent = (event: {event: string; data: any}) => event.event === 'overheat'
+  ? ProductionActions.overheatReceived(event.data)
+  : undefined;
 
 export const getTemperaturesEpic$ = (action$: any) =>
     action$.pipe(
@@ -132,13 +136,13 @@ export const sendBrewingDataEpic$ = (action$: any) =>
           if (sendResult) {
             // Start the brewing process
             return from(ProductionRepository.startBrewing()).pipe(
-              switchMap((startResult) => startResult ? createBrewingStatusPolling$(action$) : of(ProductionActions.stopPolling()))
+              switchMap((startResult) => startResult ? createBrewingStatusPolling$(action$) : of(ProductionActions.brewingStartFailure('Der Controller konnte den Brauvorgang nicht starten.')))
             );
           } else {
-            return of(ProductionActions.stopPolling());
+            return of(ProductionActions.brewingStartFailure('Das Rezept konnte nicht an den Controller übertragen werden.'));
           }
         }),
-        catchError((error) => of(ProductionActions.stopPolling()))
+        catchError((error) => of(ProductionActions.brewingStartFailure(error instanceof Error ? error.message : 'Braustart fehlgeschlagen.')))
       )
     )
   );
@@ -146,10 +150,16 @@ export const sendBrewingDataEpic$ = (action$: any) =>
 export const confirmEpic$ = (action$: any) =>
   action$.pipe(
     ofType(ProductionActions.ActionTypes.CONFIRM),
-    mergeMap((action: any) =>
+    exhaustMap((action: any) =>
       from(ProductionRepository.confirm(action.payload.confirmState)).pipe(
-        map(() => ({ type: 'NO_OP' })),
-        catchError((error) => of({ type: 'NO_OP' }))
+        map(() => ProductionActions.confirmSuccess()),
+        catchError((error) => {
+          const message = error instanceof Error ? error.message : 'Bestätigung fehlgeschlagen';
+          return from([
+            ProductionActions.confirmFailure(message),
+            ApplicationActions.openErrorDialog(true, 'Bestätigung fehlgeschlagen', message),
+          ]);
+        })
       )
     )
   );
@@ -173,7 +183,7 @@ export const checkIsBackendAvailableEpic$ = (action$: any) =>
 export const nextProcedureStepEpic$ = (action$: any) =>
   action$.pipe(
     ofType(ProductionActions.ActionTypes.NEXT_PROCEDURE_STEP),
-    switchMap(() =>
+    exhaustMap(() =>
       from(ProductionRepository.nextProcedureStep()).pipe(
         map((result) =>
           result
@@ -198,13 +208,9 @@ export const productionWebSocketEpic$ = (action$: any) =>
         }
         return new Observable((observer) => {
           wsController!.onMessage((event) => {
-            try {
-              const msg = JSON.parse(event.data);
-              if (msg.event === 'overheat') {
-                observer.next(ProductionActions.overheatReceived(msg.data));
-              }
-            } catch (e) {
-              // ignore invalid messages
+            const action = mapControlSocketEvent(event);
+            if (action) {
+              observer.next(action);
             }
           });
           wsController!.connect();

--- a/src/reducers/beerReducer.test.ts
+++ b/src/reducers/beerReducer.test.ts
@@ -47,6 +47,23 @@ describe('beerDataReducer finished brews', () => {
         expect(state.finishedBrews).toEqual([brew]);
     });
 
+    it('retains the exact create payload on failure and clears it only on success', () => {
+        const {id, ...payload} = brew;
+        const pending = beerDataReducer(initialBeerState, BeerActions.addFinishedBrew(payload));
+        expect(pending.isAddingFinishedBrew).toBe(true);
+        expect(pending.pendingFinishedBrewPayload).toBe(payload);
+
+        const failed = beerDataReducer(pending, BeerActions.addFinishedBrewFailure('HTTP 500'));
+        expect(failed.isAddingFinishedBrew).toBe(false);
+        expect(failed.addFinishedBrewError).toBe('HTTP 500');
+        expect(failed.pendingFinishedBrewPayload).toBe(payload);
+
+        const retrying = beerDataReducer(failed, BeerActions.addFinishedBrew(failed.pendingFinishedBrewPayload!));
+        const succeeded = beerDataReducer(retrying, BeerActions.addFinishedBrewSuccess(brew));
+        expect(succeeded.pendingFinishedBrewPayload).toBeUndefined();
+        expect(succeeded.isAddingFinishedBrew).toBe(false);
+    });
+
     it('replaces the existing id after update success', () => {
         const pending = beerDataReducer({...initialBeerState, finishedBrews: [brew]}, BeerActions.updateActiveBeer({...brew, state: eBrewState.MATURATION}));
         const state = beerDataReducer(pending, BeerActions.updateFinishedBrewSuccess({...brew, state: eBrewState.MATURATION}, 'ABC'));
@@ -60,4 +77,29 @@ describe('beerDataReducer finished brews', () => {
         expect(state.finishedBrews).toEqual([brew]);
         expect(state.finishedBrewUpdateErrors?.ABC).toBeDefined();
     });
+});
+
+describe('beerDataReducer loading failures', () => {
+    it('clears recipe and finished-brew loading independently after errors', () => {
+        const loadingBeers = beerDataReducer(initialBeerState, BeerActions.getBeers(true));
+        expect(beerDataReducer(loadingBeers, BeerActions.getBeersFailure()).isFetchingBeers).toBe(false);
+        const loadingBrews = beerDataReducer(initialBeerState, BeerActions.getFinishedBeers(true));
+        expect(beerDataReducer(loadingBrews, BeerActions.getFinishedBeersFailure()).isFetchingFinishedBrews).toBe(false);
+    });
+});
+
+it('tracks a finished-brew delete and releases it after failure', () => {
+    const deleting = beerDataReducer(initialBeerState, BeerActions.deleteFinishedBeer('ABC'));
+    expect(deleting.deletingFinishedBrewIds).toEqual(['ABC']);
+    const failed = beerDataReducer(deleting, BeerActions.deleteFinishedBeerFailure('ABC', 'HTTP 500'));
+    expect(failed.deletingFinishedBrewIds).toEqual([]);
+    expect(failed.finishedBrewDeleteErrors?.ABC).toBe('HTTP 500');
+});
+
+it('replaces stale recipes when the server returns an empty list', () => {
+    const stale = {...initialBeerState, beers: [{id: 'beer-1', name: 'stale'} as Beer], selectedBeer: {id: 'beer-1'} as Beer, isFetching: true, isFetchingBeers: true};
+    const state = beerDataReducer(stale, BeerActions.getBeersSuccess([]));
+    expect(state.beers).toEqual([]);
+    expect(state.selectedBeer).toBeUndefined();
+    expect(state.isFetchingBeers).toBe(false);
 });

--- a/src/reducers/beerReducer.ts
+++ b/src/reducers/beerReducer.ts
@@ -2,9 +2,10 @@ import { BeerActions } from '../actions/actions';
 import AllBeerActions = BeerActions.AllBeerActions;
 import {Beer} from "../model/Beer";
 import {BeerDTO} from "../model/BeerDTO";
-import {FinishedBrew} from "../model/FinishedBrew";
+import {FinishedBrew, FinishedBrewCreatePayload} from "../model/FinishedBrew";
 import {BeerRecipeScaler} from "../utils/BeerScaler/ScalingBeerRecipe";
 import {RecipeImportResult} from '../model/RecipeImport';
+import {enforceFinishedBrewStateInvariant} from '../utils/finishedBrewChanges';
 
 
 export interface BeerDataReducerState {
@@ -12,6 +13,8 @@ export interface BeerDataReducerState {
     beer: BeerDTO | undefined
     isSuccessful: boolean,
     isFetching: boolean,
+    isFetchingBeers: boolean,
+    isFetchingFinishedBrews: boolean,
     isSubmitSuccessful: boolean | undefined,
     message: string | undefined,
     type: string | undefined,
@@ -29,6 +32,9 @@ export interface BeerDataReducerState {
     finishedBrewUpdateErrors?: Record<string, string>
     isAddingFinishedBrew?: boolean
     addFinishedBrewError?: string
+    pendingFinishedBrewPayload?: FinishedBrewCreatePayload
+    deletingFinishedBrewIds?: string[]
+    finishedBrewDeleteErrors?: Record<string, string>
 }
 
 export const initialBeerState: BeerDataReducerState =
@@ -37,6 +43,8 @@ export const initialBeerState: BeerDataReducerState =
         beer: undefined,
         isSuccessful: false,
         isFetching: false,
+        isFetchingBeers: false,
+        isFetchingFinishedBrews: false,
         isSubmitSuccessful: true,
         message: undefined,
         type: undefined,
@@ -46,6 +54,9 @@ export const initialBeerState: BeerDataReducerState =
         savingFinishedBrewIds: [],
         finishedBrewUpdateErrors: {},
         isAddingFinishedBrew: false,
+        pendingFinishedBrewPayload: undefined,
+        deletingFinishedBrewIds: [],
+        finishedBrewDeleteErrors: {},
     }
 
 const beerDataReducer = (
@@ -65,15 +76,26 @@ const beerDataReducer = (
                   ...aState,
                   beers: aAction.payload.beers,
                   selectedBeer: selectedBeer,
-                  isFetching: false
+                  isFetching: false,
+                  isFetchingBeers: false
               };
           }
-          return { ...aState };
+          return {
+              ...aState,
+              beers: [],
+              selectedBeer: undefined,
+              beerToBrew: undefined,
+              isFetching: false,
+              isFetchingBeers: false,
+          };
 
       }
 
       case BeerActions.ActionTypes.GET_BEERS: {
-      return { ...aState, isFetching: aAction.payload.isFetching };
+      return { ...aState, isFetching: aAction.payload.isFetching, isFetchingBeers: aAction.payload.isFetching };
+    }
+    case BeerActions.ActionTypes.GET_BEERS_FAILURE: {
+      return {...aState, isFetching: false, isFetchingBeers: false};
     }
     case BeerActions.ActionTypes.SET_SELECTED_BEER: {
       return { ...aState, selectedBeer: aAction.payload.beer };
@@ -127,10 +149,13 @@ const beerDataReducer = (
     }
 
     case BeerActions.ActionTypes.GET_FINISHED_BEERS: {
-      return { ...aState, isFetching: aAction.payload.isFetching };
+      return { ...aState, isFetching: aAction.payload.isFetching, isFetchingFinishedBrews: aAction.payload.isFetching };
     }
     case BeerActions.ActionTypes.GET_FINISHED_BEERS_SUCCESS: {
-      return { ...aState, finishedBrews: aAction.payload.finishedBeers ?? undefined };
+      return { ...aState, isFetching: false, isFetchingFinishedBrews: false, finishedBrews: aAction.payload.finishedBeers ?? undefined };
+    }
+    case BeerActions.ActionTypes.GET_FINISHED_BEERS_FAILURE: {
+      return {...aState, isFetching: false, isFetchingFinishedBrews: false};
     }
     case BeerActions.ActionTypes.UPDATE_ACTIVE_BEER: {
       const requestedId = aAction.payload.beer.id;
@@ -140,18 +165,30 @@ const beerDataReducer = (
       return { ...aState, savingFinishedBrewIds, finishedBrewUpdateErrors };
     }
     case BeerActions.ActionTypes.DELETE_FINISHED_BEER: {
-      return { ...aState };
+      const id = aAction.payload.finishedBrewId;
+      const errors = {...(aState.finishedBrewDeleteErrors ?? {})};
+      delete errors[id];
+      return { ...aState, deletingFinishedBrewIds: Array.from(new Set([...(aState.deletingFinishedBrewIds ?? []), id])), finishedBrewDeleteErrors: errors };
     }
     case BeerActions.ActionTypes.DELETE_FINISHED_BEER_SUCCESS: {
       let finishedBrews = aState.finishedBrews ? [...aState.finishedBrews] : [];
       finishedBrews = finishedBrews.filter(b => b.id !== aAction.payload.deletedFinishedBrewId);
-      return { ...aState, finishedBrews };
+      return { ...aState, finishedBrews, deletingFinishedBrewIds: (aState.deletingFinishedBrewIds ?? []).filter(id => id !== aAction.payload.deletedFinishedBrewId) };
+    }
+    case BeerActions.ActionTypes.DELETE_FINISHED_BEER_FAILURE: {
+      const {deletedFinishedBrewId, message} = aAction.payload;
+      return {...aState, deletingFinishedBrewIds: (aState.deletingFinishedBrewIds ?? []).filter(id => id !== deletedFinishedBrewId), finishedBrewDeleteErrors: {...(aState.finishedBrewDeleteErrors ?? {}), [deletedFinishedBrewId]: message}};
     }
     case BeerActions.ActionTypes.ADD_FINISHED_BREW: {
-      return { ...aState, isAddingFinishedBrew: true, addFinishedBrewError: undefined };
+      return {
+        ...aState,
+        isAddingFinishedBrew: true,
+        addFinishedBrewError: undefined,
+        pendingFinishedBrewPayload: aAction.payload.finishedBrew,
+      };
     }
     case BeerActions.ActionTypes.ADD_FINISHED_BREW_SUCCESS: {
-      const createdBrew = aAction.payload.beer;
+      const createdBrew = enforceFinishedBrewStateInvariant(aAction.payload.beer);
       const finishedBrews = aState.finishedBrews ?? [];
       if (!createdBrew?.id) {
         return {...aState, isAddingFinishedBrew: false, addFinishedBrewError: 'Die Create-Antwort enthält keine FinishedBeer-ID.'};
@@ -160,6 +197,7 @@ const beerDataReducer = (
         ...aState,
         isAddingFinishedBrew: false,
         addFinishedBrewError: undefined,
+        pendingFinishedBrewPayload: undefined,
         finishedBrews: [...finishedBrews, createdBrew],
       };
     }
@@ -167,7 +205,7 @@ const beerDataReducer = (
       return { ...aState, isAddingFinishedBrew: false, addFinishedBrewError: aAction.payload.message };
     }
     case BeerActions.ActionTypes.UPDATE_FINISHED_BREW_SUCCESS: {
-        const updatedBrew = aAction.payload.beer;
+        const updatedBrew = enforceFinishedBrewStateInvariant(aAction.payload.beer);
           const requestedId = aAction.payload.requestedId;
           const finishedBrews = aState.finishedBrews ?? [];
           const savingFinishedBrewIds = (aState.savingFinishedBrewIds ?? []).filter(id => id !== requestedId);

--- a/src/reducers/productionReducer.test.ts
+++ b/src/reducers/productionReducer.test.ts
@@ -2,6 +2,7 @@ import {ProductionActions} from '../actions/actions';
 import {initialProductionState, productionReducer} from './productionReducer';
 import {AlarmType, BrewingStatus, ProcessMode, ProcessPhase, ProcessState, WaitingFor} from '../model/brewingStatus.types';
 import {ToggleState} from '../enums/eToggleState';
+import {ConfirmStates} from '../enums/eConfirmStates';
 
 const statusWithAlarms = (alarms: BrewingStatus['alarms']): BrewingStatus => ({
     elapsedTime: 0,
@@ -65,4 +66,54 @@ describe('productionReducer agitator state', () => {
 
         expect(nextState.currentAgitatorState).toBe(ToggleState.ON);
     });
+});
+
+describe('productionReducer confirm lifecycle', () => {
+    it('sets pending for a request and clears it on success', () => {
+        const pending = productionReducer(initialProductionState, ProductionActions.confirm(ConfirmStates.IODINE));
+        expect(pending.isConfirmPending).toBe(true);
+
+        const succeeded = productionReducer(pending, ProductionActions.confirmSuccess());
+        expect(succeeded.isConfirmPending).toBe(false);
+        expect(succeeded.confirmError).toBeUndefined();
+    });
+
+    it('clears pending on failure while preserving the current waiting status', () => {
+        const waitingStatus = {...statusWithAlarms([]), waiting: {waitingFor: WaitingFor.IODINE_TEST, canConfirm: true}};
+        const waiting = productionReducer(initialProductionState, ProductionActions.setBrewingStatus(waitingStatus));
+        const pending = productionReducer(waiting, ProductionActions.confirm(ConfirmStates.IODINE));
+        const failed = productionReducer(pending, ProductionActions.confirmFailure('HTTP 500'));
+
+        expect(failed.isConfirmPending).toBe(false);
+        expect(failed.confirmError).toBe('HTTP 500');
+        expect(failed.brewingStatus?.waiting).toEqual(waitingStatus.waiting);
+    });
+});
+
+describe('productionReducer next-step lifecycle', () => {
+    it('blocks while pending and clears pending after failure', () => {
+        const pending = productionReducer(initialProductionState, ProductionActions.nextProcedureStep());
+        expect(pending.isNextProcedureStepPending).toBe(true);
+        const failed = productionReducer(pending, ProductionActions.nextProcedureStepFailure('HTTP 500'));
+        expect(failed.isNextProcedureStepPending).toBe(false);
+        expect(failed.nextProcedureStepError).toBe('HTTP 500');
+    });
+});
+
+describe('productionReducer stale status', () => {
+    it('marks an existing status stale while offline and clears stale on a fresh status', () => {
+        const withStatus = productionReducer(initialProductionState, ProductionActions.setBrewingStatus(statusWithAlarms([])));
+        const offline = productionReducer(withStatus, ProductionActions.isBackenAvailable({isBackenAvailable: false, statusText: 'offline'}));
+        expect(offline.brewingStatus).toBe(withStatus.brewingStatus);
+        expect(offline.isBrewingStatusStale).toBe(true);
+        const refreshed = productionReducer(offline, ProductionActions.setBrewingStatus(statusWithAlarms([])));
+        expect(refreshed.isBrewingStatusStale).toBe(false);
+    });
+});
+
+it('makes a brewing start failure visible and releases polling pending state', () => {
+    const pending = productionReducer(initialProductionState, ProductionActions.sendBrewingData({} as any));
+    const failed = productionReducer(pending, ProductionActions.brewingStartFailure('HTTP 500'));
+    expect(failed.isPollingRunning).toBe(false);
+    expect(failed.brewingStartError).toBe('HTTP 500');
 });

--- a/src/reducers/productionReducer.ts
+++ b/src/reducers/productionReducer.ts
@@ -26,6 +26,12 @@ export interface ProductionReducerState {
     waterStatus: WaterStatus;
     isPollingRunning: boolean;
     overHeat: boolean;
+    isConfirmPending: boolean;
+    confirmError?: string;
+    isNextProcedureStepPending: boolean;
+    nextProcedureStepError?: string;
+    isBrewingStatusStale: boolean;
+    brewingStartError?: string;
 }
 
 export const initialProductionState: ProductionReducerState = {
@@ -42,7 +48,12 @@ export const initialProductionState: ProductionReducerState = {
     isBackenAvailable:  false,
     waterStatus: { filledLiters: 0, targetLiters: 0, openClose: false },
     isPollingRunning: false,
-    overHeat: false
+    overHeat: false,
+    isConfirmPending: false,
+    confirmError: undefined,
+    isNextProcedureStepPending: false,
+    nextProcedureStepError: undefined,
+    isBrewingStatusStale: false
 };
 
 const productionReducer = (
@@ -77,12 +88,15 @@ const productionReducer = (
         }
 
         case ProductionActions.ActionTypes.SEND_BREWING_DATA: {
-            return { ...aState, isPollingRunning: true };
+            return { ...aState, isPollingRunning: true, brewingStartError: undefined };
+        }
+        case ProductionActions.ActionTypes.BREWING_START_FAILURE: {
+            return {...aState, isPollingRunning: false, brewingStartError: aAction.payload.error};
         }
         case ProductionActions.ActionTypes.SET_BREWING_STATUS: {
             const aBrewingStatus = aAction.payload.brewingStatus;
             const aIsTerminalOrIdle = isProcessIdle(aBrewingStatus) || isProcessFinished(aBrewingStatus) || isProcessAborted(aBrewingStatus) || isProcessInError(aBrewingStatus);
-            return { ...aState, brewingStatus: aBrewingStatus, isPollingRunning: aIsTerminalOrIdle ? false : aState.isPollingRunning };
+            return { ...aState, brewingStatus: aBrewingStatus, isBrewingStatusStale: false, isPollingRunning: aIsTerminalOrIdle ? false : aState.isPollingRunning };
         }
         case ProductionActions.ActionTypes.START_POLLING: {
             return { ...aState, isPollingRunning: true };
@@ -91,17 +105,36 @@ const productionReducer = (
             return { ...aState, isPollingRunning: false };
         }
         case ProductionActions.ActionTypes.CONFIRM: {
-            return { ...aState };
+            return { ...aState, isConfirmPending: true, confirmError: undefined };
+        }
+        case ProductionActions.ActionTypes.CONFIRM_SUCCESS: {
+            return { ...aState, isConfirmPending: false, confirmError: undefined };
+        }
+        case ProductionActions.ActionTypes.CONFIRM_FAILURE: {
+            return { ...aState, isConfirmPending: false, confirmError: aAction.payload.error };
+        }
+        case ProductionActions.ActionTypes.NEXT_PROCEDURE_STEP: {
+            return {...aState, isNextProcedureStepPending: true, nextProcedureStepError: undefined};
+        }
+        case ProductionActions.ActionTypes.NEXT_PROCEDURE_STEP_SUCCESS: {
+            return {...aState, isNextProcedureStepPending: false, nextProcedureStepError: undefined};
+        }
+        case ProductionActions.ActionTypes.NEXT_PROCEDURE_STEP_FAILURE: {
+            const error = aAction.payload.error instanceof Error ? aAction.payload.error.message : String(aAction.payload.error);
+            return {...aState, isNextProcedureStepPending: false, nextProcedureStepError: error};
         }
         case ProductionActions.ActionTypes.CHECK_IS_BACKEND_AVAILABLE: {
             return { ...aState };
         }
         case ProductionActions.ActionTypes.IS_BACKEND_AVAILABLE: {
             const aIsBackenAvailable = aAction.payload.isBackenAvailable.isBackenAvailable;
-            if (aState.isBackenAvailable === aIsBackenAvailable) {
+            const isBrewingStatusStale = aIsBackenAvailable
+                ? aState.isBrewingStatusStale
+                : aState.brewingStatus !== undefined;
+            if (aState.isBackenAvailable === aIsBackenAvailable && aState.isBrewingStatusStale === isBrewingStatusStale) {
                 return aState;
             }
-            return { ...aState, isBackenAvailable: aIsBackenAvailable };
+            return { ...aState, isBackenAvailable: aIsBackenAvailable, isBrewingStatusStale };
         }
         case ProductionActions.ActionTypes.SET_WATER_STATUS: {
             return { ...aState, waterStatus: aAction.payload.waterStatus };

--- a/src/repositorys/FinishedBeerRepository.ts
+++ b/src/repositorys/FinishedBeerRepository.ts
@@ -1,5 +1,6 @@
 import {BaseRepository} from "./BaseRepository";
 import {FinishedBrew, FinishedBrewCreatePayload} from "../model/FinishedBrew";
+import {enforceFinishedBrewStateInvariant} from '../utils/finishedBrewChanges';
 
 export class FinishedBeerRepository extends BaseRepository {
 
@@ -8,11 +9,11 @@ export class FinishedBeerRepository extends BaseRepository {
     }
 
     static sendNewFinishedBeer(aBeer: FinishedBrewCreatePayload): Promise<FinishedBrew> {
-        return this.post<FinishedBrew>("finishedbeer", aBeer);
+        return this.post<FinishedBrew>("finishedbeer", enforceFinishedBrewStateInvariant(aBeer));
     }
 
     static updateFinishedBeer(aBeer: FinishedBrew): Promise<FinishedBrew> {
-        return this.put<FinishedBrew>("finishedbeer", aBeer);
+        return this.put<FinishedBrew>("finishedbeer", enforceFinishedBrewStateInvariant(aBeer));
     }
 
     static deleteFinishedBeer(aBeerId: string): Promise<void> {

--- a/src/repositorys/ProductionRepository.test.ts
+++ b/src/repositorys/ProductionRepository.test.ts
@@ -28,6 +28,13 @@ describe('ProductionRepository API method/path usage', () => {
     expect(mockedAxios.post).toHaveBeenCalledWith(expect.stringContaining('/Confirm/Decoction'));
   });
 
+  it('rejects when the confirm request fails', async () => {
+    const error = new Error('network unavailable');
+    mockedAxios.post.mockRejectedValueOnce(error);
+
+    await expect(ProductionRepository.confirm(ConfirmStates.IODINE)).rejects.toBe(error);
+  });
+
   it('uses POST for command-based state changes', async () => {
     await ProductionRepository.startBrewing();
     await ProductionRepository.fillWaterAutomatic(15);

--- a/src/repositorys/ProductionRepository.ts
+++ b/src/repositorys/ProductionRepository.ts
@@ -110,17 +110,7 @@ export class ProductionRepository {
 
 
     private static async _doConfirm(aConfirmState: ConfirmStates) {
-        try {
-            const response = await axios.post(ConfirmURL + aConfirmState);
-            if (response.status === 200) {
-                console.log(response.data);
-            } else {
-                console.log(response.data);
-            }
-        } catch (error) {
-            console.error('Fehler beim API-Aufruf', error);
-        }
-
+        await axios.post(ConfirmURL + aConfirmState);
     }
 
     private static async _doGetTemperature(): Promise<number> {

--- a/src/utils/finishedBrewChanges.test.ts
+++ b/src/utils/finishedBrewChanges.test.ts
@@ -1,6 +1,6 @@
 import {eBrewState} from '../enums/eBrewState';
 import {FinishedBrew} from '../model/FinishedBrew';
-import {completeFinishedBrew, mergeFinishedBrewChanges} from './finishedBrewChanges';
+import {completeFinishedBrew, enforceFinishedBrewStateInvariant, mergeFinishedBrewChanges} from './finishedBrewChanges';
 
 const brew: FinishedBrew = {
     id: 'ABC', name: 'Testbier', startDate: '2026-08-20', liters: 20,
@@ -27,5 +27,15 @@ describe('finished brew changes', () => {
     it('does not overwrite an explicitly supplied end date', () => {
         const updated = completeFinishedBrew({...brew, endDate: '2026-08-26'});
         expect(updated.endDate).toBe('2026-08-26');
+    });
+});
+
+describe('enforceFinishedBrewStateInvariant', () => {
+    it('never allows FINISHED together with active=true', () => {
+        expect(enforceFinishedBrewStateInvariant({...brew, state: eBrewState.FINISHED, active: true})).toMatchObject({state: eBrewState.FINISHED, active: false});
+    });
+
+    it('does not change active fermentation or maturation records', () => {
+        expect(enforceFinishedBrewStateInvariant(brew)).toBe(brew);
     });
 });

--- a/src/utils/finishedBrewChanges.ts
+++ b/src/utils/finishedBrewChanges.ts
@@ -13,3 +13,7 @@ export const completeFinishedBrew = (brew: FinishedBrew, now: Date = new Date())
     active: false,
     endDate: brew.endDate || now.toISOString(),
 });
+
+export const enforceFinishedBrewStateInvariant = <TBrew extends FinishedBrew | Omit<FinishedBrew, 'id'>>(brew: TBrew): TBrew => (
+    brew.state === eBrewState.FINISHED ? ({...brew, active: false} as TBrew) : brew
+);


### PR DESCRIPTION
### Motivation
- Reduce race conditions and duplicate requests by serializing network actions per entity and preventing parallel operations. 
- Make failures and pending states visible to the UI so users can retry and avoid data loss during create/update/delete flows. 
- Ensure finished-brew domain invariants (e.g. `FINISHED` cannot be `active`) and avoid excessive form-save churn.

### Description
- Introduced new action types, payloads and creators for failures and pending/success states (`GET_*_FAILURE`, `CONFIRM_SUCCESS`/`FAILURE`, `BREWING_START_FAILURE`, `DELETE_FINISHED_BEER_FAILURE`, etc.) and wired them into `BeerActions` and `ProductionActions`. 
- Reworked epics to serialize operations and reduce overlapping requests using `switchMap`/`exhaustMap`/`groupBy` where appropriate (`getBeersEpic`, `getFinishedBeersEpic`, `deleteFinishedBeerEpic`, `updateFinishedBeerEpic`, `sendNewFinishedBeerEpic`, `confirmEpic$`, `nextProcedureStepEpic$`), added mapping for socket events and improved error handling. 
- Improved reducers to track fine-grained fetching/pending/error state: `productionReducer` gained `isConfirmPending`, `confirmError`, `isNextProcedureStepPending`, `isBrewingStatusStale`, `brewingStartError`; `beerDataReducer` tracks `isFetchingBeers`, `isFetchingFinishedBrews`, `pendingFinishedBrewPayload`, `deletingFinishedBrewIds`, and related errors. 
- Production and mobile UI updates to show pending/error states and stale-controller warnings, block duplicate actions, and keep dialogs open while saves are in-flight; `ProductionDialogs`, `MobileProductionView`, `MobileActiveFinishedBrewView`, `FinishedBrewsTable`, and `BeerTable` updated accordingly. 
- Avoids excessive autosaves from `BeerForm` by removing immediate `saveBeerFormState` callbacks in many per-field `setState` handlers; replaced with saving on state change and fewer explicit calls so only one `saveBeerFormState` action is emitted per field edit. 
- Enforced finished-brew invariants via `enforceFinishedBrewStateInvariant` and applied it in repository and reducer entry points; updated `FinishedBeerRepository` to send validated payloads. 
- Added/adjusted many unit tests covering epics, reducers, components and repositories: new tests for epic serialization/retry behavior, finished-brew lifecycle, confirm lifecycle, polling/stale status handling, and UI behaviors. 

### Testing
- Ran the unit test suite including added tests under `src/epics/*`, `src/containers/**/*test.tsx`, and `src/reducers/*test.ts`; these validate epic serialization, retry/failure flows, reducer pending/error handling and updated component behavior. 
- Exercised production and finished-brew integration scenarios in tests that simulate pending requests and failures to confirm dialogs remain open and payloads are preserved for retries. 
- All automated tests (unit/epic/reducer/component) were executed and passed locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a90a5ccefc8832f99134d6d48f65f48)