### PR TITLE
Fix TypeScript compilation errors in beer epics, tests and finished-brews UI

### DIFF
--- a/src/containers/MainView/BeerRecipes/Table.test.tsx
+++ b/src/containers/MainView/BeerRecipes/Table.test.tsx
@@ -26,7 +26,7 @@ it('does not delete the recipe used by an active brewing process', () => {
         exportShoppingListPdf: jest.fn(), deleteBeer,
     } as BeerTableProps;
     const table = new BeerTableComponent(props);
-    table.state.beerPendingDelete = storedRecipe;
+    Object.assign(table.state, {beerPendingDelete: storedRecipe});
 
     table.confirmDeleteBeer();
 

--- a/src/containers/MainView/FinishBrewsBeers/FinishedBrewsTable.tsx
+++ b/src/containers/MainView/FinishBrewsBeers/FinishedBrewsTable.tsx
@@ -383,7 +383,7 @@ export class FinishedBrewsTable extends React.Component<FinishedBrewsTableProps,
                             <span role="img" aria-label="Abbrechen" style={{ fontSize: 22, verticalAlign: 'middle',  display: 'inline-block', position: 'relative', top: '3px' }}>✖️</span>
                         </button>
                     </div>
-                    {this.props.finishedBrewUpdateErrors[brewId] && <p role="alert">Speichern fehlgeschlagen: {this.props.finishedBrewUpdateErrors[brewId]}</p>}
+                    {this.props.addFinishedBrewError && <p role="alert">Speichern fehlgeschlagen: {this.props.addFinishedBrewError}</p>}
                 </TableCell>
             </TableRow>
         );

--- a/src/epics/beerCreateEpic.test.ts
+++ b/src/epics/beerCreateEpic.test.ts
@@ -54,7 +54,7 @@ describe('sendNewFinishedBeerEpic', () => {
             .mockResolvedValueOnce({...payload, id: 'brew-1'});
         const action$ = new Subject<BeerActions.AddFinishedBrew>();
         const emitted: BeerActions.AllBeerActions[] = [];
-        const subscription = sendNewFinishedBeerEpic(action$).subscribe(action => emitted.push(action as BeerActions.AllBeerActions));
+        const subscription = sendNewFinishedBeerEpic(action$).subscribe((action: unknown) => emitted.push(action as BeerActions.AllBeerActions));
 
         action$.next(BeerActions.addFinishedBrew(payload));
         await flush();

--- a/src/epics/beerEpics.ts
+++ b/src/epics/beerEpics.ts
@@ -85,7 +85,7 @@ export const deleteFinishedBeerEpic = (action$: any) =>
   action$.pipe(
     ofType(BeerActions.ActionTypes.DELETE_FINISHED_BEER),
     groupBy((action: any) => action.payload.finishedBrewId),
-    mergeMap(actionsForBrew$ => actionsForBrew$.pipe(exhaustMap((action: any) =>
+    mergeMap((actionsForBrew$: any) => actionsForBrew$.pipe(exhaustMap((action: any) =>
       from(FinishedBeerRepository.deleteFinishedBeer(action.payload.finishedBrewId)).pipe(
         map(() => BeerActions.deleteFinishedBeerSuccess(true, action.payload.finishedBrewId)),
           catchError((aError: Error) =>
@@ -106,7 +106,7 @@ export const updateFinishedBeerEpic = (action$: any) =>
   action$.pipe(
     ofType(BeerActions.ActionTypes.UPDATE_ACTIVE_BEER),
     groupBy((action: any) => action.payload.beer.id),
-    mergeMap((actionsForBrew$) => actionsForBrew$.pipe(
+    mergeMap((actionsForBrew$: any) => actionsForBrew$.pipe(
       exhaustMap((action: any) =>
         from(FinishedBeerRepository.updateFinishedBeer(action.payload.beer)).pipe(
           map((beer) => BeerActions.updateFinishedBrewSuccess({...action.payload.beer, ...beer}, action.payload.beer.id)),

--- a/src/epics/beerFetchEpic.test.ts
+++ b/src/epics/beerFetchEpic.test.ts
@@ -14,7 +14,7 @@ it('emits only the newest recipe response when refresh requests overlap', async 
     repository.getBeers.mockReturnValueOnce(oldRequest.promise).mockReturnValueOnce(newRequest.promise);
     const action$ = new Subject<BeerActions.GetBeers>();
     const emitted: BeerActions.AllBeerActions[] = [];
-    const subscription = getBeersEpic(action$).subscribe(action => emitted.push(action as BeerActions.AllBeerActions));
+    const subscription = getBeersEpic(action$).subscribe((action: unknown) => emitted.push(action as BeerActions.AllBeerActions));
     action$.next(BeerActions.getBeers(true));
     action$.next(BeerActions.getBeers(true));
     newRequest.resolve([{id: 'new'} as Beer]);

--- a/src/epics/productionEpics.test.ts
+++ b/src/epics/productionEpics.test.ts
@@ -136,7 +136,7 @@ describe('nextProcedureStepEpic$', () => {
     mockedProductionRepository.nextProcedureStep.mockReturnValue(request.promise);
     const action$ = new Subject<ProductionActions.NextProcedureStep>();
     const emitted: ProductionActions.AllProductionActions[] = [];
-    const subscription = nextProcedureStepEpic$(action$).subscribe(action => emitted.push(action as ProductionActions.AllProductionActions));
+    const subscription = nextProcedureStepEpic$(action$).subscribe((action: unknown) => emitted.push(action as ProductionActions.AllProductionActions));
 
     action$.next(ProductionActions.nextProcedureStep());
     action$.next(ProductionActions.nextProcedureStep());
@@ -154,7 +154,7 @@ describe('sendBrewingDataEpic$ failures', () => {
     mockedProductionRepository.sendBrewingData.mockResolvedValue(false);
     const action$ = new Subject<ProductionActions.SendBrewingData>();
     const emitted: ProductionActions.AllProductionActions[] = [];
-    const subscription = sendBrewingDataEpic$(action$).subscribe(action => emitted.push(action as ProductionActions.AllProductionActions));
+    const subscription = sendBrewingDataEpic$(action$).subscribe((action: unknown) => emitted.push(action as ProductionActions.AllProductionActions));
     action$.next(ProductionActions.sendBrewingData(createBrewingData()));
     await flushPromises();
     expect(emitted).toEqual([ProductionActions.brewingStartFailure('Das Rezept konnte nicht an den Controller übertragen werden.')]);


### PR DESCRIPTION
### Motivation

- Address multiple TypeScript compilation errors preventing a successful build, caused by direct assignment to React `state` in a test, an undefined `brewId` usage in the finished-brews row, and missing/implicit types in RxJS epic/grouped streams and test subscriptions.

### Description

- Replace direct `state` assignment in `BeerTable` test with `Object.assign(table.state, {beerPendingDelete: ...})` to avoid writing the read-only `state` property in `src/containers/MainView/BeerRecipes/Table.test.tsx`.
- Fix finished-brew new-row error rendering by showing the shared `addFinishedBrewError` prop instead of indexing `finishedBrewUpdateErrors` with a row-only `brewId` in `src/containers/MainView/FinishBrewsBeers/FinishedBrewsTable.tsx`.
- Add explicit `any` typing for grouped RxJS streams (`actionsForBrew$`) in `src/epics/beerEpics.ts` to resolve `unknown`-type pipe usage.
- Annotate epic test `subscribe` callbacks with `(action: unknown)` to avoid implicit `any` parameters in `src/epics/beerCreateEpic.test.ts`, `src/epics/beerFetchEpic.test.ts`, and `src/epics/productionEpics.test.ts`.
- Commit message: `Fix TypeScript compilation errors` (changes staged and committed).

### Testing

- Ran `git diff --check` and committed the changes successfully with a clean working tree, which passed.
- Attempted a production build via `npm run build` (invoked `scripts/build-with-version.js`) which exited early due to incomplete dependency installation and thus did not complete successfully.
- Attempted dependency install with `npm ci`, which failed due to an HTTP 403 from the npm registry and prevented running `tsc`/full TypeScript verification and the build.
- Local quick checks (file diffs and code edits) verify the TypeScript errors from the rollout transcript were addressed, but a full compile/test run could not be completed in this environment due to dependency/registry issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a90b19cd5d0832fb55a67451a1aa9cc)