### PR TITLE
Fix heater/flame display: drive flames from hardware.heater and add user-facing heater status

### DIFF
--- a/docs/codex/compatibility/cross-repo-contracts.md
+++ b/docs/codex/compatibility/cross-repo-contracts.md
@@ -90,7 +90,7 @@ The Settings UI also consumes the existing `POST /api/audio/test` contract. Its 
 
 The UI accepts `currentStep.phase: DECOCTION` as a public sequential mash phase and sends new decoction recipe steps with `procedureType: DECOCTION` plus `executionMode: CONFIRMATION_HOLD`. Database persistence of the new optional field is **Needs verification** in the database/backend repository.
 
-After `Confirm/Decoction`, control may publish a return heat-up with `heating.followsDecoction: true`; `heating.heaterEnabled` is then the authoritative heater indicator. For `waiting.waitingFor: DECOCTION_RETURN_CONFIRMATION` with `canConfirm: true`, the UI sends exactly `POST /Confirm/DecoctionReturned`. Status payloads without `heating` retain the legacy heater fallback.
+After `Confirm/Decoction`, control may publish a return heat-up with `heating.followsDecoction: true`; `heating.heaterEnabled` then indicates whether process logic permits the heater to be used. The actual heater indicator remains `hardware.heater`, and flames are shown only for `hardware.heater === 'ON'`. For `waiting.waitingFor: DECOCTION_RETURN_CONFIRMATION` with `canConfirm: true`, the UI sends exactly `POST /Confirm/DecoctionReturned`.
 
 Production `Rasten` now retain `stepId`, and decoctions retain `relatedRastId` without copying the referenced temperature. PI/control lookup of `relatedRastId -> RAST.stepId -> temperature` **Needs cross-repository update**.
 

--- a/docs/codex/compatibility/final-ui-control-compatibility-report.md
+++ b/docs/codex/compatibility/final-ui-control-compatibility-report.md
@@ -70,7 +70,7 @@ The UI-facing availability endpoint is `GET /Available/`; PI control also preser
 | `currentStep.mode` | string enum | PI control | Current step mode. | UI labels, heating/progress/waiting decisions. | Preserve documented enum strings. |
 | `waiting.waitingFor` | string enum | PI control | Concrete wait/confirmation reason or status. | UI maps only concrete values to confirmation endpoints; generic values do not dispatch. | Do not rename concrete confirmation enum values without coordinated UI update. |
 | `heating.followsDecoction` | boolean | PI control | Marks the return heat-up after a decoction. | Production return-phase copy and status. | Missing values use the ordinary-heating compatibility path. |
-| `heating.heaterEnabled` | boolean | PI control | Reports whether heating is actually enabled. | Desktop flames and mobile heating state. | When present this is authoritative; older payloads use hardware/mode fallback. |
+| `heating.heaterEnabled` | boolean | PI control | Reports whether process logic permits heater use. | Desktop and mobile blocked/ready/active heating status. | This is a permission, not the physical heater state; flames use `hardware.heater` only. |
 | `waiting.canConfirm` | boolean | PI control | Whether confirmation may be submitted. | UI enables confirm button only when a concrete confirm exists and `canConfirm` is true. | Keep boolean semantics stable. |
 | `temperature.current` | number | PI control | Current temperature in Celsius. | UI gauges/mobile display; fallback from `/temperatur/0` if missing/zero. | Keep Celsius and numeric type stable. |
 | `temperature.target` | number | PI control | Target temperature in Celsius. | UI target gauge/mobile display. | Keep Celsius and numeric type stable. |

--- a/docs/codex/data-flow.md
+++ b/docs/codex/data-flow.md
@@ -67,7 +67,7 @@ Needs verification: backend ordering of `GET beers`, because the UI treats the l
   - `DECOCTION_CONFIRMATION` -> `Confirm/Decoction`
   - `DECOCTION_RETURN_CONFIRMATION` -> `Confirm/DecoctionReturned`
   - `USER_CONFIRMATION`, `NONE`, or unknown waiting reasons do not send a confirm command. `Wait` may be displayed as a status, but the UI must not call `Confirm/Wait`.
-- During the return phase after a decoction, `heating.followsDecoction` selects return-specific Production copy and `heating.heaterEnabled` drives the actual heater/flame indication. Older control responses without `heating` keep the legacy fallback.
+- During the return phase after a decoction, `heating.followsDecoction` selects return-specific Production copy. `heating.heaterEnabled` describes whether heating is permitted and drives the user-facing blocked/ready status; it is not a physical switch state. Production flames are driven exclusively by `hardware.heater === 'ON'`.
 - `USER_CONFIRMATION` and unknown waiting reasons remain visibly marked as waiting inline but do not render a confirmation button.
 
 ## Hop reminder flow

--- a/docs/codex/domain-model.md
+++ b/docs/codex/domain-model.md
@@ -45,7 +45,7 @@ Runtime status is normalized into process state, current step, temperature, hard
 - `temperature.current`/`target`: gauges and mobile display.
 - `hardware.heater`/`agitator`: flames, water-control agitator visual, mobile agitator display.
 - `heating.followsDecoction`: marks the main-mash heat-up directly after a decoction so Production presents the return phase instead of an ordinary heat-up.
-- `heating.heaterEnabled`: authoritative physical-heater state when present; older payloads retain the `hardware.heater`/step-mode fallback.
+- `heating.heaterEnabled`: process-level permission to use the heater, especially around decoction transitions. It does not report the physical switch state. The UI derives “Heizung gesperrt” from `false`, “Heizung bereit” from an enabled but physically off heater, and “Heizung aktiv” from an enabled and physically on heater.
 - `waiting.waitingFor`/`canConfirm`: central inline confirmation content and confirm endpoint mapping for desktop and mobile. `MASHING_OUT_CONFIRMATION` uses the existing `Confirm/Mashup` control confirmation value. Generic or unknown waiting values are displayed without an action button.
 - `DECOCTION_RETURN_CONFIRMATION` asks for the completed return of the decoction and maps exclusively to `POST /Confirm/DecoctionReturned`.
 

--- a/docs/codex/external/control-context.md
+++ b/docs/codex/external/control-context.md
@@ -72,7 +72,7 @@ See `docs/codex/interfaces.md` for full JSON shape. Important values:
 - `currentStep.phase`: `NONE`, `MASHING_IN`, `RAST`, `MASHING_OUT`, `COOKING`, `COOLING`, `FINISHED`.
 - `currentStep.mode`: `NONE`, `HEATING`, `HOLDING`, `TIMER_RUNNING`, `WAITING`, `FINISHED`, `ERROR`.
 - `waiting.waitingFor`: `NONE`, `USER_CONFIRMATION`, `IODINE_TEST`, `MASHING_IN_CONFIRMATION`, `MASHING_OUT_CONFIRMATION`, `COOKING_CONFIRMATION`, `BOILING_CONFIRMATION`, `DECOCTION_CONFIRMATION`, `DECOCTION_RETURN_CONFIRMATION`.
-- `heating.followsDecoction` marks the return heat-up after decoction; `heating.heaterEnabled` reports whether the heater is physically enabled.
+- `heating.followsDecoction` marks the return heat-up after decoction; `heating.heaterEnabled` reports whether the process currently permits heater use, not whether the heater is physically switched on.
 - `temperature.sensorHealth`: `OK`, `MISSING`, `STALE`, `INVALID_READING`, `MULTIPLE_SENSORS_FOUND`, `NOT_CONFIGURED`.
 - `hardware.heater` and `hardware.agitator`: `ON`, `OFF`, or `ERROR`.
 

--- a/docs/codex/interfaces.md
+++ b/docs/codex/interfaces.md
@@ -93,7 +93,7 @@ interface BrewingStatus {
   };
   temperature: { current?: number; target?: number };
   hardware: { heater?: string; agitator?: string };
-  heating?: { followsDecoction?: boolean; heaterEnabled?: boolean };
+  heating?: { followsDecoction?: boolean; heaterEnabled?: boolean }; // heaterEnabled permits heater use; hardware.heater is the physical state
   waiting: { waitingFor: WaitingFor; canConfirm: boolean };
   error: { code?: string | null; details?: string | null };
 }

--- a/src/containers/Mobile/MobileStatusView/MobileProductionView.test.tsx
+++ b/src/containers/Mobile/MobileStatusView/MobileProductionView.test.tsx
@@ -157,6 +157,19 @@ describe('MobileProductionView stale status', () => {
     });
 });
 
+describe('MobileProductionView heater status', () => {
+    it('shows heater permission separately from the physical heater state', () => {
+        const status = makeStatus();
+        status.hardware.heater = 'OFF';
+        status.heating = {followsDecoction: true, heaterEnabled: true};
+
+        renderMobileView({brewingStatus: status});
+
+        expect(screen.getByText('Heizung bereit')).toBeInTheDocument();
+        expect(screen.queryByText('Heizung aktiv')).not.toBeInTheDocument();
+    });
+});
+
 
 describe('MobileProductionView polling lifecycle', () => {
     it('starts polling when the mobile status page opens', () => {

--- a/src/containers/Mobile/MobileStatusView/MobileProductionView.tsx
+++ b/src/containers/Mobile/MobileStatusView/MobileProductionView.tsx
@@ -7,7 +7,7 @@ import {getBrewingStatusLabel, getConfirmationRequestViewModel, getStatusChangeK
 import SettingsPage from '../../Settings/SettingsPage.connect';
 import {ConfirmStates} from '../../../enums/eConfirmStates';
 import {ControlConfirmationNotice} from '../../Production/components/InlineProcessNotice';
-import {isHeaterActive} from '../../Production/utils/productionStatus';
+import {getHeaterDisplayLabel} from '../../Production/utils/productionStatus';
 
 interface MobileProductionViewProps {
     temperature: number;
@@ -132,8 +132,8 @@ export class MobileProductionView extends React.Component<MobileProductionViewPr
                                 <span className="mobile-value">{isStepWaiting(brewingStatus) ? 'Ja' : 'Nein'}</span>
                             </div>
                             <div className="mobile-info-block">
-                                <span className="mobile-label">Heizt auf:</span>
-                                <span className="mobile-value">{this.props.isBrewingStatusStale ? 'Unbekannt' : (isHeaterActive(brewingStatus) ? 'Ja' : 'Nein')}</span>
+                                <span className="mobile-label">Heizung:</span>
+                                <span className="mobile-value">{this.props.isBrewingStatusStale ? 'Unbekannt' : getHeaterDisplayLabel(brewingStatus)}</span>
                             </div>
                             <div className="mobile-info-block">
                                 <span className="mobile-label">Rührwerk:</span>

--- a/src/containers/Production/Production.css
+++ b/src/containers/Production/Production.css
@@ -102,12 +102,40 @@
     display: flex;
     justify-content: center;
     align-items: center;
+    flex-direction: column;
     background: var(--color-surface-strong);
     border-radius: 0 0 12px 12px;
     box-shadow: 0 2px 8px var(--shadow-error-soft);
     overflow: visible;
     min-height: 4rem;
     padding: var(--spacing-xs) 0;
+}
+
+.heater-status {
+    border: 1px solid var(--color-disabled-border);
+    border-radius: 999px;
+    color: var(--color-light-text);
+    font-size: 0.78rem;
+    font-weight: 700;
+    line-height: 1.2;
+    padding: 0.2rem 0.55rem;
+    white-space: nowrap;
+}
+
+.heater-status--active {
+    background: var(--color-error-subtle);
+    border-color: var(--color-error);
+}
+
+.heater-status--ready {
+    background: var(--color-success-subtle);
+    border-color: var(--color-success);
+}
+
+.heater-status--blocked,
+.heater-status--unknown {
+    background: var(--color-disabled-bg);
+    color: var(--color-disabled-text);
 }
 
 /* Temperaturanzeige mittig */
@@ -438,7 +466,8 @@
     justify-content: center;
     gap: clamp(0.5rem, 3vw, 2rem);
     width: 100%;
-    height: 100%;
+    flex: 1 1 auto;
+    min-height: 0;
     min-width: 0;
 }
 

--- a/src/containers/Production/Production.test.tsx
+++ b/src/containers/Production/Production.test.tsx
@@ -732,29 +732,36 @@ describe('Production recipe water filling', () => {
 
 
 describe('Production flame display', () => {
-    it('renders no flame strip when heating is off', () => {
-        const {container} = renderProduction({brewingStatus: createBrewingStatus(ProcessState.IDLE)});
-        expect(container.querySelector('.flame-strip')).toBeNull();
+    const cases = [
+        {name: 'ready heater', heater: 'OFF', enabled: true, followsDecoction: false, mode: ProcessMode.TIMER_RUNNING, current: 60, target: 55, label: 'Heizung bereit', flame: false},
+        {name: 'active heater', heater: 'ON', enabled: true, followsDecoction: false, mode: ProcessMode.HEATING, current: 54, target: 55, label: 'Heizung aktiv', flame: true},
+        {name: 'blocked heater', heater: 'OFF', enabled: false, followsDecoction: false, mode: ProcessMode.HEATING, current: 54, target: 55, label: 'Heizung gesperrt', flame: false},
+        {name: 'rest above target', heater: 'OFF', enabled: true, followsDecoction: false, mode: ProcessMode.TIMER_RUNNING, current: 60, target: 55, label: 'Heizung bereit', flame: false},
+        {name: 'rest actively reheating', heater: 'ON', enabled: true, followsDecoction: false, mode: ProcessMode.HEATING, current: 54, target: 55, label: 'Heizung aktiv', flame: true},
+        {name: 'blocked decoction return', heater: 'OFF', enabled: false, followsDecoction: true, mode: ProcessMode.HEATING, current: 54, target: 55, label: 'Heizung gesperrt', flame: false},
+        {name: 'enabled decoction return', heater: 'OFF', enabled: true, followsDecoction: true, mode: ProcessMode.HEATING, current: 54, target: 55, label: 'Heizung bereit', flame: false},
+    ] as const;
+
+    it.each(cases)('derives flames and the user-facing status for $name', ({heater, enabled, followsDecoction, mode, current, target, label, flame}) => {
+        const status = createBrewingStatus(ProcessState.ACTIVE);
+        status.currentStep = {phase: ProcessPhase.RAST, mode};
+        status.temperature = {current, target};
+        status.hardware.heater = heater;
+        status.heating = {followsDecoction, heaterEnabled: enabled};
+
+        const {container} = renderProduction({brewingStatus: status});
+
+        expect(screen.getByText(label)).toBeInTheDocument();
+        expect(container.querySelector('.flame-strip') !== null).toBe(flame);
+        expect(screen.queryAllByLabelText('Heizflamme')).toHaveLength(flame ? 4 : 0);
     });
 
-    it('renders responsive flames while heating', () => {
-        const heatingStatus = createBrewingStatus(ProcessState.ACTIVE);
-        heatingStatus.currentStep.mode = ProcessMode.HEATING;
-        const {container} = renderProduction({brewingStatus: heatingStatus});
-        expect(container.querySelector('.flame-strip')).toBeInTheDocument();
-        expect(screen.getAllByLabelText('Heizflamme')).toHaveLength(4);
-    });
-
-    it('uses heating.heaterEnabled as the authoritative heater state during decoction return', () => {
-        const returnHeating = createBrewingStatus(ProcessState.ACTIVE);
-        returnHeating.currentStep = {phase: ProcessPhase.DECOCTION, mode: ProcessMode.HEATING};
-        returnHeating.hardware.heater = 'ON';
-        returnHeating.heating = {followsDecoction: true, heaterEnabled: false};
-        const {container, rerender, props} = renderProduction({brewingStatus: returnHeating});
+    it('does not infer an active flame from heating mode when hardware is off', () => {
+        const status = createBrewingStatus(ProcessState.ACTIVE);
+        status.currentStep.mode = ProcessMode.HEATING;
+        status.hardware.heater = 'OFF';
+        const {container} = renderProduction({brewingStatus: status});
         expect(container.querySelector('.flame-strip')).toBeNull();
-
-        rerender(<Production {...props} brewingStatus={{...returnHeating, heating: {...returnHeating.heating, heaterEnabled: true}}} />);
-        expect(container.querySelector('.flame-strip')).toBeInTheDocument();
     });
 });
 

--- a/src/containers/Production/Production.tsx
+++ b/src/containers/Production/Production.tsx
@@ -30,7 +30,7 @@ import {isBrewingProcessActive, isProcessActive} from "../../utils/brewingStatus
 import {getVesselContentType} from "../../utils/brewingStatus/vesselContent";
 import {calculateHopSchedule, getDueHopAddition, HopAddition} from "./utils/hopSchedule";
 import {getRemainingSecondsFromStatus, shouldCountdownLocally, tickRemainingSeconds} from "./utils/productionCountdown";
-import {isAgitatorActive, isControllerAvailable as getIsControllerAvailable, isHeaterActive} from "./utils/productionStatus";
+import {getHeaterDisplayLabel, getHeaterDisplayStatus, isAgitatorActive, isControllerAvailable as getIsControllerAvailable, isHeaterActive} from "./utils/productionStatus";
 import {RecipeWaterFill, RecipeWaterFillStatus} from "./waterFill/recipeWaterFill.types";
 import {completeWaterFill, createInitialRecipeWaterFillStatus, failWaterFill, includePreparedSpargeAfterMashingOut, markValveOpened, resetWaterFill, startManualWaterFill, startWaterFill} from "./waterFill/recipeWaterFillState";
 import {ProductionDialogs} from "./components/ProductionDialogs";
@@ -556,9 +556,14 @@ export class Production extends React.Component<ProductionProps, ProductionState
 
     renderFlames() {
         const {brewingStatus} = this.props;
+        const heaterStatus = getHeaterDisplayStatus(brewingStatus);
+        const heaterLabel = this.props.isBrewingStatusStale ? 'Heizungsstatus unbekannt' : getHeaterDisplayLabel(brewingStatus);
 
         return (
             <div className='Flame'>
+              <span className={`heater-status heater-status--${this.props.isBrewingStatusStale ? 'unknown' : heaterStatus}`}>
+                  {heaterLabel}
+              </span>
               {!this.props.isBrewingStatusStale && isHeaterActive(brewingStatus) && (
                     <div className="flame-strip" aria-label="Heizung aktiv">
                         <Flame/>

--- a/src/containers/Production/utils/productionStatus.ts
+++ b/src/containers/Production/utils/productionStatus.ts
@@ -1,12 +1,26 @@
 import {BackendAvailable} from '../../../reducers/productionReducer';
-import {BrewingStatus, ProcessMode} from '../../../model/brewingStatus.types';
+import {BrewingStatus} from '../../../model/brewingStatus.types';
+
+export type HeaterDisplayStatus = 'blocked' | 'ready' | 'active';
 
 export const isControllerAvailable = (aBackendAvailable: BackendAvailable | boolean): boolean =>
     typeof aBackendAvailable === 'boolean' ? aBackendAvailable : aBackendAvailable?.isBackenAvailable === true;
 
 export const isHeaterActive = (aBrewingStatus?: BrewingStatus): boolean =>
-    typeof aBrewingStatus?.heating?.heaterEnabled === 'boolean'
-        ? aBrewingStatus.heating.heaterEnabled
-        : aBrewingStatus?.hardware?.heater === 'ON' || aBrewingStatus?.currentStep?.mode === ProcessMode.HEATING;
+    aBrewingStatus?.hardware?.heater === 'ON';
+
+export const getHeaterDisplayStatus = (aBrewingStatus?: BrewingStatus): HeaterDisplayStatus => {
+    if (aBrewingStatus?.heating?.heaterEnabled === false) return 'blocked';
+    return isHeaterActive(aBrewingStatus) ? 'active' : 'ready';
+};
+
+export const getHeaterDisplayLabel = (aBrewingStatus?: BrewingStatus): string => {
+    const labels: Record<HeaterDisplayStatus, string> = {
+        blocked: 'Heizung gesperrt',
+        ready: 'Heizung bereit',
+        active: 'Heizung aktiv',
+    };
+    return labels[getHeaterDisplayStatus(aBrewingStatus)];
+};
 
 export const isAgitatorActive = (aBrewingStatus?: BrewingStatus): boolean => aBrewingStatus?.hardware?.agitator === 'ON';


### PR DESCRIPTION
### Motivation

- Die Flammenanzeige zeigte fälschlicherweise eine aktive Heizung, weil die Helper-Logik `heating.heaterEnabled` und Prozessmodus-Indikatoren als physisches Schaltbild interpretiert hat.\
- Ziel war, die Flamme ausschließlich an `hardware.heater === 'ON'` zu koppeln und gleichzeitig die Heizfreigabe (`heaterEnabled`) als verständlichen UI-Status darzustellen.\

### Description

- `isHeaterActive` in `src/containers/Production/utils/productionStatus.ts` wurde angepasst, so dass es jetzt ausschließlich `hardware.heater === 'ON'` prüft und nicht mehr `heating.heaterEnabled` oder `ProcessMode`.\
- Neue Hilfsfunktionen `getHeaterDisplayStatus` und `getHeaterDisplayLabel` wurden eingeführt, die aus `heating.heaterEnabled` und `hardware.heater` die drei benutzerfreundlichen Zustände ableiten: `Heizung gesperrt`, `Heizung bereit`, `Heizung aktiv`.\
- Die Desktop-Production-UI zeigt den kompakten Status-Badge im bestehenden Flammenbereich an; die animierten Flammen bleiben entkoppelt und werden nur angezeigt, wenn `hardware.heater === 'ON'`.\
- Mobile Statusansicht verwendet statt einer Ja/Nein-Anzeige nun das ableitete Label (`Heizung gesperrt`/`Heizung bereit`/`Heizung aktiv`).\
- Projektdokumentation in mehreren `docs/codex/*`-Dateien wurde aktualisiert, um die korrekte semantische Bedeutung von `heating.heaterEnabled` (als Freigabe/Permission) und `hardware.heater` (als physischer Schaltzustand) zu beschreiben.\
- Dateien geändert: `src/containers/Production/utils/productionStatus.ts`, `src/containers/Production/Production.tsx`, `src/containers/Production/Production.css`, `src/containers/Production/Production.test.tsx`, `src/containers/Mobile/MobileStatusView/MobileProductionView.tsx`, `src/containers/Mobile/MobileStatusView/MobileProductionView.test.tsx` sowie mehrere `docs/codex`-Kontextdateien.

### Testing

- Unit-/Integrationstests wurden ergänzt/aktualisiert: `src/containers/Production/Production.test.tsx` (mehrere Fälle inklusive Dekoktion-Return, Rast über Ziel, aktives Nachheizen) und `src/containers/Mobile/MobileStatusView/MobileProductionView.test.tsx` (Prüfung der Trennung von Heizfreigabe und physischem Zustand).\
- Repository-Checks (`git diff --check`) und die Code-Änderungen wurden lokal committed (Commit: `b9b815a`).\
- Ausführen der automatisierten Tests / Build in dieser Umgebung schlug fehl, weil `npm ci` in dieser Umgebung Abhängigkeitsfehler (Zugriff/Cache-Probleme gegen registry.npmjs.org) gemeldet hat; daher konnten `react-scripts` und die Testläufer nicht gestartet werden und die Jest-Runner-Läufe wurden nicht erfolgreich ausgeführt.\
- Ergebnis: Tests wurden ergänzt und sollten in einer vollständigen Entwickler-/CI-Umgebung mit funktionierendem npm-Registry-Zugriff grün laufen; hier blieb die Ausführung aufgrund von Paket-Installationsfehlern ausstehend.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a914db85124832fb5d490bd9a28d481)