### PR TITLE
UI: Clarify active production step, compact water controls, style recipe import dialog

### DIFF
--- a/src/containers/DatabaseOverview/RecipeImportDialog.css
+++ b/src/containers/DatabaseOverview/RecipeImportDialog.css
@@ -1,0 +1,124 @@
+.recipe-import-dialog.MuiPaper-root {
+    color: var(--color-text);
+    background: var(--color-surface-2);
+    border: 1px solid var(--color-border);
+    border-radius: var(--border-radius-large);
+    box-shadow: 0 12px 32px var(--shadow-panel2);
+}
+
+.recipe-import-dialog__title.MuiDialogTitle-root {
+    padding: var(--spacing-md) var(--spacing-lg);
+    color: var(--color-white);
+    background: var(--color-accent);
+    font-size: var(--font-size-section-title);
+    font-weight: 700;
+}
+
+.recipe-import-dialog__content.MuiDialogContent-root {
+    padding: var(--spacing-md) var(--spacing-lg) var(--spacing-lg);
+}
+
+.recipe-import-dialog__format .MuiInputLabel-root,
+.recipe-import-dialog__format .MuiSelect-icon {
+    color: var(--color-text-secondary);
+}
+
+.recipe-import-dialog__format .MuiOutlinedInput-root {
+    color: var(--color-text);
+    background: var(--color-surface-strong);
+    border-radius: var(--border-radius-medium);
+}
+
+.recipe-import-dialog__format .MuiOutlinedInput-notchedOutline {
+    border-color: var(--color-border-strong);
+}
+
+.recipe-import-dialog__format .MuiOutlinedInput-root:hover:not(.Mui-disabled) .MuiOutlinedInput-notchedOutline {
+    border-color: var(--color-accent-border);
+}
+
+.recipe-import-dialog__format .MuiOutlinedInput-root.Mui-focused .MuiOutlinedInput-notchedOutline {
+    border-color: var(--color-primary);
+    border-width: 2px;
+}
+
+.recipe-import-dialog__format .MuiInputLabel-root.Mui-focused {
+    color: var(--color-accent-hover);
+}
+
+.recipe-import-dialog__format .Mui-disabled {
+    color: var(--color-disabled-text);
+    -webkit-text-fill-color: var(--color-disabled-text);
+}
+
+.recipe-import-dialog__menu.MuiPaper-root {
+    color: var(--color-text);
+    background: var(--color-surface-strong);
+    border: 1px solid var(--color-border);
+}
+
+.recipe-import-dialog__menu .MuiMenuItem-root:hover,
+.recipe-import-dialog__menu .MuiMenuItem-root.Mui-selected,
+.recipe-import-dialog__menu .MuiMenuItem-root.Mui-selected:hover {
+    background: var(--color-accent-subtle-hover);
+}
+
+.recipe-import-dialog__file-button.MuiButton-root,
+.recipe-import-dialog__cancel-button.MuiButton-root,
+.recipe-import-dialog__import-button.MuiButton-root {
+    min-height: var(--control-height-compact);
+    border-radius: var(--border-radius-medium);
+    font-weight: 700;
+    text-transform: none;
+}
+
+.recipe-import-dialog__file-button.MuiButton-root,
+.recipe-import-dialog__cancel-button.MuiButton-root {
+    color: var(--color-accent-hover);
+    border-color: var(--color-accent-border);
+}
+
+.recipe-import-dialog__file-button.MuiButton-root:hover,
+.recipe-import-dialog__cancel-button.MuiButton-root:hover {
+    color: var(--color-white);
+    background: var(--color-accent-subtle-hover);
+    border-color: var(--color-accent-hover);
+}
+
+.recipe-import-dialog__import-button.MuiButton-root {
+    color: var(--color-text-on-primary);
+    background: var(--color-primary);
+}
+
+.recipe-import-dialog__import-button.MuiButton-root:hover {
+    background: var(--color-primary-hover);
+}
+
+.recipe-import-dialog__file-button.MuiButton-root:focus-visible,
+.recipe-import-dialog__cancel-button.MuiButton-root:focus-visible,
+.recipe-import-dialog__import-button.MuiButton-root:focus-visible {
+    outline: 2px solid var(--color-accent-hover);
+    outline-offset: 2px;
+}
+
+.recipe-import-dialog .MuiButton-root.Mui-disabled {
+    color: var(--color-disabled-text);
+    background: var(--color-disabled-bg);
+    border-color: var(--color-disabled-border);
+}
+
+.recipe-import-dialog__error {
+    margin: var(--spacing-md) 0 0;
+    padding: var(--spacing-sm) var(--spacing-md);
+    color: var(--color-text);
+    background: var(--color-error-subtle);
+    border: 1px solid var(--color-error);
+    border-radius: var(--border-radius-medium);
+    font-size: var(--font-size-small);
+}
+
+.recipe-import-dialog__actions.MuiDialogActions-root {
+    gap: var(--spacing-sm);
+    padding: var(--spacing-md) var(--spacing-lg) var(--spacing-lg);
+    border-top: 1px solid var(--color-border-soft);
+}

--- a/src/containers/DatabaseOverview/RecipeImportDialog.test.tsx
+++ b/src/containers/DatabaseOverview/RecipeImportDialog.test.tsx
@@ -13,6 +13,16 @@ const selectFile = (file: File) => fireEvent.change(document.querySelector('inpu
 describe('RecipeImportDialog', () => {
     beforeEach(() => (createImportIdempotencyKey as jest.Mock).mockReset().mockReturnValue('key-a'));
 
+    it('uses the app dialog styles for its surface and controls', () => {
+        render(<RecipeImportDialog open onCancel={jest.fn()} onImport={jest.fn()} />);
+
+        expect(screen.getByRole('dialog')).toHaveClass('recipe-import-dialog');
+        expect(screen.getByText('Rezept importieren')).toHaveClass('recipe-import-dialog__title');
+        expect(screen.getByRole('button', {name: 'Datei auswählen'})).toHaveClass('recipe-import-dialog__file-button');
+        expect(screen.getByRole('button', {name: 'Abbrechen'})).toHaveClass('recipe-import-dialog__cancel-button');
+        expect(screen.getByRole('button', {name: 'Importieren'})).toHaveClass('recipe-import-dialog__import-button');
+    });
+
     it.each([
         ['Brauhaus', RecipeImportFormat.BRAUHAUS],
         ['MaischeMalzundMehr (MMuM)', RecipeImportFormat.MMUM],

--- a/src/containers/DatabaseOverview/RecipeImportDialog.tsx
+++ b/src/containers/DatabaseOverview/RecipeImportDialog.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import {Button, CircularProgress, Dialog, DialogActions, DialogContent, DialogTitle, FormControl, InputLabel, MenuItem, Select, SelectChangeEvent} from '@mui/material';
 import {JsonObject, RecipeImportFormat, RecipeImportRequest} from '../../model/RecipeImport';
 import {createImportIdempotencyKey} from '../../utils/recipeImport';
+import './RecipeImportDialog.css';
 
 interface RecipeImportDialogProps {
     open: boolean;
@@ -65,12 +66,13 @@ export const RecipeImportDialog: React.FC<RecipeImportDialogProps> = ({open, loa
     const canImport = Boolean(format && recipe && idempotencyKey && !parseError && !loading);
 
     return (
-        <Dialog open={open} onClose={loading ? undefined : resetAndCancel} maxWidth="sm" fullWidth>
-            <DialogTitle>Rezept importieren</DialogTitle>
-            <DialogContent>
-                <FormControl fullWidth margin="normal">
+        <Dialog open={open} onClose={loading ? undefined : resetAndCancel} maxWidth="sm" fullWidth PaperProps={{className: 'recipe-import-dialog'}}>
+            <DialogTitle className="recipe-import-dialog__title">Rezept importieren</DialogTitle>
+            <DialogContent className="recipe-import-dialog__content">
+                <FormControl className="recipe-import-dialog__format" fullWidth margin="normal">
                     <InputLabel id="recipe-import-format-label">Importformat</InputLabel>
                     <Select labelId="recipe-import-format-label" label="Importformat" value={format} disabled={loading}
+                        MenuProps={{PaperProps: {className: 'recipe-import-dialog__menu'}}}
                         onChange={(event: SelectChangeEvent) => {
                             setFormat(event.target.value as RecipeImportFormat);
                             if (recipe) setIdempotencyKey(createImportIdempotencyKey());
@@ -79,17 +81,17 @@ export const RecipeImportDialog: React.FC<RecipeImportDialogProps> = ({open, loa
                         <MenuItem value={RecipeImportFormat.MMUM}>MaischeMalzundMehr (MMuM)</MenuItem>
                     </Select>
                 </FormControl>
-                <Button component="label" variant="outlined" fullWidth disabled={loading}>
+                <Button className="recipe-import-dialog__file-button" component="label" variant="outlined" fullWidth disabled={loading}>
                     {fileName || 'Datei auswählen'}
                     <input hidden type="file" accept=".json,application/json"
                         onChange={(event) => { void readFile(event.target.files?.[0]); event.target.value = ''; }} />
                 </Button>
-                {parseError && <p role="alert">{parseError}</p>}
-                {backendError && submitted && <p role="alert">{backendError}</p>}
+                {parseError && <p className="recipe-import-dialog__error" role="alert">{parseError}</p>}
+                {backendError && submitted && <p className="recipe-import-dialog__error" role="alert">{backendError}</p>}
             </DialogContent>
-            <DialogActions>
-                <Button onClick={resetAndCancel} disabled={loading}>Abbrechen</Button>
-                <Button onClick={() => {
+            <DialogActions className="recipe-import-dialog__actions">
+                <Button className="recipe-import-dialog__cancel-button" onClick={resetAndCancel} disabled={loading}>Abbrechen</Button>
+                <Button className="recipe-import-dialog__import-button" onClick={() => {
                     if (format && recipe && idempotencyKey) {
                         setSubmitted(true);
                         onImport({format, recipe, idempotencyKey});

--- a/src/containers/Production/ProcessList/ProcessList.test.tsx
+++ b/src/containers/Production/ProcessList/ProcessList.test.tsx
@@ -210,6 +210,16 @@ describe('ProcessList compact production overview', () => {
         alarms: [],
     });
 
+    it('uses a single compact active-step heading above the step name and target temperature', () => {
+        const {container} = render(<ProcessList displayMode="current" selectedBeer={selectedBeer} currentStepIndex={3} brewingStatus={activeStatus(3)} remainingSeconds={1176} />);
+
+        expect(screen.getAllByText('Aktiver Schritt')).toHaveLength(1);
+        expect(screen.getByText('Rast 2')).toBeInTheDocument();
+        expect(screen.getByText('68 °C')).toBeInTheDocument();
+        expect(container.querySelector('.current-step-heading')).toContainElement(screen.getByText('Rast 2'));
+        expect(container.querySelector('.current-step-heading')).toContainElement(screen.getByText('68 °C'));
+    });
+
     it('shows current visible step position and total visible steps', () => {
         render(<ProcessList selectedBeer={selectedBeer} currentStepIndex={3} currentStep={{index: 3, phase: ProcessPhase.RAST, mode: ProcessMode.TIMER_RUNNING}} brewingStatus={activeStatus(3)} remainingSeconds={1176} />);
 

--- a/src/containers/Production/ProcessList/ProcessList.tsx
+++ b/src/containers/Production/ProcessList/ProcessList.tsx
@@ -333,12 +333,12 @@ export class ProcessList extends React.Component<ProcessListProps, ProcessListSt
 
         const currentStepCard = hasRecipeProcess ? (
             <>
-                <div className="current-process-label">Aktueller Schritt</div>
+                <div className="current-process-label">Aktiver Schritt</div>
                 <section className={`current-process-step${confirmationRequest ? ' current-process-step--action-required' : ''}`} aria-label="Aktueller Prozessschritt">
                     <div className="current-step-heading">
                         <div>
                             <h4>{isProcessStarted ? this.getCurrentStepTitle(activeStep) : 'Noch kein Brauvorgang gestartet'}</h4>
-                            <span className="current-step-badge">{isProcessStarted ? 'Aktiver Schritt' : 'Geplanter Ablauf'}</span>
+                            {!isProcessStarted && <span className="current-step-badge">Geplanter Ablauf</span>}
                         </div>
                         {this.getCurrentStepMeta(activeStep, isProcessStarted)}
                     </div>

--- a/src/containers/Production/Production.css
+++ b/src/containers/Production/Production.css
@@ -310,7 +310,7 @@
     align-items: flex-start;
     gap: var(--spacing-lg);
 }
-.settingsRowWater { align-items: center; }
+.settingsRowWater { align-items: end; }
 .rightAligned,
 .leftAligned {
     margin: 0;
@@ -345,6 +345,13 @@
 .settings .quantity-picker-input { background: var(--color-surface-strong); }
 
 .settings .quantity-picker-input-disabled { background: var(--color-disabled-bg); }
+
+.waterSettingsSeparator {
+    width: 100%;
+    margin: var(--spacing-md) 0 0;
+    border: 0;
+    border-top: 1px solid var(--color-border-soft);
+}
 
 /* Buttons */
 .startBtnDiv {
@@ -431,7 +438,7 @@
 .recipeWaterButtons {
     display: flex;
     gap: var(--spacing-sm);
-    margin-top: var(--spacing-md);
+    margin-top: var(--spacing-sm);
 }
 
 .recipeWaterBtn {

--- a/src/containers/Production/Production.test.tsx
+++ b/src/containers/Production/Production.test.tsx
@@ -775,6 +775,21 @@ describe('Production layout structure', () => {
         expect(screen.getByRole('heading', {name: 'Wasser'})).toBeInTheDocument();
     });
 
+    it('groups manual water controls above a separator and the recipe water buttons', () => {
+        const {container} = renderProduction();
+        const manualControls = screen.getByLabelText('Manuelle Wasserzufuhr');
+        const separator = container.querySelector('.waterSettingsSeparator');
+        const recipeControls = container.querySelector('.recipeWaterButtons');
+
+        expect(manualControls).toContainElement(screen.getByText('Wasser aktivieren'));
+        expect(manualControls).toContainElement(screen.getByText('Liter'));
+        expect(separator).toBeInTheDocument();
+        expect(recipeControls).toContainElement(screen.getByRole('button', {name: /Nachguss/}));
+        expect(recipeControls).toContainElement(screen.getByRole('button', {name: /Hauptguss/}));
+        expect(manualControls.compareDocumentPosition(separator as Node) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+        expect((separator as Node).compareDocumentPosition(recipeControls as Node) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    });
+
     it('keeps the main production regions in a shared structural grid', () => {
         const {container} = renderProduction();
 

--- a/src/containers/Production/Production.tsx
+++ b/src/containers/Production/Production.tsx
@@ -670,7 +670,7 @@ export class Production extends React.Component<ProductionProps, ProductionState
 
                 <section className="settingsGroup" aria-labelledby="water-settings-title">
                     <h4 id="water-settings-title">Wasser</h4>
-                    <div className="settingsRowWater">
+                    <div className="settingsRowWater" aria-label="Manuelle Wasserzufuhr">
                         <div className="leftAligned">
                             {renderSwitch('Wasser aktivieren', waterSwitchState, this.toggleWaterSwitchState)}
                         </div>
@@ -679,6 +679,7 @@ export class Production extends React.Component<ProductionProps, ProductionState
                                             isDisabled={settingsDisabled || waterSwitchState} label="Liter" labelPosition="above"/>
                         </div>
                     </div>
+                    <hr className="waterSettingsSeparator" />
                     <div className="recipeWaterButtons">
                         <button className="recipeWaterBtn" disabled={spargeWaterDisabled} onClick={this.startSpargeWaterFilling}>{this.getRecipeWaterButtonLabel('sparge')}</button>
                         <button className="recipeWaterBtn" disabled={mashWaterDisabled} onClick={this.startMashWaterFilling}>{this.getRecipeWaterButtonLabel('mash')}</button>


### PR DESCRIPTION
### Motivation

- Improve the Production view UX by making the “Aktiver Schritt” heading single and more compact so step name and target temperature appear together. 
- Make manual water controls (activate, toggle, liters) visually grouped and aligned, separated from the recipe water actions while keeping existing water logic unchanged. 
- Make the Recipe Import dialog visually consistent with the app’s dark/orange theme using existing MUI controls and design tokens without changing import behavior.

### Description

- #167: Reworked the active-step header to use a single compact label and removed the redundant badge; ensured step name and target temperature are rendered within the same compact heading and added a focused unit test. (Changed: `src/containers/Production/ProcessList/ProcessList.tsx`, `src/containers/Production/ProcessList/ProcessList.test.tsx`)
- #168: Grouped manual water controls into one aligned row, added a subtle horizontal separator, and kept Nachguss/Hauptguss buttons below; adjusted CSS for alignment and spacing and added a layout test that asserts the grouping and order. (Changed: `src/containers/Production/Production.tsx`, `src/containers/Production/Production.css`, `src/containers/Production/Production.test.tsx`)
- #169: Restyled the Recipe Import dialog to reuse existing MUI Dialog/Select/Button components and app design tokens by adding scoped CSS classes and a small test that asserts the presence of the dialog surface and control classes; no import logic changes. (Changed: `src/containers/DatabaseOverview/RecipeImportDialog.tsx`, `src/containers/DatabaseOverview/RecipeImportDialog.css`, `src/containers/DatabaseOverview/RecipeImportDialog.test.tsx`)
- No backend, API, water-control logic or recipe-import behavior was modified; changes are strictly presentational and test additions are targeted to the modified components.

### Testing

- Ran `git diff --check` (no whitespace/format errors) and validated the working tree is clean before submitting changes. (success)
- Added/updated targeted Jest tests for the ProcessList, Production layout and RecipeImportDialog; attempted to run the targeted `npm test` commands, but the CI/test runs could not complete because dependency installation/build failed in this environment (npm registry access returned HTTP 403). (tests present but execution blocked)
- Attempted `npm ci`/`npm run build` to execute the full test/build matrix, but installation failed due to network/registry access restrictions; therefore local test execution and a full build could not be verified here. (failed due to environment)

Open points / risks

- Automated unit tests were added; however, they could not be executed in this environment because `npm ci` failed with HTTP 403 when contacting the npm registry—please run the test suite in CI or a developer environment with network access to confirm all tests pass. 
- No runtime or API behavior was changed, but reviewers should run the app to visually verify the new header alignment, water control separator, and the import dialog’s visual states (hover/focus/disabled) in the real theme.

Files changed (by issue)

- #167: `src/containers/Production/ProcessList/ProcessList.tsx`, `src/containers/Production/ProcessList/ProcessList.test.tsx`
- #168: `src/containers/Production/Production.tsx`, `src/containers/Production/Production.css`, `src/containers/Production/Production.test.tsx`
- #169: `src/containers/DatabaseOverview/RecipeImportDialog.tsx`, `src/containers/DatabaseOverview/RecipeImportDialog.css`, `src/containers/DatabaseOverview/RecipeImportDialog.test.tsx`

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a914f6021a0832f9bbbfb974779f868)