### PR TITLE
Manuelle Wasserzufuhr als orangeer Unterbereich (visuelle Anpassung, Issue #168)

### DIFF
--- a/src/containers/Production/Production.css
+++ b/src/containers/Production/Production.css
@@ -311,6 +311,7 @@
     gap: var(--spacing-lg);
 }
 .settingsRowWater { align-items: end; }
+.manualWaterControls { margin-top: var(--spacing-xs); }
 .rightAligned,
 .leftAligned {
     margin: 0;
@@ -345,13 +346,6 @@
 .settings .quantity-picker-input { background: var(--color-surface-strong); }
 
 .settings .quantity-picker-input-disabled { background: var(--color-disabled-bg); }
-
-.waterSettingsSeparator {
-    width: 100%;
-    margin: var(--spacing-md) 0 0;
-    border: 0;
-    border-top: 1px solid var(--color-border-soft);
-}
 
 /* Buttons */
 .startBtnDiv {

--- a/src/containers/Production/Production.test.tsx
+++ b/src/containers/Production/Production.test.tsx
@@ -773,21 +773,23 @@ describe('Production layout structure', () => {
         expect(screen.getByRole('heading', {name: 'Rührwerk'})).toBeInTheDocument();
         expect(screen.getByRole('heading', {name: 'Intervallbetrieb'})).toBeInTheDocument();
         expect(screen.getByRole('heading', {name: 'Wasser'})).toBeInTheDocument();
+        expect(screen.getByRole('heading', {name: 'Manuelle Wasserzufuhr'})).toBeInTheDocument();
     });
 
-    it('groups manual water controls above a separator and the recipe water buttons', () => {
+    it('groups manual water controls in an accent container above the recipe water buttons', () => {
         const {container} = renderProduction();
-        const manualControls = screen.getByLabelText('Manuelle Wasserzufuhr');
-        const separator = container.querySelector('.waterSettingsSeparator');
+        const manualHeading = screen.getByRole('heading', {name: 'Manuelle Wasserzufuhr'});
+        const manualControls = container.querySelector('.manualWaterSettings');
         const recipeControls = container.querySelector('.recipeWaterButtons');
 
+        expect(manualControls).toHaveClass('intervalSettings');
+        expect(manualControls).toContainElement(manualHeading);
         expect(manualControls).toContainElement(screen.getByText('Wasser aktivieren'));
         expect(manualControls).toContainElement(screen.getByText('Liter'));
-        expect(separator).toBeInTheDocument();
+        expect(container.querySelector('.waterSettingsSeparator')).not.toBeInTheDocument();
         expect(recipeControls).toContainElement(screen.getByRole('button', {name: /Nachguss/}));
         expect(recipeControls).toContainElement(screen.getByRole('button', {name: /Hauptguss/}));
-        expect(manualControls.compareDocumentPosition(separator as Node) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
-        expect((separator as Node).compareDocumentPosition(recipeControls as Node) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+        expect((manualControls as Node).compareDocumentPosition(recipeControls as Node) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
     });
 
     it('keeps the main production regions in a shared structural grid', () => {

--- a/src/containers/Production/Production.tsx
+++ b/src/containers/Production/Production.tsx
@@ -670,16 +670,18 @@ export class Production extends React.Component<ProductionProps, ProductionState
 
                 <section className="settingsGroup" aria-labelledby="water-settings-title">
                     <h4 id="water-settings-title">Wasser</h4>
-                    <div className="settingsRowWater" aria-label="Manuelle Wasserzufuhr">
-                        <div className="leftAligned">
-                            {renderSwitch('Wasser aktivieren', waterSwitchState, this.toggleWaterSwitchState)}
-                        </div>
-                        <div className="rightAligned">
-                            <QuantityPicker initialValue={1} min={1} max={this.MAX_WATER_LEVEL} onChange={this.onSetWaterChangeQuantity}
-                                            isDisabled={settingsDisabled || waterSwitchState} label="Liter" labelPosition="above"/>
+                    <div className="intervalSettings manualWaterSettings" aria-labelledby="manual-water-settings-title">
+                        <h5 id="manual-water-settings-title">Manuelle Wasserzufuhr</h5>
+                        <div className="settingsRowWater manualWaterControls">
+                            <div className="leftAligned">
+                                {renderSwitch('Wasser aktivieren', waterSwitchState, this.toggleWaterSwitchState)}
+                            </div>
+                            <div className="rightAligned">
+                                <QuantityPicker initialValue={1} min={1} max={this.MAX_WATER_LEVEL} onChange={this.onSetWaterChangeQuantity}
+                                                isDisabled={settingsDisabled || waterSwitchState} label="Liter" labelPosition="above"/>
+                            </div>
                         </div>
                     </div>
-                    <hr className="waterSettingsSeparator" />
                     <div className="recipeWaterButtons">
                         <button className="recipeWaterBtn" disabled={spargeWaterDisabled} onClick={this.startSpargeWaterFilling}>{this.getRecipeWaterButtonLabel('sparge')}</button>
                         <button className="recipeWaterBtn" disabled={mashWaterDisabled} onClick={this.startMashWaterFilling}>{this.getRecipeWaterButtonLabel('mash')}</button>


### PR DESCRIPTION
### Motivation

- Ziel ist, die Wasser-Card visuell an den bereits vorhandenen Aufbau des Rührwerk‑Bereichs anzupassen, damit beide Bereiche aus demselben Designsystem stammen.
- Die manuelle Wasserzufuhr soll als eigener, orange umrandeter Unterbereich dargestellt werden und das vorhandene „Intervallbetrieb“-Styling wiederverwenden.
- Es dürfen keine Änderungen an Wasserlogik, Button‑Zuständen oder Backend/API stattfinden.

### Description

- Die manuelle Steuerung wurde in `src/containers/Production/Production.tsx` in eine Accent‑Box überführt, indem die vorhandene `.intervalSettings`‑Klasse wiederverwendet wurde und eine neue Überschrift `Manuelle Wasserzufuhr` (`<h5>`) eingefügt wurde.
- Toggle (`Wasser aktivieren`) und Liter‑QuantityPicker wurden innerhalb des neuen Unterbereichs sauber ausgerichtet (neue Klassen: `.manualWaterSettings`, `.manualWaterControls`) und die bisherige horizontale Trennlinie entfernt, sodass die Rezeptbuttons (`Nachguss` / `Hauptguss`) weiterhin nebeneinander darunter stehen.
- Kleine CSS‑Anpassung in `src/containers/Production/Production.css` zur Positionierung des Unterbereichs (`.manualWaterControls`) und Entfernen der alten Separator‑Regel, um den visuellen Stil an den Rührwerk‑Bereich anzugleichen.
- Der Test in `src/containers/Production/Production.test.tsx` wurde aktualisiert, um die neue Überschrift und Struktur abzufragen (prüft nun die Existenz von `Manuelle Wasserzufuhr`, die Wiederverwendung der Accent‑Containerklasse und das Fehlen des Separators).
- Es wurden keine Änderungen an business‑logic, API‑Aufrufen oder Button‑Handlern vorgenommen.

### Testing

- Die unit‑Testdatei `src/containers/Production/Production.test.tsx` wurde angepasst, um die neue DOM‑Hierarchie zu erwarten; die Tests konnten jedoch in dieser Umgebung nicht ausgeführt werden.
- Ein Versuch, die Tests lokal mit `CI=true npm test -- --runInBand src/containers/Production/Production.test.tsx` auszuführen, schlug fehl, weil Abhängigkeiten nicht installiert werden konnten (`npm ci` wurde durch eine Registry‑Sicherheitsrichtlinie mit HTTP 403 geblockt), daher wurden die Jest‑Tests nicht ausgeführt.
- Vor dem Push wurde `git diff --check` ausgeführt; es wurden keine linter‑blocking Diff‑Fehler gefunden.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a9153c373d0832facdb72d1593c0c0e)