### PR TITLE
Debounce für Rührwerks-Geschwindigkeit (300ms)

### DIFF
--- a/src/containers/Production/Production.test.tsx
+++ b/src/containers/Production/Production.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import {render, screen, fireEvent, waitFor} from '@testing-library/react';
-import {Production} from './Production';
+import {act, render, screen, fireEvent, waitFor, within} from '@testing-library/react';
+import {AGITATOR_SPEED_DEBOUNCE_MS, Production} from './Production';
 import {Beer} from '../../model/Beer';
 import {ToggleState} from '../../enums/eToggleState';
 import {AlarmType, BrewingStatus, ProcessMode, ProcessPhase, ProcessState, WaitingFor} from '../../model/brewingStatus.types';
@@ -86,6 +86,73 @@ const renderProduction = (aOverrides: Partial<React.ComponentProps<typeof Produc
     };
     return {props, ...render(<Production {...props} />)};
 };
+
+describe('Production agitator speed control', () => {
+    beforeEach(() => jest.useFakeTimers());
+    afterEach(() => {
+        jest.clearAllTimers();
+        jest.useRealTimers();
+    });
+
+    const getSpeedControl = () => screen.getByText('Geschwindigkeit').closest('.quantity-picker-container') as HTMLElement;
+
+    const incrementSpeed = () => {
+        const incrementButton = within(getSpeedControl()).getByRole('button', {name: '+'});
+        fireEvent.mouseDown(incrementButton);
+        fireEvent.mouseUp(incrementButton);
+    };
+
+    it('updates the displayed speed immediately and sends only the latest rapid change', () => {
+        const setAgitatorSpeed = jest.fn();
+        renderProduction({setAgitatorSpeed});
+
+        incrementSpeed();
+        incrementSpeed();
+        incrementSpeed();
+
+        expect(within(getSpeedControl()).getByText('4')).toBeInTheDocument();
+        expect(setAgitatorSpeed).not.toHaveBeenCalled();
+
+        act(() => jest.advanceTimersByTime(AGITATOR_SPEED_DEBOUNCE_MS));
+
+        expect(setAgitatorSpeed).toHaveBeenCalledTimes(1);
+        expect(setAgitatorSpeed).toHaveBeenCalledWith(4);
+    });
+
+    it('sends a single change only after the debounce delay', () => {
+        const setAgitatorSpeed = jest.fn();
+        renderProduction({setAgitatorSpeed});
+
+        incrementSpeed();
+        act(() => jest.advanceTimersByTime(AGITATOR_SPEED_DEBOUNCE_MS - 1));
+        expect(setAgitatorSpeed).not.toHaveBeenCalled();
+
+        act(() => jest.advanceTimersByTime(1));
+        expect(setAgitatorSpeed).toHaveBeenCalledWith(2);
+    });
+
+    it('cancels a pending speed request when the view unmounts', () => {
+        const setAgitatorSpeed = jest.fn();
+        const {unmount} = renderProduction({setAgitatorSpeed});
+
+        incrementSpeed();
+        unmount();
+        act(() => jest.advanceTimersByTime(AGITATOR_SPEED_DEBOUNCE_MS));
+
+        expect(setAgitatorSpeed).not.toHaveBeenCalled();
+    });
+
+    it('cancels a pending speed request when the controller becomes unavailable', () => {
+        const setAgitatorSpeed = jest.fn();
+        const {props, rerender} = renderProduction({setAgitatorSpeed});
+
+        incrementSpeed();
+        rerender(<Production {...props} isBackenAvailable={{isBackenAvailable: false, statusText: 'Offline'}} />);
+        act(() => jest.advanceTimersByTime(AGITATOR_SPEED_DEBOUNCE_MS));
+
+        expect(setAgitatorSpeed).not.toHaveBeenCalled();
+    });
+});
 
 describe('Production finished-brew persistence', () => {
     beforeEach(() => dataCollector.reset());

--- a/src/containers/Production/Production.tsx
+++ b/src/containers/Production/Production.tsx
@@ -40,6 +40,8 @@ import {equipmentAlarmDisplay, isEquipmentAlarmActive} from '../../utils/brewing
 import {getConfirmationRequestViewModel} from '../../utils/brewingStatus/selectors';
 import {ConfirmStates} from '../../enums/eConfirmStates';
 
+export const AGITATOR_SPEED_DEBOUNCE_MS = 300;
+
 export interface ProductionProps {
     selectedBeer?: Beer;
     temperature: number;
@@ -110,6 +112,7 @@ export class Production extends React.Component<ProductionProps, ProductionState
     private readonly MAX_BREAK_TIME = 10;
     private readonly MAX_RUNNING_TIME = 10;
     private remainingTimeInterval: NodeJS.Timeout | null = null;
+    private agitatorSpeedDebounceTimeout: NodeJS.Timeout | null = null;
     private errorTimeouts: NodeJS.Timeout[] = [];
     private isMountedComponent = false;
 
@@ -159,6 +162,7 @@ export class Production extends React.Component<ProductionProps, ProductionState
 
     componentWillUnmount() {
         this.isMountedComponent = false;
+        this.clearAgitatorSpeedDebounce();
         if (this.remainingTimeInterval !== null) {
             clearInterval(this.remainingTimeInterval);
             this.remainingTimeInterval = null;
@@ -175,6 +179,10 @@ export class Production extends React.Component<ProductionProps, ProductionState
 
         if (prevProps.brewingStatus !== brewingStatus) {
             this.syncRemainingTimeFromStatus();
+        }
+
+        if (getIsControllerAvailable(prevProps.isBackenAvailable) && !this.isControllerAvailable()) {
+            this.clearAgitatorSpeedDebounce();
         }
 
         if (isEquipmentAlarmActive(prevProps.brewingStatus) && !isEquipmentAlarmActive(brewingStatus)) {
@@ -364,9 +372,21 @@ export class Production extends React.Component<ProductionProps, ProductionState
         if (!this.isControllerAvailable()) {
             return;
         }
-        const {setAgitatorSpeed} = this.props
         this.setState({agitatorSpeed: value});
-        setAgitatorSpeed(value);
+        this.clearAgitatorSpeedDebounce();
+        this.agitatorSpeedDebounceTimeout = setTimeout(() => {
+            this.agitatorSpeedDebounceTimeout = null;
+            if (this.isControllerAvailable()) {
+                this.props.setAgitatorSpeed(value);
+            }
+        }, AGITATOR_SPEED_DEBOUNCE_MS);
+    }
+
+    clearAgitatorSpeedDebounce = (): void => {
+        if (this.agitatorSpeedDebounceTimeout !== null) {
+            clearTimeout(this.agitatorSpeedDebounceTimeout);
+            this.agitatorSpeedDebounceTimeout = null;
+        }
     }
 
     onIntervalChangeBreakTime = (value: number) => {


### PR DESCRIPTION
### Motivation
- Der aktuelle `onAgitatorSpeedChange` ruft unmittelbar `setAgitatorSpeed` auf und führt bei schnellen Slider-/Picker-Änderungen zu vielen Controller-Requests; nur der letzte Wert soll gesendet werden. 
- Sichtbares UI-Verhalten muss sofort reagieren, während der eigentliche Controller-Request debounced wird. 
- Beim Unmounten oder bei Verlust der Controller-Verfügbarkeit müssen ausstehende Timers sauber bereinigt werden.

### Description
- Ergänzt konstante `AGITATOR_SPEED_DEBOUNCE_MS = 300` und einen Timeout-Puffer in `src/containers/Production/Production.tsx`. 
- Debounce-Logik umgesetzt in `onAgitatorSpeedChange`: lokale State-Aktualisierung erfolgt sofort, das Dispatch `setAgitatorSpeed(value)` wird per `setTimeout` verzögert und vorherige Timer werden überschrieben. 
- Cleanup hinzugefügt: Pending-Timeout wird beim `componentWillUnmount` und beim Wechsel der Controller-Verfügbarkeit abgeräumt (Methode `clearAgitatorSpeedDebounce`). 
- Tests ergänzt in `src/containers/Production/Production.test.tsx` mit Fake-Timer-Szenarien, die Abdeckung für schnelle Mehrfachänderungen, einzelne Änderung, sofortige UI-Aktualisierung und Cleanup bei Unmount / Controller-Ausfall hinzufügen.
- Es wurden nur zielgerichtete Änderungen an der bestehenden Struktur vorgenommen; Ein-/Ausschalt-Logik, Intervallbetrieb und sonstige Rührwerkslogik bleiben unverändert.

### Testing
- Unit tests wurden ergänzt (`src/containers/Production/Production.test.tsx`) to cover: rapid multiple changes -> only last sent, single change -> request after ~300ms, immediate UI update, cleanup on unmount and controller-unavailable. 
- `git diff --check` passed locally against the working tree. 
- Running `npm test`/`npm run build` could not be completed in this environment because dependency installation was blocked by a peer-dependency conflict and network/proxy restrictions, so the new Jest tests were not executed here (the test code is present and uses `jest.useFakeTimers()` and `act(jest.advanceTimersByTime(...))`). 

Geänderte Dateien
- `src/containers/Production/Production.tsx` (Debounce-Konstante, Timeout-Feld, `onAgitatorSpeedChange`, `clearAgitatorSpeedDebounce`, Cleanup-Aufrufe)
- `src/containers/Production/Production.test.tsx` (neue Tests für Debounce- und Cleanup-Verhalten)

Debounce-Implementierung
- Debounce befindet sich in `Production.onAgitatorSpeedChange` und nutzt `AGITATOR_SPEED_DEBOUNCE_MS = 300` sowie `setTimeout`/`clearTimeout`.

Tests ausgeführt / Ergebnis
- `git diff --check`: erfolgreich.
- `npm ci` / `npm test` / `npm run build`: konnten in dieser Umgebung nicht erfolgreich ausgeführt werden aufgrund eines vorhandenen Peer-Dependency-Konflikts (`@material-ui/core` vs. `@types/react`) und einer blockierten Paket-Proxy-Verbindung; die Jest-Tests wurden daher nicht ausgeführt hier, sind aber im Repo angelegt.

Weitere Beobachtungen
- Das sichtbare Bedienelement ist ein `QuantityPicker` (Plus/Minus) und kein nativer Slider, was das UX-Verhalten nicht beeinflusst, aber bei künftigen UI-Änderungen beachtet werden sollte. 
- Die Build-/Test-Ausführung in dieser Umgebung ist durch Paketauflösungs- und Proxy-Probleme eingeschränkt; lokale CI oder ein Entwickler-Rechner mit Netzwerkzugang wird benötigt, um die neuen Tests laufen zu lassen und `npm run build` zu prüfen.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a929c41bc8c832f94fc48b82bf36d24)