### PR TITLE
Agitator: switch-mode UI, status load handling, CSS tweaks and expanded tests

### DIFF
--- a/src/containers/Production/Production.css
+++ b/src/containers/Production/Production.css
@@ -213,18 +213,19 @@
     font-weight: 700;
 }
 
-.agitatorModeControl { display: grid; grid-template-columns: repeat(3, 1fr); gap: 0.25rem; }
-.agitatorModeControl button, .agitatorPauseButton { border: 1px solid var(--color-accent-border); border-radius: var(--border-radius-medium); background: var(--color-surface-2); color: var(--color-text); padding: 0.55rem 0.35rem; font-weight: 700; }
-.agitatorModeControl button[aria-pressed="true"] { background: var(--color-accent); color: var(--color-light-text); }
-.agitatorRuntimeStatus { margin: 0.65rem 0; font-weight: 700; color: var(--color-text); }
-.agitatorSpeedControl { display: grid; gap: 0.35rem; color: var(--color-text); }
+.agitatorPauseButton { border: 1px solid var(--color-accent-border); border-radius: var(--border-radius-medium); background: var(--color-surface-2); color: var(--color-text); padding: 0.55rem 0.35rem; font-weight: 700; }
+.agitatorAvailability { margin: 0 0 var(--spacing-xs); color: var(--color-text-muted); font-size: var(--font-size-small); }
+.agitatorSpeedControl { display: grid; gap: 0.35rem; margin-top: var(--spacing-sm); color: var(--color-text); }
 .agitatorSpeedControl span { display: flex; justify-content: space-between; }
 .agitatorSpeedControl input { width: 100%; accent-color: var(--color-accent); }
 .agitatorAutomaticSettings { opacity: 0.58; }
 .agitatorAutomaticSettings.is-active { opacity: 1; }
+.agitatorAutomaticHeader { display: flex; align-items: flex-start; justify-content: space-between; gap: var(--spacing-sm); }
+.agitatorAutomaticHeader p { margin: 0.2rem 0 0; color: var(--color-text-muted); font-size: var(--font-size-small); }
+.agitatorAutomaticSettings h6 { margin: var(--spacing-sm) 0 0; color: var(--color-text); font-size: var(--font-size-small); }
 .agitatorAutomaticSettings .intervalTimeControls label { display: grid; grid-template-columns: 1fr 4.5rem auto; align-items: center; gap: 0.3rem; color: var(--color-text); }
 .agitatorAutomaticSettings input { width: 100%; padding: 0.35rem; }
-.agitatorPauseButton { width: 100%; margin-top: 0.65rem; }
+.agitatorPauseButton { width: 100%; margin-top: var(--spacing-sm); padding-top: var(--spacing-sm); border-top-color: var(--color-border-soft); }
 .agitatorError { color: var(--color-error); margin: 0.5rem 0 0; }
 
 .intervalHeader {

--- a/src/containers/Production/Production.test.tsx
+++ b/src/containers/Production/Production.test.tsx
@@ -103,18 +103,73 @@ describe('Production agitator controller integration', () => {
     });
     afterEach(() => jest.restoreAllMocks());
 
-    it('initializes from detail status and renders controller runtime', async () => {
+    it('maps AUTOMATIC detail state to the switches without a runtime status row', async () => {
         renderProduction();
         expect(await screen.findByText('Geschwindigkeit')).toBeInTheDocument();
         expect(screen.getByText('36 %')).toBeInTheDocument();
-        expect(screen.getByText('Automatik · Intervallpause')).toBeInTheDocument();
+        expect(screen.getByRole('switch', {name: 'Durchgehend rühren'})).not.toBeChecked();
+        expect(screen.getByRole('switch', {name: 'Automatik'})).toBeChecked();
+        expect(screen.queryByText('Automatik · Intervallpause')).not.toBeInTheDocument();
         expect(ProductionRepository.getAgitatorStatus).toHaveBeenCalledTimes(1);
     });
 
-    it('sends a complete config for mode selection', async () => {
+    it('keeps the complete agitator UI visible and disabled when detail status is unavailable', async () => {
+        jest.spyOn(ProductionRepository, 'getAgitatorStatus').mockRejectedValue(new Error('offline'));
+        renderProduction({isBackenAvailable: {isBackenAvailable: false, statusText: 'Offline'}});
+        expect(await screen.findByText('Rührwerk-Konfiguration nicht verfügbar')).toBeInTheDocument();
+        expect(screen.getByRole('switch', {name: 'Durchgehend rühren'})).toBeDisabled();
+        expect(screen.getByRole('switch', {name: 'Automatik'})).toBeDisabled();
+        expect(screen.getByLabelText('Laufzeit')).toBeDisabled();
+        expect(screen.getByLabelText('Pausenzeit')).toBeDisabled();
+        expect(screen.getByRole('slider')).toBeDisabled();
+        expect(screen.getByText('Geschwindigkeit')).toBeInTheDocument();
+        expect(ProductionRepository.setAgitatorConfig).not.toHaveBeenCalled();
+    });
+
+    it.each([
+        ['OFF', false, false],
+        ['CONTINUOUS', true, false],
+        ['AUTOMATIC', false, true],
+    ] as const)('maps %s controller mode to continuous=%s and automatic=%s', async (mode, continuous, automatic) => {
+        jest.spyOn(ProductionRepository, 'getAgitatorStatus').mockResolvedValue({
+            ...detail,
+            config: {...detail.config, mode},
+        });
         renderProduction();
-        fireEvent.click(await screen.findByRole('button', {name: 'Dauerhaft'}));
+        expect(await screen.findByRole('switch', {name: 'Durchgehend rühren'})).toHaveProperty('checked', continuous);
+        expect(screen.getByRole('switch', {name: 'Automatik'})).toHaveProperty('checked', automatic);
+    });
+
+    it('switches directly from AUTOMATIC to CONTINUOUS with the complete confirmed config', async () => {
+        renderProduction();
+        fireEvent.click(await screen.findByRole('switch', {name: 'Durchgehend rühren'}));
         await waitFor(() => expect(ProductionRepository.setAgitatorConfig).toHaveBeenCalledWith({mode: 'CONTINUOUS', speedPercent: 36, runningSeconds: 30, breakSeconds: 120}));
+        expect(ProductionRepository.setAgitatorConfig).toHaveBeenCalledTimes(1);
+    });
+
+    it('switches directly from CONTINUOUS to AUTOMATIC and preserves interval and speed config', async () => {
+        jest.spyOn(ProductionRepository, 'getAgitatorStatus').mockResolvedValue({...detail, config: {...detail.config, mode: 'CONTINUOUS'}});
+        renderProduction();
+        fireEvent.click(await screen.findByRole('switch', {name: 'Automatik'}));
+        await waitFor(() => expect(ProductionRepository.setAgitatorConfig).toHaveBeenCalledWith({mode: 'AUTOMATIC', speedPercent: 36, runningSeconds: 30, breakSeconds: 120}));
+        expect(ProductionRepository.setAgitatorConfig).toHaveBeenCalledTimes(1);
+    });
+
+    it('turns an active mode off without changing the remaining config', async () => {
+        renderProduction();
+        fireEvent.click(await screen.findByRole('switch', {name: 'Automatik'}));
+        await waitFor(() => expect(ProductionRepository.setAgitatorConfig).toHaveBeenCalledWith({mode: 'OFF', speedPercent: 36, runningSeconds: 30, breakSeconds: 120}));
+    });
+
+    it('keeps both mode switches disabled while a config request is pending', async () => {
+        let resolveConfig!: (config: any) => void;
+        jest.spyOn(ProductionRepository, 'setAgitatorConfig').mockImplementation(config => new Promise(resolve => { resolveConfig = resolve; }));
+        renderProduction();
+        fireEvent.click(await screen.findByRole('switch', {name: 'Durchgehend rühren'}));
+        expect(screen.getByRole('switch', {name: 'Durchgehend rühren'})).toBeDisabled();
+        expect(screen.getByRole('switch', {name: 'Automatik'})).toBeDisabled();
+        resolveConfig({...detail.config, mode: 'CONTINUOUS'});
+        await waitFor(() => expect(screen.getByRole('switch', {name: 'Durchgehend rühren'})).toBeEnabled());
     });
 
     it('debounces speed drafts and sends only the latest complete config', async () => {
@@ -137,7 +192,21 @@ describe('Production agitator controller integration', () => {
         await screen.findByText('36 %');
         rerender(<Production {...props} brewingStatus={{...createBrewingStatus(), agitator: {mode: 'AUTOMATIC', paused: true, operation: 'INTERVAL', intervalPhase: 'BREAK', actualOutputOn: false}}} />);
         expect(await screen.findByText('36 %')).toBeInTheDocument();
-        expect(screen.getByText('Pausiert')).toBeInTheDocument();
+        expect(screen.getByRole('switch', {name: 'Automatik'})).toBeChecked();
+        expect(screen.getByRole('button', {name: 'Rührwerk fortsetzen'})).toBeInTheDocument();
+        expect(ProductionRepository.setAgitatorConfig).not.toHaveBeenCalled();
+    });
+
+    it('renders polled multi-client mode changes without sending config', async () => {
+        const {props, rerender} = renderProduction();
+        await screen.findByText('36 %');
+        (ProductionRepository.setAgitatorConfig as jest.Mock).mockClear();
+        rerender(<Production {...props} brewingStatus={{...createBrewingStatus(), agitator: {mode: 'CONTINUOUS', paused: false, operation: 'CONTINUOUS', intervalPhase: 'IDLE', actualOutputOn: true}}} />);
+        expect(await screen.findByRole('switch', {name: 'Durchgehend rühren'})).toBeChecked();
+        expect(screen.getByRole('switch', {name: 'Automatik'})).not.toBeChecked();
+        rerender(<Production {...props} brewingStatus={{...createBrewingStatus(), agitator: {mode: 'OFF', paused: false, operation: 'OFF', intervalPhase: 'IDLE', actualOutputOn: false}}} />);
+        await waitFor(() => expect(screen.getByRole('switch', {name: 'Durchgehend rühren'})).not.toBeChecked());
+        expect(screen.getByRole('switch', {name: 'Automatik'})).not.toBeChecked();
         expect(ProductionRepository.setAgitatorConfig).not.toHaveBeenCalled();
     });
 
@@ -148,6 +217,26 @@ describe('Production agitator controller integration', () => {
         expect(await screen.findByText('42 %')).toBeInTheDocument();
         expect(screen.getByDisplayValue('20')).toBeInTheDocument();
         expect(screen.getByDisplayValue('90')).toBeInTheDocument();
+    });
+
+    it('keeps interval settings visible but only editable in AUTOMATIC mode and places speed afterwards', async () => {
+        jest.spyOn(ProductionRepository, 'getAgitatorStatus').mockResolvedValue({...detail, config: {...detail.config, mode: 'OFF'}});
+        const {container} = renderProduction();
+        expect(await screen.findByLabelText('Laufzeit')).toBeDisabled();
+        expect(screen.getByLabelText('Pausenzeit')).toBeDisabled();
+        const automaticCard = container.querySelector('.agitatorAutomaticSettings') as HTMLElement;
+        const speed = screen.getByText('Geschwindigkeit').closest('label') as HTMLElement;
+        expect(automaticCard.compareDocumentPosition(speed) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+        expect(screen.getByText('36 %')).toBeInTheDocument();
+    });
+
+    it('pauses independently without changing the selected mode', async () => {
+        renderProduction();
+        fireEvent.click(await screen.findByRole('button', {name: 'Rührwerk pausieren'}));
+        await waitFor(() => expect(ProductionRepository.pauseAgitator).toHaveBeenCalledTimes(1));
+        expect(screen.getByRole('switch', {name: 'Automatik'})).toBeChecked();
+        expect(ProductionRepository.setAgitatorConfig).not.toHaveBeenCalled();
+        expect(screen.getByRole('button', {name: 'Rührwerk fortsetzen'})).toBeInTheDocument();
     });
 });
 

--- a/src/containers/Production/Production.tsx
+++ b/src/containers/Production/Production.tsx
@@ -84,6 +84,7 @@ interface ProductionState {
     agitatorRuntime?: AgitatorRuntimeStatus;
     agitatorSpeedDraft?: number;
     agitatorRequestPending: boolean;
+    agitatorStatusLoadFailed: boolean;
     waterSwitchState: boolean
     liters: number
     waterFillingError: boolean
@@ -119,6 +120,7 @@ export class Production extends React.Component<ProductionProps, ProductionState
             agitatorRuntime: undefined,
             agitatorSpeedDraft: undefined,
             agitatorRequestPending: false,
+            agitatorStatusLoadFailed: false,
             waterSwitchState: false,
             liters: 0,
             waterFillingError: false,
@@ -180,6 +182,9 @@ export class Production extends React.Component<ProductionProps, ProductionState
 
         if (getIsControllerAvailable(prevProps.isBackenAvailable) && !this.isControllerAvailable()) {
             this.clearAgitatorSpeedDebounce();
+        }
+        if (!getIsControllerAvailable(prevProps.isBackenAvailable) && this.isControllerAvailable() && !this.state.agitatorConfig) {
+            this.loadAgitatorStatus();
         }
 
         if (isEquipmentAlarmActive(prevProps.brewingStatus) && !isEquipmentAlarmActive(brewingStatus)) {
@@ -255,6 +260,7 @@ export class Production extends React.Component<ProductionProps, ProductionState
             if (!this.isMountedComponent) return;
             this.setState({
                 agitatorConfig: detail.config,
+                agitatorStatusLoadFailed: false,
                 agitatorRuntime: {
                     mode: detail.config.mode,
                     paused: detail.runtime.paused,
@@ -266,6 +272,7 @@ export class Production extends React.Component<ProductionProps, ProductionState
         } catch (error) {
             // The remaining production screen stays usable when detail status is unavailable.
             console.error('Rührwerkstatus konnte nicht geladen werden', error);
+            if (this.isMountedComponent) this.setState({agitatorStatusLoadFailed: true});
         }
     }
 
@@ -299,9 +306,11 @@ export class Production extends React.Component<ProductionProps, ProductionState
         }
     }
 
-    selectAgitatorMode = (mode: AgitatorMode): void => {
-        if (!this.isControllerAvailable() || !this.state.agitatorConfig) return;
-        void this.submitAgitatorConfig({...this.state.agitatorConfig, mode});
+    toggleAgitatorMode = (mode: Exclude<AgitatorMode, 'OFF'>, checked: boolean): void => {
+        const {agitatorConfig, agitatorRequestPending} = this.state;
+        if (!this.isControllerAvailable() || !agitatorConfig || agitatorRequestPending) return;
+        const nextMode: AgitatorMode = checked ? mode : (agitatorConfig.mode === mode ? 'OFF' : agitatorConfig.mode);
+        if (nextMode !== agitatorConfig.mode) void this.submitAgitatorConfig({...agitatorConfig, mode: nextMode});
     }
 
     toggleAgitatorPause = async (): Promise<void> => {
@@ -319,19 +328,6 @@ export class Production extends React.Component<ProductionProps, ProductionState
             if (this.isMountedComponent) this.setState({agitatorRequestPending: false, mainAgitatorError: true});
         }
     }
-
-    getAgitatorStatusLabel = (): string => {
-        const runtime = this.state.agitatorRuntime;
-        if (!runtime) return 'Status wird geladen';
-        if (runtime.paused) return 'Pausiert';
-        if (runtime.mode === 'OFF') return 'Aus';
-        if (runtime.mode === 'CONTINUOUS') return 'Dauerbetrieb';
-        if (runtime.operation === 'CONTINUOUS') return 'Automatik · Heizen';
-        if (runtime.operation === 'INTERVAL' && runtime.intervalPhase === 'RUNNING') return 'Automatik · Intervall läuft';
-        if (runtime.operation === 'INTERVAL' && runtime.intervalPhase === 'BREAK') return 'Automatik · Intervallpause';
-        return 'Automatik';
-    }
-
 
     syncRemainingTimeFromStatus = (): void => {
         const remainingSeconds = this.getRemainingSecondsFromStatus();
@@ -633,7 +629,7 @@ export class Production extends React.Component<ProductionProps, ProductionState
     }
 
     renderSettings() {
-        const {waterSwitchState, agitatorConfig, agitatorRuntime, agitatorSpeedDraft, agitatorRequestPending} = this.state;
+        const {waterSwitchState, agitatorConfig, agitatorRuntime, agitatorSpeedDraft, agitatorRequestPending, agitatorStatusLoadFailed} = this.state;
         const settingsDisabled = !this.isControllerAvailable();
         const mashWaterDisabled = settingsDisabled || this.isRecipeWaterButtonDisabled('mash');
         const spargeWaterDisabled = settingsDisabled || this.isRecipeWaterButtonDisabled('sparge');
@@ -665,30 +661,35 @@ export class Production extends React.Component<ProductionProps, ProductionState
 
                 <section className="settingsGroup" aria-labelledby="agitator-settings-title">
                     <h4 id="agitator-settings-title">Rührwerk</h4>
-                    <div className="agitatorModeControl" role="group" aria-label="Rührwerk Betriebsart">
-                        {([['OFF', 'Aus'], ['CONTINUOUS', 'Dauerhaft'], ['AUTOMATIC', 'Automatik']] as const).map(([mode, label]) => (
-                            <button key={mode} type="button" aria-pressed={agitatorConfig?.mode === mode}
-                                    disabled={settingsDisabled || !agitatorConfig || agitatorRequestPending}
-                                    onClick={() => this.selectAgitatorMode(mode)}>{label}</button>
-                        ))}
-                    </div>
-                    <p className="agitatorRuntimeStatus" aria-live="polite">{this.getAgitatorStatusLabel()}</p>
-                    {agitatorConfig && <>
-                        <label className="agitatorSpeedControl">
-                            <span>Geschwindigkeit <strong>{agitatorSpeedDraft ?? agitatorConfig.speedPercent} %</strong></span>
-                            <input type="range" min="0" max="100" value={agitatorSpeedDraft ?? agitatorConfig.speedPercent}
-                                   disabled={settingsDisabled} onChange={(event) => this.onAgitatorSpeedChange(Number(event.target.value))}/>
-                        </label>
-                        <div className={`intervalSettings agitatorAutomaticSettings ${agitatorConfig.mode === 'AUTOMATIC' ? 'is-active' : ''}`} aria-labelledby="interval-settings-title">
-                            <h5 id="interval-settings-title">Automatik · Intervall</h5>
-                            <div className="intervalTimeControls">
-                                <label>Laufzeit <input aria-label="Laufzeit" type="number" min="0" value={agitatorConfig.runningSeconds}
-                                    disabled={settingsDisabled || agitatorRequestPending} onChange={(event) => this.onIntervalChangeRunningTime(Number(event.target.value))}/><span>s</span></label>
-                                <label>Pause <input aria-label="Pause" type="number" min="0" value={agitatorConfig.breakSeconds}
-                                    disabled={settingsDisabled || agitatorRequestPending} onChange={(event) => this.onIntervalChangeBreakTime(Number(event.target.value))}/><span>s</span></label>
+                    {(settingsDisabled || !agitatorConfig) && <p className="agitatorAvailability" role="status">
+                        {agitatorStatusLoadFailed || settingsDisabled ? 'Rührwerk-Konfiguration nicht verfügbar' : 'Rührwerk-Konfiguration wird geladen'}
+                    </p>}
+                    {renderSwitch('Durchgehend rühren', agitatorConfig?.mode === 'CONTINUOUS',
+                        (checked) => this.toggleAgitatorMode('CONTINUOUS', checked), settingsDisabled || !agitatorConfig || agitatorRequestPending)}
+                    <div className={`intervalSettings agitatorAutomaticSettings ${agitatorConfig?.mode === 'AUTOMATIC' ? 'is-active' : ''}`} aria-labelledby="interval-settings-title">
+                        <div className="agitatorAutomaticHeader">
+                            <div>
+                                <h5 id="interval-settings-title">Automatik</h5>
+                                <p>Beim Heizen durchgehend, sonst im Intervall</p>
                             </div>
+                            <Switch className="productionSwitch" onChange={(checked) => this.toggleAgitatorMode('AUTOMATIC', checked)}
+                                checked={agitatorConfig?.mode === 'AUTOMATIC'} height={24} width={44} handleDiameter={18}
+                                checkedIcon={false} uncheckedIcon={false} disabled={settingsDisabled || !agitatorConfig || agitatorRequestPending}
+                                aria-label="Automatik" />
                         </div>
-                    </>}
+                        <h6>Intervall</h6>
+                        <div className="intervalTimeControls">
+                            <label>Laufzeit <input aria-label="Laufzeit" type="number" min="0" value={agitatorConfig?.runningSeconds ?? ''}
+                                disabled={settingsDisabled || !agitatorConfig || agitatorRequestPending || agitatorConfig.mode !== 'AUTOMATIC'} onChange={(event) => this.onIntervalChangeRunningTime(Number(event.target.value))}/><span>s</span></label>
+                            <label>Pausenzeit <input aria-label="Pausenzeit" type="number" min="0" value={agitatorConfig?.breakSeconds ?? ''}
+                                disabled={settingsDisabled || !agitatorConfig || agitatorRequestPending || agitatorConfig.mode !== 'AUTOMATIC'} onChange={(event) => this.onIntervalChangeBreakTime(Number(event.target.value))}/><span>s</span></label>
+                        </div>
+                    </div>
+                    <label className="agitatorSpeedControl">
+                        <span>Geschwindigkeit <strong>{agitatorConfig ? `${agitatorSpeedDraft ?? agitatorConfig.speedPercent} %` : '–'}</strong></span>
+                        <input type="range" min="0" max="100" value={agitatorSpeedDraft ?? agitatorConfig?.speedPercent ?? 0}
+                               disabled={settingsDisabled || !agitatorConfig} onChange={(event) => this.onAgitatorSpeedChange(Number(event.target.value))}/>
+                    </label>
                     {agitatorRuntime && agitatorRuntime.mode !== 'OFF' && <button className="agitatorPauseButton" type="button"
                         disabled={settingsDisabled || agitatorRequestPending} onClick={this.toggleAgitatorPause}>
                         {agitatorRuntime.paused ? 'Rührwerk fortsetzen' : 'Rührwerk pausieren'}


### PR DESCRIPTION
### Motivation
- Improve agitator control UX by switching to explicit switch controls for `CONTINUOUS` and `AUTOMATIC` modes and surface status when controller detail cannot be loaded.
- Make UI robust to multi-client polls and partial/legacy status updates and ensure mode changes submit complete configs consistently.
- Adjust styling to match the new layout and provide clearer availability and automatic-section visuals.

### Description
- Reworked agitator UI in `Production.tsx` to render two switches via a helper `renderSwitch` for `CONTINUOUS` (`Durchgehend rühren`) and `AUTOMATIC` (`Automatik`) modes, moved speed control after the automatic card, and reorganized interval inputs under an automatic header.
- Replaced `selectAgitatorMode` with `toggleAgitatorMode` to implement toggle semantics (turn off if unchecked, otherwise set the given mode) and to avoid submitting while a request is pending.
- Added `agitatorStatusLoadFailed` state and updated `loadAgitatorStatus` to set this flag on error so the UI shows `Rührwerk-Konfiguration nicht verfügbar` while keeping controls visible but disabled.
- Trigger a status load in `componentDidUpdate` when the controller becomes available and no agitator config is present.
- Kept pause handling and config submission logic but adjusted when controls are disabled while requests are pending and preserved other config fields when changing modes.
- Updated CSS (`Production.css`) to add `.agitatorAvailability`, `.agitatorAutomaticHeader`, and spacing/padding adjustments for the new layout and behavior.
- Extended and updated `Production.test.tsx` with many new/changed tests that cover mapping of modes to switches, offline-status handling, toggle behavior between modes, pending-request disabling, debounced speed updates, merge/poll behavior, ordering/visibility of interval and speed controls, and independent pause actions.

### Testing
- Updated and ran unit tests for the production agitator controller in `Production.test.tsx` (Jest-based); all updated tests executed and passed locally.
- Verified debounced speed behavior and request-pending disable flows via the test suite; those tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a9321d1ed9c832fa4b4b3b129db4219)