### PR TITLE
Forward brew-session-running Socket.IO events to Redux

### DIFF
--- a/docs/codex/exports/ui-context-for-control.md
+++ b/docs/codex/exports/ui-context-for-control.md
@@ -34,3 +34,5 @@ Needs verification in control repository: exact operational meaning of `WaterSta
 See `docs/codex/compatibility/final-ui-control-compatibility-report.md` for the final UI ↔ PI control contract. Resolved items: `/Available/` is UI-facing availability while `/` remains preserved, both `/WaterStatus` and `/WaterStatus/` are supported with object/default shape, `TurnOn`/`TurnOff` no-value aliases are valid, value-bearing command aliases remain preserved, `Wait` is status-only and `/Confirm/Wait` is rejected by PI, and `currentTime` is a Unix timestamp not used for UI progress.
 
 Remaining open items: exact operational meaning of `WaterStatus.filledLiters / WaterStatus.targetLiters`, long-term stability of `/temperatur/0`, socket.io `overheat` payload shape, and initial empty `Status` behavior.
+
+The shared Socket.IO connection also accepts `brew-session-running` with an optional payload. The UI currently maps it only to `ProductionActions.BREW_SESSION_RUNNING_RECEIVED`; it does not infer BrewSession fields or trigger REST synchronization, polling, or navigation.

--- a/docs/codex/interfaces.md
+++ b/docs/codex/interfaces.md
@@ -72,9 +72,10 @@ The desktop header sends `POST /api/system/shutdown` without a request body only
 ## Socket.io
 
 - URL is derived from `BaseURL` by replacing leading `http` with `ws`.
-- `WebSocketController` uses `socket.io-client` and subscribes to event name `overheat`.
+- `WebSocketController` uses `socket.io-client` and subscribes to event names `overheat` and `brew-session-running` on one shared connection.
 - On `overheat`, it calls the configured handler with `{ event: 'overheat', data }`.
-- Needs verification: production epic currently parses `event.data` as JSON, which does not match the controller handler object shape.
+- On `brew-session-running`, it calls the same configured handler with `{ event: 'brew-session-running', data }`; `data` may be absent. The UI converts this to the payload-free technical Redux action `BREW_SESSION_RUNNING_RECEIVED` and does not start synchronization, polling, or navigation.
+- The production epic maps the controller's structured handler object directly and ignores unknown event names.
 
 ## Normalized brewing status expected by UI
 

--- a/docs/codex/system-overview.md
+++ b/docs/codex/system-overview.md
@@ -30,7 +30,7 @@ The UI expects a brewing-control service at `BaseURL`/`CommandsURL`/`ConfirmURL`
 - Starting brewing and advancing workflow steps.
 - Hardware commands for water filling, heater, agitator speed, and agitator interval.
 - Confirmation commands for waiting states.
-- Socket.io `overheat` event.
+- Socket.io `overheat` and payload-optional `brew-session-running` events. The latter is currently only forwarded as a technical Redux signal.
 
 Needs verification in PI/control repository: exact command syntax, status schema, whether trailing slashes are required, whether temperature alter `0` is fixed, socket.io payload shape, safety behavior, and units.
 
@@ -54,4 +54,3 @@ No `.env`-based URL configuration was found in inspected source. Changing deploy
 5. Production view maps the selected recipe into `BrewingData`, sends it to control, starts brewing, then polls status every second until terminal state.
 6. Runtime status updates drive progress display, confirm dialogs, timeline grouping, hop-addition reminders, finish dialog, and saved finished-brew records.
 7. Finished brew completion stores collected status samples as JSON in `FinishedBrew.brewValues`.
-

--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -632,6 +632,7 @@ export namespace ProductionActions {
         WEBSOCKET_CONNECT = 'ProductionActions.WEBSOCKET_CONNECT',
         WEBSOCKET_DISCONNECT = 'ProductionActions.WEBSOCKET_DISCONNECT',
         OVERHEAT_RECEIVED = 'ProductionActions.OVERHEAT_RECEIVED',
+        BREW_SESSION_RUNNING_RECEIVED = 'ProductionActions.BREW_SESSION_RUNNING_RECEIVED',
     }
 
     export interface SetWaterStatus {
@@ -747,6 +748,9 @@ export namespace ProductionActions {
             data: any;
         };
     }
+    export interface BrewSessionRunningReceived {
+        readonly type: ActionTypes.BREW_SESSION_RUNNING_RECEIVED;
+    }
 
     export type AllProductionActions =
         GetTemperatures |
@@ -773,7 +777,8 @@ export namespace ProductionActions {
         NextProcedureStepFailure |
         WebSocketConnect |
         WebSocketDisconnect |
-        OverheatReceived;
+        OverheatReceived |
+        BrewSessionRunningReceived;
 
     export function setWaterStatus(aWaterStatus: WaterStatus): ProductionActions.SetWaterStatus {
         return {
@@ -934,6 +939,12 @@ export namespace ProductionActions {
         return {
             type: ActionTypes.OVERHEAT_RECEIVED,
             payload: { data }
+        };
+    }
+
+    export function brewSessionRunningReceived(): BrewSessionRunningReceived {
+        return {
+            type: ActionTypes.BREW_SESSION_RUNNING_RECEIVED
         };
     }
 }

--- a/src/epics/productionEpics.test.ts
+++ b/src/epics/productionEpics.test.ts
@@ -162,9 +162,18 @@ describe('sendBrewingDataEpic$ failures', () => {
   });
 });
 
-it('maps the structured socket.io overheat event without JSON parsing', () => {
-  expect(mapControlSocketEvent({event: 'overheat', data: {temperature: 101}})).toEqual(ProductionActions.overheatReceived({temperature: 101}));
-  expect(mapControlSocketEvent({event: 'other', data: {}})).toBeUndefined();
+describe('mapControlSocketEvent', () => {
+  it('maps the structured socket.io overheat event without JSON parsing', () => {
+    expect(mapControlSocketEvent({event: 'overheat', data: {temperature: 101}})).toEqual(ProductionActions.overheatReceived({temperature: 101}));
+  });
+
+  it('maps brew-session-running to its payload-free technical Redux signal', () => {
+    expect(mapControlSocketEvent({event: 'brew-session-running'})).toEqual(ProductionActions.brewSessionRunningReceived());
+  });
+
+  it('ignores unknown socket events', () => {
+    expect(mapControlSocketEvent({event: 'other', data: {}})).toBeUndefined();
+  });
 });
 
 describe('startWaterFillingEpic$', () => {

--- a/src/epics/productionEpics.ts
+++ b/src/epics/productionEpics.ts
@@ -18,9 +18,16 @@ export const WATER_FILLING_MAX_DURATION = 30 * 60 * 1000;
 const WS_URL = (typeof BaseURL !== 'undefined' ? BaseURL : '').replace(/^http/, 'ws');
 let wsController: WebSocketController | null = null;
 
-export const mapControlSocketEvent = (event: {event: string; data: any}) => event.event === 'overheat'
-  ? ProductionActions.overheatReceived(event.data)
-  : undefined;
+export const mapControlSocketEvent = (event: {event: string; data?: any}) => {
+  switch (event.event) {
+    case 'overheat':
+      return ProductionActions.overheatReceived(event.data);
+    case 'brew-session-running':
+      return ProductionActions.brewSessionRunningReceived();
+    default:
+      return undefined;
+  }
+};
 
 export const getTemperaturesEpic$ = (action$: any) =>
     action$.pipe(

--- a/src/utils/WebSocketController.test.ts
+++ b/src/utils/WebSocketController.test.ts
@@ -1,0 +1,58 @@
+import { io } from 'socket.io-client';
+import { WebSocketController } from './WebSocketController';
+
+jest.mock('socket.io-client', () => ({
+  io: jest.fn(),
+}));
+
+type SocketListener = (data?: any) => void;
+
+describe('WebSocketController', () => {
+  const listeners: Record<string, SocketListener> = {};
+  const socket = {
+    on: jest.fn((event: string, listener: SocketListener) => {
+      listeners[event] = listener;
+      return socket;
+    }),
+    disconnect: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    Object.keys(listeners).forEach((event) => delete listeners[event]);
+    (io as jest.Mock).mockReturnValue(socket);
+  });
+
+  it('registers overheat and brew-session-running on the existing socket connection', () => {
+    const controller = new WebSocketController('ws://controller');
+
+    controller.connect();
+    controller.connect();
+
+    expect(io).toHaveBeenCalledTimes(1);
+    expect(socket.on).toHaveBeenCalledWith('overheat', expect.any(Function));
+    expect(socket.on).toHaveBeenCalledWith('brew-session-running', expect.any(Function));
+  });
+
+  it('forwards brew-session-running with its payload to the message handler', () => {
+    const handler = jest.fn();
+    const controller = new WebSocketController('ws://controller');
+    controller.onMessage(handler);
+    controller.connect();
+
+    listeners['brew-session-running']({session: 'active'});
+
+    expect(handler).toHaveBeenCalledWith({event: 'brew-session-running', data: {session: 'active'}});
+  });
+
+  it('forwards brew-session-running when the server sends no payload', () => {
+    const handler = jest.fn();
+    const controller = new WebSocketController('ws://controller');
+    controller.onMessage(handler);
+    controller.connect();
+
+    listeners['brew-session-running']();
+
+    expect(handler).toHaveBeenCalledWith({event: 'brew-session-running', data: undefined});
+  });
+});

--- a/src/utils/WebSocketController.ts
+++ b/src/utils/WebSocketController.ts
@@ -1,6 +1,6 @@
 import { io, Socket } from 'socket.io-client';
 
-export type MessageHandler = (event: { event: string; data: any }) => void;
+export type MessageHandler = (event: { event: string; data?: any }) => void;
 
 export class WebSocketController {
   private socket: Socket | null = null;
@@ -17,6 +17,11 @@ export class WebSocketController {
     this.socket.on('overheat', (data: any) => {
       if (this.messageHandler) {
         this.messageHandler({ event: 'overheat', data });
+      }
+    });
+    this.socket.on('brew-session-running', (data?: any) => {
+      if (this.messageHandler) {
+        this.messageHandler({ event: 'brew-session-running', data });
       }
     });
   }


### PR DESCRIPTION
### Motivation

- The UI needs to receive the controller's technical `brew-session-running` Socket.IO event on the existing global connection and propagate it to Redux as a technical signal without adding any BrewSession synchronization logic. 
- The change must reuse the single shared `WebSocketController` and preserve the existing `overheat` behavior and reconnect semantics.

### Description

- `src/utils/WebSocketController.ts`: subscribe the shared socket to `brew-session-running` and forward `{ event: 'brew-session-running', data }` (where `data` may be absent) via the existing `MessageHandler`; relax the handler type to `data?: any`.
- `src/actions/actions.ts`: add `ActionTypes.BREW_SESSION_RUNNING_RECEIVED` and the action creator `brewSessionRunningReceived()` following the `ProductionActions` naming/structure.
- `src/epics/productionEpics.ts`: extend `mapControlSocketEvent()` to map `brew-session-running` to `ProductionActions.brewSessionRunningReceived()` while keeping the `overheat` mapping unchanged.
- Tests and docs: add `src/utils/WebSocketController.test.ts` to cover registration, payload/no-payload forwarding and connection deduplication; update `src/epics/productionEpics.test.ts` to assert the new mapping; update `docs/codex/*` to document the new Socket.IO event and the fact that it is currently only a payload-free technical Redux signal.

### Testing

- Added/updated tests: `src/utils/WebSocketController.test.ts` (new) and `src/epics/productionEpics.test.ts` (updated) which cover event registration, payload/no-payload forwarding, unknown-event ignoring, and connection deduplication; these tests are present in the repo.
- Performed repository checks with `git diff --check` and `git status` which reported no issues.
- Attempted to run the relevant Jest suite with `npm test -- --watchAll=false --runInBand src/utils/WebSocketController.test.ts src/epics/productionEpics.test.ts src/containers/index.test.tsx`, but executing `react-scripts` was blocked by missing/blocked dependency resolution (registry HTTP 403), so the test run could not complete in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a941326a630832f8d825a005216c869)