### PR TITLE
Show Socket.IO connection status on Info/Version page

### DIFF
--- a/docs/codex/interfaces.md
+++ b/docs/codex/interfaces.md
@@ -76,6 +76,7 @@ The desktop header sends `POST /api/system/shutdown` without a request body only
 - On `overheat`, it calls the configured handler with `{ event: 'overheat', data }`.
 - On `brew-session-running`, it calls the same configured handler with `{ event: 'brew-session-running', data }`; `data` may be absent. The UI converts this to the payload-free technical Redux action `BREW_SESSION_RUNNING_RECEIVED` and does not start synchronization, polling, or navigation.
 - The production epic maps the controller's structured handler object directly and ignores unknown event names.
+- The same shared connection reports `connect` as `{ connected: true, socketId: socket.id }` and `disconnect` as `{ connected: false, socketId: undefined }` through the production Redux flow. The Socket.IO ID is transient diagnostic data only; the UI does not persist it or use it as a client/device identity.
 
 ## Normalized brewing status expected by UI
 

--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -633,6 +633,7 @@ export namespace ProductionActions {
         WEBSOCKET_DISCONNECT = 'ProductionActions.WEBSOCKET_DISCONNECT',
         OVERHEAT_RECEIVED = 'ProductionActions.OVERHEAT_RECEIVED',
         BREW_SESSION_RUNNING_RECEIVED = 'ProductionActions.BREW_SESSION_RUNNING_RECEIVED',
+        SOCKET_CONNECTION_CHANGED = 'ProductionActions.SOCKET_CONNECTION_CHANGED',
     }
 
     export interface SetWaterStatus {
@@ -751,6 +752,10 @@ export namespace ProductionActions {
     export interface BrewSessionRunningReceived {
         readonly type: ActionTypes.BREW_SESSION_RUNNING_RECEIVED;
     }
+    export interface SocketConnectionChanged {
+        readonly type: ActionTypes.SOCKET_CONNECTION_CHANGED;
+        payload: { connected: boolean; socketId?: string };
+    }
 
     export type AllProductionActions =
         GetTemperatures |
@@ -778,7 +783,8 @@ export namespace ProductionActions {
         WebSocketConnect |
         WebSocketDisconnect |
         OverheatReceived |
-        BrewSessionRunningReceived;
+        BrewSessionRunningReceived |
+        SocketConnectionChanged;
 
     export function setWaterStatus(aWaterStatus: WaterStatus): ProductionActions.SetWaterStatus {
         return {
@@ -945,6 +951,13 @@ export namespace ProductionActions {
     export function brewSessionRunningReceived(): BrewSessionRunningReceived {
         return {
             type: ActionTypes.BREW_SESSION_RUNNING_RECEIVED
+        };
+    }
+
+    export function socketConnectionChanged(connected: boolean, socketId?: string): SocketConnectionChanged {
+        return {
+            type: ActionTypes.SOCKET_CONNECTION_CHANGED,
+            payload: {connected, socketId}
         };
     }
 }

--- a/src/containers/Version/VersionPage.css
+++ b/src/containers/Version/VersionPage.css
@@ -1,6 +1,52 @@
 .version-page {
   padding: 1.5rem 2rem;
   color: var(--color-black);
+  display: grid;
+  gap: 1rem;
+}
+
+.socket-card h2 {
+  margin-bottom: 0.5rem;
+}
+
+.socket-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: 700;
+}
+
+.socket-status-indicator {
+  width: 0.7rem;
+  height: 0.7rem;
+  flex: 0 0 0.7rem;
+  border: 2px solid currentColor;
+  border-radius: 50%;
+}
+
+.socket-status-connected {
+  color: var(--color-success-dark);
+}
+
+.socket-status-connected .socket-status-indicator {
+  background: var(--color-success);
+}
+
+.socket-status-disconnected {
+  color: var(--color-error-deep);
+}
+
+.socket-id {
+  min-width: 0;
+  max-width: 70%;
+  overflow-wrap: anywhere;
+  text-align: right;
+}
+
+@media (max-width: 480px) {
+  .version-page {
+    padding: 1rem;
+  }
 }
 
 .version-card {

--- a/src/containers/Version/VersionPage.test.tsx
+++ b/src/containers/Version/VersionPage.test.tsx
@@ -70,4 +70,16 @@ describe('VersionPage', () => {
             expect(screen.getByTestId('database-version')).toHaveTextContent('v1.1.0');
         });
     });
+
+    it('shows the connected status and current socket id', (): void => {
+        render(<VersionPage socketConnected socketId="abc123" loadControlVersion={() => new Promise<string>(() => {})} loadDatabaseVersion={() => new Promise<string>(() => {})} />);
+        expect(screen.getByText('Verbunden')).toBeInTheDocument();
+        expect(screen.getByTestId('socket-id')).toHaveTextContent('abc123');
+    });
+
+    it('shows no socket id while disconnected', (): void => {
+        render(<VersionPage socketConnected={false} loadControlVersion={() => new Promise<string>(() => {})} loadDatabaseVersion={() => new Promise<string>(() => {})} />);
+        expect(screen.getByText('Nicht verbunden')).toBeInTheDocument();
+        expect(screen.getByTestId('socket-id')).toHaveTextContent('–');
+    });
 });

--- a/src/containers/Version/VersionPage.tsx
+++ b/src/containers/Version/VersionPage.tsx
@@ -10,6 +10,8 @@ interface VersionPageProps {
     version?: string;
     loadControlVersion?: () => Promise<string>;
     loadDatabaseVersion?: () => Promise<string>;
+    socketConnected?: boolean;
+    socketId?: string;
 }
 
 interface VersionPageState {
@@ -82,6 +84,7 @@ class VersionPage extends React.Component<VersionPageProps, VersionPageState> {
 
     render(): React.ReactNode {
         const {controlVersion, databaseVersion, isControlLoading, isDatabaseLoading} = this.state;
+        const {socketConnected = false, socketId} = this.props;
         return (
             <div className="version-page">
                 <section className="version-card">
@@ -93,6 +96,22 @@ class VersionPage extends React.Component<VersionPageProps, VersionPageState> {
                     {this.renderVersionRow('UI', this.getVersion(), 'application-version', false)}
                     {this.renderVersionRow('Control', controlVersion, 'control-version', isControlLoading)}
                     {this.renderVersionRow('Database', databaseVersion, 'database-version', isDatabaseLoading)}
+                </section>
+                <section className="version-card socket-card" aria-labelledby="socket-connection-title">
+                    <h2 id="socket-connection-title">Socket-Verbindung</h2>
+                    <div className="version-value-row">
+                        <span className="version-label">Status</span>
+                        <span className={`socket-status ${socketConnected ? 'socket-status-connected' : 'socket-status-disconnected'}`}>
+                            <span className="socket-status-indicator" aria-hidden="true" />
+                            {socketConnected ? 'Verbunden' : 'Nicht verbunden'}
+                        </span>
+                    </div>
+                    <div className="version-value-row">
+                        <span className="version-label">Socket-ID</span>
+                        <span className="version-value socket-id" data-testid="socket-id">
+                            {socketConnected && socketId ? socketId : '–'}
+                        </span>
+                    </div>
                 </section>
             </div>
         );

--- a/src/containers/index.connect.ts
+++ b/src/containers/index.connect.ts
@@ -6,6 +6,8 @@ import {Index} from './index';
 const mapStateToProps = (state: any) => ({
     viewState: state.applicationReducer.view as Views,
     brewingStatus: state.productionReducer.brewingStatus,
+    socketConnected: state.productionReducer.socketConnection.connected,
+    socketId: state.productionReducer.socketConnection.socketId,
 });
 
 const mapDispatchToProps = (dispatch: any) => ({

--- a/src/containers/index.test.tsx
+++ b/src/containers/index.test.tsx
@@ -36,6 +36,7 @@ const renderIndex = (brewingStatus: BrewingStatus, viewState = Views.VERSION, li
             checkIsBackenAvailable={jest.fn()}
             webSocketConnect={lifecycle.connect}
             webSocketDisconnect={lifecycle.disconnect}
+            socketConnected={false}
         />
     );
     return result;

--- a/src/containers/index.tsx
+++ b/src/containers/index.tsx
@@ -21,6 +21,8 @@ interface indexMainProps {
     checkIsBackenAvailable : () => void;
     webSocketConnect: () => void;
     webSocketDisconnect: () => void;
+    socketConnected: boolean;
+    socketId?: string;
 }
 
 export class Index extends React.Component<indexMainProps> {
@@ -43,7 +45,7 @@ export class Index extends React.Component<indexMainProps> {
     }
 
     render() {
-        const {viewState} = this.props;
+        const {viewState, socketConnected, socketId} = this.props;
         const mode = getUiMode();
         const activeView = isViewAllowed(viewState, mode) ? viewState : CONTROLLER_HOME_VIEW;
 
@@ -63,7 +65,7 @@ export class Index extends React.Component<indexMainProps> {
                 {activeView === Views.SETTINGS && <SettingsPage />}
                 {activeView === Views.FINISHED_BREWS && <FinishedBrewsTable />}
                 {activeView === Views.BREWING_CALCULATIONS && <BrewingCalculations />}
-                {activeView === Views.VERSION && <VersionPage />}
+                {activeView === Views.VERSION && <VersionPage socketConnected={socketConnected} socketId={socketId} />}
             </div>
             </Suspense>
 

--- a/src/epics/productionEpics.test.ts
+++ b/src/epics/productionEpics.test.ts
@@ -171,6 +171,13 @@ describe('mapControlSocketEvent', () => {
     expect(mapControlSocketEvent({event: 'brew-session-running'})).toEqual(ProductionActions.brewSessionRunningReceived());
   });
 
+  it('maps socket connection changes without affecting existing control events', () => {
+    expect(mapControlSocketEvent({event: 'connection-status', data: {connected: true, socketId: 'abc123'}}))
+      .toEqual(ProductionActions.socketConnectionChanged(true, 'abc123'));
+    expect(mapControlSocketEvent({event: 'connection-status', data: {connected: false}}))
+      .toEqual(ProductionActions.socketConnectionChanged(false));
+  });
+
   it('ignores unknown socket events', () => {
     expect(mapControlSocketEvent({event: 'other', data: {}})).toBeUndefined();
   });

--- a/src/epics/productionEpics.ts
+++ b/src/epics/productionEpics.ts
@@ -24,6 +24,8 @@ export const mapControlSocketEvent = (event: {event: string; data?: any}) => {
       return ProductionActions.overheatReceived(event.data);
     case 'brew-session-running':
       return ProductionActions.brewSessionRunningReceived();
+    case 'connection-status':
+      return ProductionActions.socketConnectionChanged(event.data.connected, event.data.socketId);
     default:
       return undefined;
   }

--- a/src/reducers/productionReducer.test.ts
+++ b/src/reducers/productionReducer.test.ts
@@ -39,6 +39,22 @@ describe('productionReducer waterStatus', () => {
     });
 });
 
+describe('productionReducer socket connection', () => {
+    it('stores a connected socket id and clears it on disconnect', () => {
+        const connected = productionReducer(initialProductionState, ProductionActions.socketConnectionChanged(true, 'abc123'));
+        expect(connected.socketConnection).toEqual({connected: true, socketId: 'abc123'});
+        const disconnected = productionReducer(connected, ProductionActions.socketConnectionChanged(false));
+        expect(disconnected.socketConnection).toEqual({connected: false, socketId: undefined});
+    });
+
+    it('replaces the previous id after reconnect', () => {
+        const first = productionReducer(initialProductionState, ProductionActions.socketConnectionChanged(true, 'abc123'));
+        const disconnected = productionReducer(first, ProductionActions.socketConnectionChanged(false));
+        const reconnected = productionReducer(disconnected, ProductionActions.socketConnectionChanged(true, 'xyz789'));
+        expect(reconnected.socketConnection).toEqual({connected: true, socketId: 'xyz789'});
+    });
+});
+
 describe('productionReducer brewingStatus alarms', () => {
     it('replaces the complete status so an ended alarm is removed on the next poll', () => {
         const activeAlarm = {type: AlarmType.EQUIPMENT_ALARM, active: true};

--- a/src/reducers/productionReducer.ts
+++ b/src/reducers/productionReducer.ts
@@ -32,6 +32,10 @@ export interface ProductionReducerState {
     nextProcedureStepError?: string;
     isBrewingStatusStale: boolean;
     brewingStartError?: string;
+    socketConnection: {
+        connected: boolean;
+        socketId?: string;
+    };
 }
 
 export const initialProductionState: ProductionReducerState = {
@@ -53,7 +57,8 @@ export const initialProductionState: ProductionReducerState = {
     confirmError: undefined,
     isNextProcedureStepPending: false,
     nextProcedureStepError: undefined,
-    isBrewingStatusStale: false
+    isBrewingStatusStale: false,
+    socketConnection: {connected: false}
 };
 
 const productionReducer = (
@@ -142,6 +147,18 @@ const productionReducer = (
         case ProductionActions.ActionTypes.OVERHEAT_RECEIVED: {
             console.warn('Overheat received, setting overHeat to true');
             return { ...aState, overHeat: true };
+        }
+        case ProductionActions.ActionTypes.SOCKET_CONNECTION_CHANGED: {
+            return {
+                ...aState,
+                socketConnection: {
+                    connected: aAction.payload.connected,
+                    socketId: aAction.payload.connected ? aAction.payload.socketId : undefined
+                }
+            };
+        }
+        case ProductionActions.ActionTypes.WEBSOCKET_DISCONNECT: {
+            return {...aState, socketConnection: {connected: false}};
         }
 
         default:

--- a/src/utils/WebSocketController.test.ts
+++ b/src/utils/WebSocketController.test.ts
@@ -10,6 +10,7 @@ type SocketListener = (data?: any) => void;
 describe('WebSocketController', () => {
   const listeners: Record<string, SocketListener> = {};
   const socket = {
+    id: undefined as string | undefined,
     on: jest.fn((event: string, listener: SocketListener) => {
       listeners[event] = listener;
     }),
@@ -20,6 +21,7 @@ describe('WebSocketController', () => {
     jest.clearAllMocks();
     Object.keys(listeners).forEach((event) => delete listeners[event]);
     (io as jest.Mock).mockReturnValue(socket);
+    socket.id = undefined;
   });
 
   it('registers overheat and brew-session-running on the existing socket connection', () => {
@@ -53,5 +55,32 @@ describe('WebSocketController', () => {
     listeners['brew-session-running']();
 
     expect(handler).toHaveBeenCalledWith({event: 'brew-session-running', data: undefined});
+  });
+
+  it('forwards connect and disconnect with the current technical socket id', () => {
+    const handler = jest.fn();
+    const controller = new WebSocketController('ws://controller');
+    controller.onMessage(handler);
+    controller.connect();
+    socket.id = 'abc123';
+    listeners.connect();
+    listeners.disconnect();
+
+    expect(handler).toHaveBeenNthCalledWith(1, {event: 'connection-status', data: {connected: true, socketId: 'abc123'}});
+    expect(handler).toHaveBeenNthCalledWith(2, {event: 'connection-status', data: {connected: false, socketId: undefined}});
+  });
+
+  it('uses only the new socket id after a reconnect', () => {
+    const handler = jest.fn();
+    const controller = new WebSocketController('ws://controller');
+    controller.onMessage(handler);
+    controller.connect();
+    socket.id = 'abc123';
+    listeners.connect();
+    listeners.disconnect();
+    socket.id = 'xyz789';
+    listeners.connect();
+
+    expect(handler).toHaveBeenLastCalledWith({event: 'connection-status', data: {connected: true, socketId: 'xyz789'}});
   });
 });

--- a/src/utils/WebSocketController.ts
+++ b/src/utils/WebSocketController.ts
@@ -1,5 +1,10 @@
 import { io, Socket } from 'socket.io-client';
 
+export interface SocketConnectionStatus {
+  connected: boolean;
+  socketId?: string;
+}
+
 export type MessageHandler = (event: { event: string; data?: any }) => void;
 
 export class WebSocketController {
@@ -14,6 +19,22 @@ export class WebSocketController {
   connect() {
     if (this.socket) return;
     this.socket = io(this.url);
+    this.socket.on('connect', () => {
+      if (this.messageHandler) {
+        this.messageHandler({
+          event: 'connection-status',
+          data: {connected: true, socketId: this.socket?.id},
+        });
+      }
+    });
+    this.socket.on('disconnect', () => {
+      if (this.messageHandler) {
+        this.messageHandler({
+          event: 'connection-status',
+          data: {connected: false, socketId: undefined},
+        });
+      }
+    });
     this.socket.on('overheat', (data: any) => {
       if (this.messageHandler) {
         this.messageHandler({ event: 'overheat', data });


### PR DESCRIPTION
### Motivation

- Provide a compact diagnostic display on the existing Info/Version page that shows whether the global Socket.IO connection to the Braumeister controller is active and expose the current transient `socket.id`.
- Reuse the existing global `WebSocketController` + epic + Redux flow so no second socket connection is created and existing events (`overheat`, `brew-session-running`) remain unchanged.

### Description

- Extended `WebSocketController` to emit `connect` and `disconnect` as structured handler events `{ event: 'connection-status', data: { connected: boolean, socketId?: string } }` while keeping `overheat` and `brew-session-running` registrations. (src/utils/WebSocketController.ts)
- Mapped the new socket events in the production epic to a new Redux action `ProductionActions.socketConnectionChanged(connected, socketId)`. (src/epics/productionEpics.ts, src/actions/actions.ts)
- Added a small technical socket connection slice to the production Redux state at `productionReducer.socketConnection` with fields `connected: boolean` and optional `socketId?: string`, and updated reducer handling for connection changes and explicit websocket disconnects. (src/reducers/productionReducer.ts)
- Updated the app shell connector so `Index` receives socket connection state and forwards it to the Version/Info page; the Info page now renders a compact "Socket‑Verbindung" card showing status (visual indicator + text) and the current `socket.id` (or `–` when disconnected). Styling is aligned with existing card/typography tokens and responsive to long IDs. (src/containers/index.connect.ts, src/containers/index.tsx, src/containers/Version/VersionPage.tsx, src/containers/Version/VersionPage.css)
- Documented the transient diagnostic nature of `socket.id` in the Codex docs so it is not mistaken for a persistent client/device id. (docs/codex/interfaces.md)
- Tests added/updated to cover: WebSocket connect/disconnect and id updates, epic mapping of the connection-status event, reducer handling for connect/disconnect/reconnect, and the Version page UI for both connected and disconnected states. (src/utils/WebSocketController.test.ts, src/epics/productionEpics.test.ts, src/reducers/productionReducer.test.ts, src/containers/Version/VersionPage.test.tsx)

Files changed (key):
- src/utils/WebSocketController.ts
- src/actions/actions.ts
- src/epics/productionEpics.ts
- src/reducers/productionReducer.ts
- src/containers/index.connect.ts
- src/containers/index.tsx
- src/containers/Version/VersionPage.tsx
- src/containers/Version/VersionPage.css
- src/utils/WebSocketController.test.ts
- src/epics/productionEpics.test.ts
- src/reducers/productionReducer.test.ts
- src/containers/Version/VersionPage.test.tsx
- docs/codex/interfaces.md

### Testing

- `git diff --check` was executed successfully to validate formatting and patch cleanliness. (passed)
- Unit tests: new and updated Jest tests were added for the controller, epic mapping, reducer and Version UI; running the project's full `npm test` in this environment failed because `react-scripts` is not installed here and registry access is blocked (environment limitation), so tests could not be executed end-to-end in CI here. (not executed due to missing deps / registry 403)
- Type check: running a local TypeScript check flagged deprecation warnings in the environment TypeScript config (project uses older tsconfig options); this is an environment/tooling note and does not reflect the introduced logic. (not blocking for the code changes)
- The new unit tests are designed to pass in the normal development environment (with project dependencies installed): they cover connect, disconnect, reconnect (id change), reducer state transitions, and the Version page rendering for both connected and disconnected states.

Notes / guarantees

- No new Socket.IO connections are created; the change reuses the existing global `WebSocketController` instance managed by the production epic. The Info/Version page only reads the Redux state.
- `socket.id` is shown only as ephemeral diagnostic information and is not persisted, stored in `localStorage`, or used as a device/client identity anywhere in the codebase.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a94221e44e0832fb570133b0403335e)