### PR TITLE
Consume Realtime Controller State v1 over Socket.IO

### DIFF
--- a/docs/codex/compatibility/cross-repo-contracts.md
+++ b/docs/codex/compatibility/cross-repo-contracts.md
@@ -204,3 +204,32 @@ The React PWA now expects the PI/control service to expose Web-Push management b
 - `POST /push/test` sends a test notification to registered subscriptions.
 
 Push notifications are triggered by the control service when `waiting.canConfirm` becomes true for confirmation states such as `MASHING_IN_CONFIRMATION`, `IODINE_TEST`, `MASHING_OUT_CONFIRMATION`, `COOKING_CONFIRMATION`, `BOILING_CONFIRMATION`, or `DECOCTION_CONFIRMATION`. This repository only implements the UI/service-worker side; backend persistence and status-transition detection remain **Needs verification** in the PI/control repository.
+
+## Realtime State Contract v1 (Brauhaus2 #194 / Braumeister #109)
+
+The existing single Socket.IO connection on namespace `/` and path `/socket.io` publishes complete controller snapshots. REST remains rooted at `/api/controller`; `GET /Status/` continues polling process state, steps, temperatures, timing, waiting/confirmation, and `heating.heaterEnabled` every second.
+
+```ts
+// heating-running-changed
+interface HeatingRunningState { running: boolean; }
+
+// agitator-state-changed
+interface AgitatorRealtimeState {
+  mode: 'OFF' | 'CONTINUOUS' | 'AUTOMATIC';
+  paused: boolean;
+  operation: 'STOPPED' | 'CONTINUOUS' | 'INTERVAL';
+  intervalPhase?: string;
+  actualOutputOn: boolean;
+  speedPercent: number;
+  runningMinutes: number;
+  breakMinutes: number;
+}
+
+// alarm-state-changed
+interface AlarmRealtimeState { alarms: Alarm[]; }
+
+// temperature-sensor-state-changed
+interface TemperatureSensorRealtimeState { health: string; sensorId?: string; }
+```
+
+`running` and `actualOutputOn` are physical hardware feedback. An alarm payload replaces the complete alarm collection. Sensor `health` values are controller-owned and must not be synthesized by the UI. While connected, these snapshots take precedence over Phase-A legacy `/Status/` fields. After disconnect, received hardware snapshots are stale/unknown. Until the Phase-B hardware test succeeds, legacy fields and the initial `GET /Agitator/Status` read remain fallbacks. Deployment and reconnect snapshot behavior **Needs verification** with Braumeister #109 and two real clients.

--- a/docs/codex/external/control-context.md
+++ b/docs/codex/external/control-context.md
@@ -252,3 +252,7 @@ No unique event ID or monotonic sequence number is generated for statuses. `curr
 - `hardware.heater === 'ON'` and `hardware.agitator === 'ON'` are meaningful for display.
 
 Needs verification in control repository: socket.io event shape, initial empty `Status` behavior, and whether `/temperatur/0` is the intended long-term stable temperature read route.
+
+## Realtime State Contract v1
+
+Brauhaus2 #194 consumes Braumeister #109 on the existing Socket.IO connection: `heating-running-changed`, `agitator-state-changed`, `alarm-state-changed`, and `temperature-sensor-state-changed`. Agitator `operation` is exactly `STOPPED | CONTINUOUS | INTERVAL` (`OFF` is only a mode), and `actualOutputOn` is physical output truth. Alarm snapshots replace the entire alarm list. The UI retains `overheat` and `brew-session-running`, retains the one-second process poll, and treats realtime state as stale after disconnect. End-to-end reconnect and two-client behavior **Needs verification** on real hardware.

--- a/docs/codex/interfaces.md
+++ b/docs/codex/interfaces.md
@@ -125,3 +125,7 @@ Additional controller API endpoints expected by the PWA:
 | POST | `/push/test` | Sends a test notification to registered subscriptions |
 
 These paths are consumed through the existing relative UI base URL `/api/controller`. Backend implementation, durable storage, and process-state event detection are **Needs verification** in the PI/control repository.
+
+### Realtime State Contract v1
+
+The exact events `heating-running-changed`, `agitator-state-changed`, `alarm-state-changed`, and `temperature-sensor-state-changed` use the existing shared connection. Payloads are respectively `{ running: boolean }`; the complete agitator snapshot with `mode: OFF|CONTINUOUS|AUTOMATIC`, `operation: STOPPED|CONTINUOUS|INTERVAL`, `paused`, optional `intervalPhase`, `actualOutputOn`, `speedPercent`, `runningMinutes`, and `breakMinutes`; `{ alarms: Alarm[] }`; and `{ health: string, sensorId?: string }`. Alarm arrays replace rather than merge state. Socket disconnect makes received hardware state stale. Braumeister #109 reconnect snapshots **Needs verification** on hardware.

--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -14,6 +14,7 @@ import {RecipeImportRequest, RecipeImportResult} from '../model/RecipeImport';
 import { ThemeName, setTheme as applyAndStoreTheme } from "../utils/theme";
 import { pushViewPath } from "../utils/viewRoutes";
 import { setStoredDebugMode } from "../utils/debugMode";
+import {AgitatorRealtimeState, AlarmRealtimeState, HeatingRunningState, TemperatureSensorRealtimeState} from '../model/RealtimeControllerState';
 
 export namespace BeerActions {
 
@@ -634,6 +635,10 @@ export namespace ProductionActions {
         OVERHEAT_RECEIVED = 'ProductionActions.OVERHEAT_RECEIVED',
         BREW_SESSION_RUNNING_RECEIVED = 'ProductionActions.BREW_SESSION_RUNNING_RECEIVED',
         SOCKET_CONNECTION_CHANGED = 'ProductionActions.SOCKET_CONNECTION_CHANGED',
+        HEATING_RUNNING_CHANGED = 'ProductionActions.HEATING_RUNNING_CHANGED',
+        AGITATOR_STATE_CHANGED = 'ProductionActions.AGITATOR_STATE_CHANGED',
+        ALARM_STATE_CHANGED = 'ProductionActions.ALARM_STATE_CHANGED',
+        TEMPERATURE_SENSOR_STATE_CHANGED = 'ProductionActions.TEMPERATURE_SENSOR_STATE_CHANGED',
     }
 
     export interface SetWaterStatus {
@@ -756,6 +761,10 @@ export namespace ProductionActions {
         readonly type: ActionTypes.SOCKET_CONNECTION_CHANGED;
         payload: { connected: boolean; socketId?: string };
     }
+    export interface HeatingRunningChanged { readonly type: ActionTypes.HEATING_RUNNING_CHANGED; payload: HeatingRunningState; }
+    export interface AgitatorStateChanged { readonly type: ActionTypes.AGITATOR_STATE_CHANGED; payload: AgitatorRealtimeState; }
+    export interface AlarmStateChanged { readonly type: ActionTypes.ALARM_STATE_CHANGED; payload: AlarmRealtimeState; }
+    export interface TemperatureSensorStateChanged { readonly type: ActionTypes.TEMPERATURE_SENSOR_STATE_CHANGED; payload: TemperatureSensorRealtimeState; }
 
     export type AllProductionActions =
         GetTemperatures |
@@ -784,7 +793,7 @@ export namespace ProductionActions {
         WebSocketDisconnect |
         OverheatReceived |
         BrewSessionRunningReceived |
-        SocketConnectionChanged;
+        SocketConnectionChanged | HeatingRunningChanged | AgitatorStateChanged | AlarmStateChanged | TemperatureSensorStateChanged;
 
     export function setWaterStatus(aWaterStatus: WaterStatus): ProductionActions.SetWaterStatus {
         return {
@@ -960,4 +969,8 @@ export namespace ProductionActions {
             payload: {connected, socketId}
         };
     }
+    export const heatingRunningChanged = (payload: HeatingRunningState): HeatingRunningChanged => ({type: ActionTypes.HEATING_RUNNING_CHANGED, payload});
+    export const agitatorStateChanged = (payload: AgitatorRealtimeState): AgitatorStateChanged => ({type: ActionTypes.AGITATOR_STATE_CHANGED, payload});
+    export const alarmStateChanged = (payload: AlarmRealtimeState): AlarmStateChanged => ({type: ActionTypes.ALARM_STATE_CHANGED, payload});
+    export const temperatureSensorStateChanged = (payload: TemperatureSensorRealtimeState): TemperatureSensorStateChanged => ({type: ActionTypes.TEMPERATURE_SENSOR_STATE_CHANGED, payload});
 }

--- a/src/containers/Dashboard/DashboardPage.connect.ts
+++ b/src/containers/Dashboard/DashboardPage.connect.ts
@@ -15,6 +15,8 @@ const mapStateToProps = (state: DashboardRootState) => ({
   beerToBrew: state.beerDataReducer.beerToBrew,
   brewingStatus: state.productionReducer.brewingStatus,
   isBackendAvailable: state.productionReducer.isBackenAvailable,
+  realtimeState: state.productionReducer.realtimeState,
+  socketConnected: state.productionReducer.socketConnection.connected,
 });
 
 const mapDispatchToProps = (dispatch: (action: BeerActions.AllBeerActions) => void) => ({

--- a/src/containers/Dashboard/DashboardPage.tsx
+++ b/src/containers/Dashboard/DashboardPage.tsx
@@ -13,6 +13,8 @@ import { eBrewState } from '../../enums/eBrewState';
 import { getBrewingStatusLabel, isProcessActive } from '../../utils/brewingStatus/selectors';
 import { buildActiveBrewRows, calculateAdditionalStats, calculateCareHints, calculateConsumption, calculateDashboardKpis, calculateRecipeHistory, formatDashboardQuantity, safeNumber } from '../../utils/Dashboard/dashboardCalculations';
 import './DashboardPage.css';
+import {RealtimeControllerState} from '../../model/RealtimeControllerState';
+import {getAgitatorActive, getHeaterDisplayStatus} from '../Production/utils/productionStatus';
 
 interface DashboardPageProps {
   beers?: Beer[];
@@ -21,6 +23,8 @@ interface DashboardPageProps {
   beerToBrew?: Beer;
   brewingStatus?: BrewingStatus;
   isBackendAvailable: boolean;
+  realtimeState?: RealtimeControllerState;
+  socketConnected?: boolean;
   getBeers: (isFetching: boolean) => void;
   getFinishedBrews: (isFetching: boolean) => void;
 }
@@ -58,8 +62,8 @@ export class DashboardPage extends React.Component<DashboardPageProps> {
           <div className="dashboard-progress" aria-label={`Fortschritt ${progress} Prozent`}><span style={{ width: `${progress}%` }} /></div>
           <div className="dashboard-time"><span>{canShowProgress ? `${formatSeconds(elapsed)} / ${formatSeconds(duration)}` : brewingStatus?.currentStep.mode === ProcessMode.HEATING ? 'Zieltemperatur wird erreicht' : 'Prozess läuft'}</span>{canShowProgress && <strong>{progress} %</strong>}</div>
           <dl className="dashboard-hardware">
-            <div><dt>Heizung</dt><dd className={brewingStatus?.hardware.heater === 'ON' ? 'is-on' : ''}>{brewingStatus?.hardware.heater === 'ON' ? 'EIN' : 'AUS'}</dd></div>
-            <div><dt>Rührwerk</dt><dd className={brewingStatus?.hardware.agitator === 'ON' ? 'is-on' : ''}>{brewingStatus?.hardware.agitator === 'ON' ? 'EIN' : 'AUS'}</dd></div>
+            <div><dt>Heizung</dt><dd className={getHeaterDisplayStatus(brewingStatus, this.props.realtimeState, this.props.socketConnected) === 'active' ? 'is-on' : ''}>{getHeaterDisplayStatus(brewingStatus, this.props.realtimeState, this.props.socketConnected) === 'unknown' ? 'UNBEKANNT' : getHeaterDisplayStatus(brewingStatus, this.props.realtimeState, this.props.socketConnected) === 'active' ? 'EIN' : 'AUS'}</dd></div>
+            <div><dt>Rührwerk</dt><dd className={getAgitatorActive(brewingStatus, this.props.realtimeState, this.props.socketConnected) ? 'is-on' : ''}>{getAgitatorActive(brewingStatus, this.props.realtimeState, this.props.socketConnected) === undefined ? 'UNBEKANNT' : getAgitatorActive(brewingStatus, this.props.realtimeState, this.props.socketConnected) ? 'EIN' : 'AUS'}</dd></div>
           </dl>
           {brewingStatus?.waiting.canConfirm && <p className="dashboard-warning">Bestätigung erforderlich: {String(brewingStatus.waiting.waitingFor)}</p>}
         </div>}

--- a/src/containers/MainView/Header/Header.connect.ts
+++ b/src/containers/MainView/Header/Header.connect.ts
@@ -9,6 +9,8 @@ const mapStateToProps = (state: any) => ({
     messages: state.applicationReducer.message,
     backendStatus: state.productionReducer.isBackenAvailable,
     brewingStatus: state.productionReducer.brewingStatus,
+    realtimeState: state.productionReducer.realtimeState,
+    socketConnected: state.productionReducer.socketConnection.connected,
 });
 
 const mapDispatchToProps = (dispatch: any) => ({

--- a/src/containers/MainView/Header/Header.tsx
+++ b/src/containers/MainView/Header/Header.tsx
@@ -12,6 +12,8 @@ import {getNavigationViews} from '../../../utils/viewConfig';
 import {UiMode} from '../../../enums/eUiMode';
 import ModalDialog, {DialogType} from '../../../components/ModalDialog/ModalDialog';
 import {SystemRepository} from '../../../repositorys/SystemRepository';
+import {RealtimeControllerState} from '../../../model/RealtimeControllerState';
+import {getAlarmSnapshot} from '../../Production/utils/productionStatus';
 
 
 
@@ -22,6 +24,8 @@ interface HeaderProps {
     removeAllMessages: () => void;
     backendStatus: boolean;
     brewingStatus?: BrewingStatus;
+    realtimeState?: RealtimeControllerState;
+    socketConnected?: boolean;
 }
 
 interface HeaderState {
@@ -107,7 +111,7 @@ export class Header extends React.Component<HeaderProps, HeaderState> {
 
     render() {
        const { messages = [] , removeAllMessages, backendStatus, brewingStatus } = this.props; // Default-Wert für messages ist ein leeres Array
-       const equipmentAlarmText = isEquipmentAlarmActive(brewingStatus) ? equipmentAlarmDisplay.headerText : undefined;
+       const equipmentAlarmText = isEquipmentAlarmActive(getAlarmSnapshot(brewingStatus, this.props.realtimeState, this.props.socketConnected)) ? equipmentAlarmDisplay.headerText : undefined;
        const uiMode = getUiMode();
        const navigationViews = getNavigationViews(uiMode);
        const isVisible = (view: Views) => navigationViews.includes(view);

--- a/src/containers/Mobile/MobileStatusView/MobileProductionView.connect.ts
+++ b/src/containers/Mobile/MobileStatusView/MobileProductionView.connect.ts
@@ -10,6 +10,8 @@ const mapStateToProps = (state: any) => ({
     isConfirmPending: state.productionReducer.isConfirmPending,
     confirmError: state.productionReducer.confirmError,
     isBrewingStatusStale: state.productionReducer.isBrewingStatusStale
+    ,realtimeState: state.productionReducer.realtimeState
+    ,socketConnected: state.productionReducer.socketConnection.connected
 });
 
 const mapDispatchToProps = (dispatch: any) => ({

--- a/src/containers/Mobile/MobileStatusView/MobileProductionView.tsx
+++ b/src/containers/Mobile/MobileStatusView/MobileProductionView.tsx
@@ -7,7 +7,8 @@ import {getBrewingStatusLabel, getConfirmationRequestViewModel, getStatusChangeK
 import SettingsPage from '../../Settings/SettingsPage.connect';
 import {ConfirmStates} from '../../../enums/eConfirmStates';
 import {ControlConfirmationNotice} from '../../Production/components/InlineProcessNotice';
-import {getHeaterDisplayLabel} from '../../Production/utils/productionStatus';
+import {getAgitatorActive, getHeaterDisplayLabel} from '../../Production/utils/productionStatus';
+import {RealtimeControllerState} from '../../../model/RealtimeControllerState';
 
 interface MobileProductionViewProps {
     temperature: number;
@@ -19,6 +20,8 @@ interface MobileProductionViewProps {
     isConfirmPending: boolean;
     confirmError?: string;
     isBrewingStatusStale: boolean;
+    realtimeState?: RealtimeControllerState;
+    socketConnected?: boolean;
 }
 
 interface MobileProductionViewState {
@@ -133,11 +136,11 @@ export class MobileProductionView extends React.Component<MobileProductionViewPr
                             </div>
                             <div className="mobile-info-block">
                                 <span className="mobile-label">Heizung:</span>
-                                <span className="mobile-value">{this.props.isBrewingStatusStale ? 'Unbekannt' : getHeaterDisplayLabel(brewingStatus)}</span>
+                                <span className="mobile-value">{this.props.isBrewingStatusStale ? 'Unbekannt' : getHeaterDisplayLabel(brewingStatus, this.props.realtimeState, this.props.socketConnected)}</span>
                             </div>
                             <div className="mobile-info-block">
                                 <span className="mobile-label">Rührwerk:</span>
-                                <span className="mobile-value">{this.props.isBrewingStatusStale ? 'Unbekannt' : (brewingStatus?.hardware?.agitator === 'ON' ? 'An' : 'Aus')}</span>
+                                <span className="mobile-value">{this.props.isBrewingStatusStale ? 'Unbekannt' : (getAgitatorActive(brewingStatus, this.props.realtimeState, this.props.socketConnected) === undefined ? 'Unbekannt' : getAgitatorActive(brewingStatus, this.props.realtimeState, this.props.socketConnected) ? 'An' : 'Aus')}</span>
                             </div>
                             <div className="mobile-info-block">
                                 <span className="mobile-label">Laufzeit:</span>

--- a/src/containers/Production/Production.connect.ts
+++ b/src/containers/Production/Production.connect.ts
@@ -52,6 +52,8 @@ const mapStateToProps = (state: RootState) => (
         isWaterFillingSuccessful: state.productionReducer.isWaterFillingSuccessful,
         isToggleAgitatorSuccess: state.productionReducer.isToggleAgitatorSuccess,
         brewingStatus: state.productionReducer.brewingStatus,
+        realtimeState: state.productionReducer.realtimeState,
+        socketConnected: state.productionReducer.socketConnection.connected,
         isBackenAvailable: state.productionReducer.isBackenAvailable,
         waterStatus: state.productionReducer.waterStatus,
         isPollingRunning: state.productionReducer.isPollingRunning,

--- a/src/containers/Production/Production.test.tsx
+++ b/src/containers/Production/Production.test.tsx
@@ -205,7 +205,7 @@ describe('Production agitator controller integration', () => {
         rerender(<Production {...props} brewingStatus={{...createBrewingStatus(), agitator: {mode: 'CONTINUOUS', paused: false, operation: 'CONTINUOUS', intervalPhase: 'IDLE', actualOutputOn: true}}} />);
         expect(await screen.findByRole('switch', {name: 'Durchgehend rühren'})).toBeChecked();
         expect(screen.getByRole('switch', {name: 'Automatik'})).not.toBeChecked();
-        rerender(<Production {...props} brewingStatus={{...createBrewingStatus(), agitator: {mode: 'OFF', paused: false, operation: 'OFF', intervalPhase: 'IDLE', actualOutputOn: false}}} />);
+        rerender(<Production {...props} brewingStatus={{...createBrewingStatus(), agitator: {mode: 'OFF', paused: false, operation: 'STOPPED', intervalPhase: 'IDLE', actualOutputOn: false}}} />);
         await waitFor(() => expect(screen.getByRole('switch', {name: 'Durchgehend rühren'})).not.toBeChecked());
         expect(screen.getByRole('switch', {name: 'Automatik'})).not.toBeChecked();
         expect(ProductionRepository.setAgitatorConfig).not.toHaveBeenCalled();

--- a/src/containers/Production/Production.tsx
+++ b/src/containers/Production/Production.tsx
@@ -30,7 +30,7 @@ import {isBrewingProcessActive, isProcessActive} from "../../utils/brewingStatus
 import {getVesselContentType} from "../../utils/brewingStatus/vesselContent";
 import {calculateHopSchedule, getDueHopAddition, HopAddition} from "./utils/hopSchedule";
 import {getRemainingSecondsFromStatus, shouldCountdownLocally, tickRemainingSeconds} from "./utils/productionCountdown";
-import {getHeaterDisplayLabel, getHeaterDisplayStatus, isAgitatorActive, isControllerAvailable as getIsControllerAvailable, isHeaterActive} from "./utils/productionStatus";
+import {getAlarmSnapshot, getAgitatorActive, getHeaterDisplayLabel, getHeaterDisplayStatus, isControllerAvailable as getIsControllerAvailable} from "./utils/productionStatus";
 import {RecipeWaterFill, RecipeWaterFillStatus} from "./waterFill/recipeWaterFill.types";
 import {completeWaterFill, createInitialRecipeWaterFillStatus, failWaterFill, includePreparedSpargeAfterMashingOut, markValveOpened, resetWaterFill, startManualWaterFill, startWaterFill} from "./waterFill/recipeWaterFillState";
 import {ProductionDialogs} from "./components/ProductionDialogs";
@@ -41,6 +41,7 @@ import {getConfirmationRequestViewModel} from '../../utils/brewingStatus/selecto
 import {ConfirmStates} from '../../enums/eConfirmStates';
 import {AgitatorConfig, AgitatorMode, AgitatorRuntimeStatus} from '../../model/Agitator';
 import {ProductionRepository} from '../../repositorys/ProductionRepository';
+import {RealtimeControllerState} from '../../model/RealtimeControllerState';
 
 export const AGITATOR_SPEED_DEBOUNCE_MS = 300;
 
@@ -77,6 +78,8 @@ export interface ProductionProps {
     isConfirmPending: boolean;
     confirmError?: string;
     debug: boolean;
+    realtimeState?: RealtimeControllerState;
+    socketConnected?: boolean;
 }
 
 interface ProductionState {
@@ -181,6 +184,9 @@ export class Production extends React.Component<ProductionProps, ProductionState
                 this.mergeAgitatorPoll(brewingStatus.agitator);
             }
         }
+        if (prevProps.realtimeState?.agitator !== this.props.realtimeState?.agitator && this.props.socketConnected && this.props.realtimeState?.agitator) {
+            this.mergeAgitatorPoll(this.props.realtimeState.agitator);
+        }
 
         if (getIsControllerAvailable(prevProps.isBackenAvailable) && !this.isControllerAvailable()) {
             this.clearAgitatorSpeedDebounce();
@@ -189,7 +195,7 @@ export class Production extends React.Component<ProductionProps, ProductionState
             this.loadAgitatorStatus();
         }
 
-        if (isEquipmentAlarmActive(prevProps.brewingStatus) && !isEquipmentAlarmActive(brewingStatus)) {
+        if (isEquipmentAlarmActive(getAlarmSnapshot(prevProps.brewingStatus, prevProps.realtimeState, prevProps.socketConnected)) && !isEquipmentAlarmActive(getAlarmSnapshot(brewingStatus, this.props.realtimeState, this.props.socketConnected))) {
             this.setState({equipmentAlarmDismissed: false});
         }
 
@@ -593,15 +599,15 @@ export class Production extends React.Component<ProductionProps, ProductionState
 
     renderFlames() {
         const {brewingStatus} = this.props;
-        const heaterStatus = getHeaterDisplayStatus(brewingStatus);
-        const heaterLabel = this.props.isBrewingStatusStale ? 'Heizungsstatus unbekannt' : getHeaterDisplayLabel(brewingStatus);
+        const heaterStatus = getHeaterDisplayStatus(brewingStatus, this.props.realtimeState, this.props.socketConnected);
+        const heaterLabel = this.props.isBrewingStatusStale ? 'Heizungsstatus unbekannt' : getHeaterDisplayLabel(brewingStatus, this.props.realtimeState, this.props.socketConnected);
 
         return (
             <div className='Flame'>
               <span className={`heater-status heater-status--${this.props.isBrewingStatusStale ? 'unknown' : heaterStatus}`}>
                   {heaterLabel}
               </span>
-              {!this.props.isBrewingStatusStale && isHeaterActive(brewingStatus) && (
+              {!this.props.isBrewingStatusStale && heaterStatus === 'active' && (
                     <div className="flame-strip" aria-label="Heizung aktiv">
                         <Flame/>
                         <Flame/>
@@ -755,7 +761,7 @@ export class Production extends React.Component<ProductionProps, ProductionState
 
             <div className="Water">
                 <WaterControl filledLiters={displayedWaterLiters} label={this.getDisplayedWaterLabel()} agitatorSpeed={currentAgitatorSpeed}
-                              agitatorState={isAgitatorActive(brewingStatus)}
+                              agitatorState={getAgitatorActive(brewingStatus, this.props.realtimeState, this.props.socketConnected) === true}
                               contentType={getVesselContentType(brewingStatus)}></WaterControl>
 
             </div>);
@@ -825,7 +831,7 @@ export class Production extends React.Component<ProductionProps, ProductionState
 
     render() {
         const {showFinishDialog} = this.state;
-        const equipmentAlarmActive = isEquipmentAlarmActive(this.props.brewingStatus);
+        const equipmentAlarmActive = isEquipmentAlarmActive(getAlarmSnapshot(this.props.brewingStatus, this.props.realtimeState, this.props.socketConnected));
         return (
             <div className="containerProduction ">
                 {this.props.isBrewingStatusStale && <div role="alert" className="production-stale-status">Controller nicht erreichbar – angezeigter Braustatus ist veraltet.</div>}

--- a/src/containers/Production/utils/productionStatus.test.ts
+++ b/src/containers/Production/utils/productionStatus.test.ts
@@ -1,0 +1,23 @@
+import {getAgitatorActive, getHeaterDisplayStatus} from './productionStatus';
+import {BrewingStatus} from '../../../model/brewingStatus.types';
+import {RealtimeControllerState} from '../../../model/RealtimeControllerState';
+
+const status = (heaterEnabled = true): BrewingStatus => ({
+  elapsedTime: 0, currentTime: 0, process: {state: 'ACTIVE' as any}, currentStep: {phase: 'RAST' as any, mode: 'HEATING' as any},
+  temperature: {}, hardware: {heater: 'OFF', agitator: 'OFF'}, heating: {heaterEnabled}, waiting: {waitingFor: 'NONE', canConfirm: false}, error: {}, alarms: []
+});
+const realtime = (running: boolean): RealtimeControllerState => ({heatingRunning: running, alarms: [], alarmsReceived: false, agitator: {mode: 'AUTOMATIC', paused: false, operation: 'INTERVAL', intervalPhase: 'RUNNING', actualOutputOn: running, speedPercent: 50, runningMinutes: 1, breakMinutes: 1}});
+
+describe('realtime production selectors', () => {
+  it('uses one heater decision table and marks disconnected snapshots unknown', () => {
+    expect(getHeaterDisplayStatus(status(), realtime(true), true)).toBe('active');
+    expect(getHeaterDisplayStatus(status(), realtime(false), true)).toBe('ready');
+    expect(getHeaterDisplayStatus(status(false), realtime(true), true)).toBe('blocked');
+    expect(getHeaterDisplayStatus(status(), realtime(true), false)).toBe('unknown');
+  });
+  it('uses actualOutputOn and treats it as stale after disconnect', () => {
+    expect(getAgitatorActive(status(), realtime(true), true)).toBe(true);
+    expect(getAgitatorActive(status(), realtime(false), true)).toBe(false);
+    expect(getAgitatorActive(status(), realtime(true), false)).toBeUndefined();
+  });
+});

--- a/src/containers/Production/utils/productionStatus.ts
+++ b/src/containers/Production/utils/productionStatus.ts
@@ -1,7 +1,8 @@
 import {BackendAvailable} from '../../../reducers/productionReducer';
 import {BrewingStatus} from '../../../model/brewingStatus.types';
+import {RealtimeControllerState} from '../../../model/RealtimeControllerState';
 
-export type HeaterDisplayStatus = 'blocked' | 'ready' | 'active';
+export type HeaterDisplayStatus = 'blocked' | 'ready' | 'active' | 'unknown';
 
 export const isControllerAvailable = (aBackendAvailable: BackendAvailable | boolean): boolean =>
     typeof aBackendAvailable === 'boolean' ? aBackendAvailable : aBackendAvailable?.isBackenAvailable === true;
@@ -9,18 +10,32 @@ export const isControllerAvailable = (aBackendAvailable: BackendAvailable | bool
 export const isHeaterActive = (aBrewingStatus?: BrewingStatus): boolean =>
     aBrewingStatus?.hardware?.heater === 'ON';
 
-export const getHeaterDisplayStatus = (aBrewingStatus?: BrewingStatus): HeaterDisplayStatus => {
+export const getHeaterDisplayStatus = (aBrewingStatus?: BrewingStatus, realtime?: RealtimeControllerState, socketConnected = false): HeaterDisplayStatus => {
     if (aBrewingStatus?.heating?.heaterEnabled === false) return 'blocked';
+    if (socketConnected && realtime?.heatingRunning !== undefined) return realtime.heatingRunning ? 'active' : 'ready';
+    if (realtime?.heatingRunning !== undefined) return 'unknown';
     return isHeaterActive(aBrewingStatus) ? 'active' : 'ready';
 };
 
-export const getHeaterDisplayLabel = (aBrewingStatus?: BrewingStatus): string => {
+export const getHeaterDisplayLabel = (aBrewingStatus?: BrewingStatus, realtime?: RealtimeControllerState, socketConnected = false): string => {
     const labels: Record<HeaterDisplayStatus, string> = {
         blocked: 'Heizung gesperrt',
         ready: 'Heizung bereit',
         active: 'Heizung aktiv',
+        unknown: 'Unbekannt',
     };
-    return labels[getHeaterDisplayStatus(aBrewingStatus)];
+    return labels[getHeaterDisplayStatus(aBrewingStatus, realtime, socketConnected)];
 };
 
 export const isAgitatorActive = (aBrewingStatus?: BrewingStatus): boolean => aBrewingStatus?.hardware?.agitator === 'ON';
+export const getAgitatorActive = (status?: BrewingStatus, realtime?: RealtimeControllerState, socketConnected = false): boolean | undefined => {
+    if (socketConnected && realtime?.agitator) return realtime.agitator.actualOutputOn;
+    if (realtime?.agitator) return undefined;
+    return status?.hardware?.agitator === 'ON';
+};
+
+export const getAlarmSnapshot = (status?: BrewingStatus, realtime?: RealtimeControllerState, socketConnected = false) => {
+    if (socketConnected && realtime?.alarmsReceived) return realtime.alarms;
+    if (!socketConnected && realtime?.alarmsReceived) return undefined;
+    return status?.alarms;
+};

--- a/src/epics/productionEpics.test.ts
+++ b/src/epics/productionEpics.test.ts
@@ -187,6 +187,16 @@ describe('sendBrewingDataEpic$ failures', () => {
 });
 
 describe('mapControlSocketEvent', () => {
+  it('maps every Realtime State Contract v1 event without changing its snapshot', () => {
+    const heating = {running: true};
+    const agitator = {mode: 'AUTOMATIC' as const, paused: false, operation: 'INTERVAL' as const, intervalPhase: 'RUNNING', actualOutputOn: true, speedPercent: 42, runningMinutes: 3, breakMinutes: 2};
+    const alarm = {alarms: [{type: 'EQUIPMENT_ALARM', active: true}]};
+    const sensor = {health: 'OK', sensorId: '28-1'};
+    expect(mapControlSocketEvent({event: 'heating-running-changed', data: heating})).toEqual(ProductionActions.heatingRunningChanged(heating));
+    expect(mapControlSocketEvent({event: 'agitator-state-changed', data: agitator})).toEqual(ProductionActions.agitatorStateChanged(agitator));
+    expect(mapControlSocketEvent({event: 'alarm-state-changed', data: alarm})).toEqual(ProductionActions.alarmStateChanged(alarm));
+    expect(mapControlSocketEvent({event: 'temperature-sensor-state-changed', data: sensor})).toEqual(ProductionActions.temperatureSensorStateChanged(sensor));
+  });
   it('maps the structured socket.io overheat event without JSON parsing', () => {
     expect(mapControlSocketEvent({event: 'overheat', data: {temperature: 101}})).toEqual(ProductionActions.overheatReceived({temperature: 101}));
   });

--- a/src/epics/productionEpics.ts
+++ b/src/epics/productionEpics.ts
@@ -15,6 +15,7 @@ import {BeerRecipeScaler} from "../utils/BeerScaler/ScalingBeerRecipe";
 import {BrewSession} from "../model/BrewSession";
 import {Beer} from "../model/Beer";
 import type {RootState} from "../reducers/rootReducer";
+import {AgitatorRealtimeState, AlarmRealtimeState, HeatingRunningState, TemperatureSensorRealtimeState} from '../model/RealtimeControllerState';
 
 const BREWING_STATUS_POLL_INTERVAL = 1000;
 export const BREWING_STATUS_REQUEST_TIMEOUT = 8000;
@@ -23,14 +24,19 @@ export const WATER_FILLING_MAX_DURATION = 30 * 60 * 1000;
 const WS_URL = (typeof BaseURL !== 'undefined' ? BaseURL : '').replace(/^http/, 'ws');
 let wsController: WebSocketController | null = null;
 
-export const mapControlSocketEvent = (event: {event: string; data?: any}) => {
+export const mapControlSocketEvent = (event: {event: string; data?: unknown}) => {
   switch (event.event) {
     case 'overheat':
       return ProductionActions.overheatReceived(event.data);
     case 'brew-session-running':
       return ProductionActions.brewSessionRunningReceived();
     case 'connection-status':
-      return ProductionActions.socketConnectionChanged(event.data.connected, event.data.socketId);
+      const connection = event.data as {connected: boolean; socketId?: string};
+      return ProductionActions.socketConnectionChanged(connection.connected, connection.socketId);
+    case 'heating-running-changed': return ProductionActions.heatingRunningChanged(event.data as HeatingRunningState);
+    case 'agitator-state-changed': return ProductionActions.agitatorStateChanged(event.data as AgitatorRealtimeState);
+    case 'alarm-state-changed': return ProductionActions.alarmStateChanged(event.data as AlarmRealtimeState);
+    case 'temperature-sensor-state-changed': return ProductionActions.temperatureSensorStateChanged(event.data as TemperatureSensorRealtimeState);
     default:
       return undefined;
   }

--- a/src/model/Agitator.ts
+++ b/src/model/Agitator.ts
@@ -1,5 +1,5 @@
 export type AgitatorMode = 'OFF' | 'CONTINUOUS' | 'AUTOMATIC';
-export type AgitatorOperation = 'OFF' | 'CONTINUOUS' | 'INTERVAL';
+export type AgitatorOperation = 'STOPPED' | 'CONTINUOUS' | 'INTERVAL';
 
 export interface AgitatorConfig {
     mode: AgitatorMode;

--- a/src/model/RealtimeControllerState.ts
+++ b/src/model/RealtimeControllerState.ts
@@ -1,0 +1,15 @@
+import {AgitatorRuntimeStatus} from './Agitator';
+import {Alarm} from './brewingStatus.types';
+
+export interface HeatingRunningState { running: boolean; }
+export type AgitatorRealtimeState = Required<Pick<AgitatorRuntimeStatus, 'mode' | 'paused' | 'operation' | 'actualOutputOn' | 'speedPercent' | 'runningMinutes' | 'breakMinutes'>> & Pick<AgitatorRuntimeStatus, 'intervalPhase'>;
+export interface AlarmRealtimeState { alarms: Alarm[]; }
+export interface TemperatureSensorRealtimeState { health: string; sensorId?: string; }
+
+export interface RealtimeControllerState {
+    heatingRunning?: boolean;
+    agitator?: AgitatorRealtimeState;
+    alarms: Alarm[];
+    alarmsReceived: boolean;
+    temperatureSensor?: TemperatureSensorRealtimeState;
+}

--- a/src/reducers/productionReducer.test.ts
+++ b/src/reducers/productionReducer.test.ts
@@ -56,6 +56,14 @@ describe('productionReducer socket connection', () => {
 });
 
 describe('productionReducer brewingStatus alarms', () => {
+    it('stores replacement realtime snapshots idempotently', () => {
+        const snapshot = {alarms: [{type: AlarmType.EQUIPMENT_ALARM, active: true}]};
+        const active = productionReducer(initialProductionState, ProductionActions.alarmStateChanged(snapshot));
+        const repeated = productionReducer(active, ProductionActions.alarmStateChanged(snapshot));
+        const cleared = productionReducer(repeated, ProductionActions.alarmStateChanged({alarms: []}));
+        expect(repeated.realtimeState.alarms).toEqual(snapshot.alarms);
+        expect(cleared.realtimeState.alarms).toEqual([]);
+    });
     it('replaces the complete status so an ended alarm is removed on the next poll', () => {
         const activeAlarm = {type: AlarmType.EQUIPMENT_ALARM, active: true};
         const alarmState = productionReducer(initialProductionState, ProductionActions.setBrewingStatus(statusWithAlarms([activeAlarm])));

--- a/src/reducers/productionReducer.ts
+++ b/src/reducers/productionReducer.ts
@@ -5,6 +5,7 @@ import { BrewingStatus } from '../model/BrewingStatus';
 import { isProcessAborted, isProcessFinished, isProcessIdle, isProcessInError } from '../utils/brewingStatus/selectors';
 import { ConfirmStates } from '../enums/eConfirmStates';
 import { WaterStatus } from '../components/Controlls/WaterControll/WaterControl';
+import {RealtimeControllerState} from '../model/RealtimeControllerState';
 
 export interface BackendAvailable {
     isBackenAvailable: boolean;
@@ -36,6 +37,7 @@ export interface ProductionReducerState {
         connected: boolean;
         socketId?: string;
     };
+    realtimeState: RealtimeControllerState;
 }
 
 export const initialProductionState: ProductionReducerState = {
@@ -58,7 +60,8 @@ export const initialProductionState: ProductionReducerState = {
     isNextProcedureStepPending: false,
     nextProcedureStepError: undefined,
     isBrewingStatusStale: false,
-    socketConnection: {connected: false}
+    socketConnection: {connected: false},
+    realtimeState: {alarms: [], alarmsReceived: false}
 };
 
 const productionReducer = (
@@ -157,6 +160,14 @@ const productionReducer = (
                 }
             };
         }
+        case ProductionActions.ActionTypes.HEATING_RUNNING_CHANGED:
+            return {...aState, realtimeState: {...aState.realtimeState, heatingRunning: aAction.payload.running}};
+        case ProductionActions.ActionTypes.AGITATOR_STATE_CHANGED:
+            return {...aState, realtimeState: {...aState.realtimeState, agitator: aAction.payload}};
+        case ProductionActions.ActionTypes.ALARM_STATE_CHANGED:
+            return {...aState, realtimeState: {...aState.realtimeState, alarms: aAction.payload.alarms, alarmsReceived: true}};
+        case ProductionActions.ActionTypes.TEMPERATURE_SENSOR_STATE_CHANGED:
+            return {...aState, realtimeState: {...aState.realtimeState, temperatureSensor: aAction.payload}};
         case ProductionActions.ActionTypes.WEBSOCKET_DISCONNECT: {
             return {...aState, socketConnection: {connected: false}};
         }

--- a/src/utils/WebSocketController.test.ts
+++ b/src/utils/WebSocketController.test.ts
@@ -49,6 +49,10 @@ describe('WebSocketController', () => {
     expect(io).toHaveBeenCalledTimes(1);
     expect(socket.on).toHaveBeenCalledWith('overheat', expect.any(Function));
     expect(socket.on).toHaveBeenCalledWith('brew-session-running', expect.any(Function));
+    expect(socket.on).toHaveBeenCalledWith('heating-running-changed', expect.any(Function));
+    expect(socket.on).toHaveBeenCalledWith('agitator-state-changed', expect.any(Function));
+    expect(socket.on).toHaveBeenCalledWith('alarm-state-changed', expect.any(Function));
+    expect(socket.on).toHaveBeenCalledWith('temperature-sensor-state-changed', expect.any(Function));
   });
 
   it('forwards brew-session-running with its payload to the message handler', () => {

--- a/src/utils/WebSocketController.ts
+++ b/src/utils/WebSocketController.ts
@@ -6,6 +6,7 @@ export interface SocketConnectionStatus {
 }
 
 export type MessageHandler = (event: { event: string; data?: any }) => void;
+const realtimeEvents = ['heating-running-changed', 'agitator-state-changed', 'alarm-state-changed', 'temperature-sensor-state-changed'] as const;
 
 export class WebSocketController {
   private socket: Socket | null = null;
@@ -53,6 +54,9 @@ export class WebSocketController {
         this.messageHandler({ event: 'brew-session-running', data });
       }
     });
+    realtimeEvents.forEach((event) => this.socket!.on(event, (data: unknown) => {
+      this.messageHandler?.({event, data});
+    }));
   }
 
   onMessage(handler: MessageHandler) {

--- a/src/utils/brewingStatus/alarmDisplay.ts
+++ b/src/utils/brewingStatus/alarmDisplay.ts
@@ -1,4 +1,4 @@
-import {AlarmType, BrewingStatus} from '../../model/brewingStatus.types';
+import {Alarm, AlarmType} from '../../model/brewingStatus.types';
 
 export const equipmentAlarmDisplay = {
     title: 'Anlagenalarm',
@@ -6,7 +6,7 @@ export const equipmentAlarmDisplay = {
     headerText: 'ANLAGENALARM – Anlage prüfen'
 };
 
-export const isEquipmentAlarmActive = (aStatus?: BrewingStatus): boolean =>
-    aStatus?.alarms?.some((aAlarm) =>
+export const isEquipmentAlarmActive = (alarms?: Alarm[]): boolean =>
+    alarms?.some((aAlarm) =>
         aAlarm.type === AlarmType.EQUIPMENT_ALARM && aAlarm.active === true
     ) === true;


### PR DESCRIPTION
### Motivation

- Implement the Realtime State Contract v1 so the UI consumes physical controller/hardware snapshots over the existing Socket.IO connection instead of relying on poll-only hardware fields.
- Preserve the 1s `/Status/` poll for process data while moving physical heater/agitator/alarm/sensor status to event-driven snapshots.
- Keep the single shared Socket.IO connection and maintain compatibility with Phase A backend fallbacks and existing `brew-session-running`/`overheat` behavior.
- Provide a central, consistent selector/view-model layer so Desktop and Mobile use the same heater/agitator/alarm semantics and stale/unknown handling on disconnects.

### Description

- Add a typed `RealtimeControllerState` model and DTOs (`HeatingRunningState`, `AgitatorRealtimeState`, `AlarmRealtimeState`, `TemperatureSensorRealtimeState`) to represent Socket.IO snapshots separately from `BrewingStatus`.
- Extend Redux with strongly typed actions and reducer handling for `HEATING_RUNNING_CHANGED`, `AGITATOR_STATE_CHANGED`, `ALARM_STATE_CHANGED`, and `TEMPERATURE_SENSOR_STATE_CHANGED`, storing replacement snapshots idempotently under `productionReducer.realtimeState`.
- Reuse the existing `WebSocketController` connection and register listeners for the four Realtime State Contract v1 events while preserving `overheat`, `brew-session-running`, and connection-status behavior; map those events to the new Redux actions in `mapControlSocketEvent`.
- Centralize display and fallback logic in production selectors: new heater/agitator/alarm helpers decide between `BrewingStatus` (process/poll) and `realtimeState` (socket) and implement the stale/unknown semantics when the socket is disconnected; update Production/Dashboard/Header/Mobile views to use these selectors.
- Adjust the agitator model to require `operation` be `STOPPED | CONTINUOUS | INTERVAL` (with `OFF` remaining a `mode`), and document the Realtime State Contract v1 in project docs for cross-repo compatibility and Phase-A/Phase-B migration notes.

### Testing

- Ran `git diff --check` to verify no whitespace/patch issues (passed).
- Added unit tests covering mapping and selector semantics (`src/containers/Production/utils/productionStatus.test.ts`, extended `src/epics/productionEpics.test.ts` and `src/reducers/productionReducer.test.ts`, and updated `src/utils/WebSocketController.test.ts`) but full execution was blocked by environment dependency issues.
- Tried TypeScript compile with `tsc --noEmit --ignoreDeprecations 6.0`, but compilation could not complete due to missing project dependencies/type declarations (many "Cannot find module 'react'" / type-definition errors) so typecheck did not fully succeed in this environment.
- Tried running Jest via the project test wrapper, but test execution was prevented by registry/dependency errors (npm/react-scripts not available in the sandbox), so automated Jest runs did not complete here.

Note: the implementation includes tests that run in a normal development environment once dependencies are installed and network access to the package registry is available; full CI/Jest and tsc verification should be executed in CI or a dev environment with project dependencies present.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a946263733c832fb924bd9820c35c2d)