### PR TITLE
Pass alarms array into isEquipmentAlarmActive in selector test

### DIFF
--- a/src/utils/brewingStatus/selectors.test.ts
+++ b/src/utils/brewingStatus/selectors.test.ts
@@ -13,10 +13,10 @@ const makeStatus = (aPart: Partial<BrewingStatus>): BrewingStatus => ({
 
 describe('brewing selectors', () => {
   it('recognizes only an explicitly active equipment alarm in the alarm list', () => {
-    expect(isEquipmentAlarmActive(makeStatus({}))).toBe(false);
-    expect(isEquipmentAlarmActive(makeStatus({alarms: [{type: 'FUTURE_ALARM', active: true}]}))).toBe(false);
-    expect(isEquipmentAlarmActive(makeStatus({alarms: [{type: AlarmType.EQUIPMENT_ALARM, active: false}]}))).toBe(false);
-    expect(isEquipmentAlarmActive(makeStatus({alarms: [{type: AlarmType.EQUIPMENT_ALARM, active: true}]}))).toBe(true);
+    expect(isEquipmentAlarmActive(makeStatus({}).alarms)).toBe(false);
+    expect(isEquipmentAlarmActive(makeStatus({alarms: [{type: 'FUTURE_ALARM', active: true}]}).alarms)).toBe(false);
+    expect(isEquipmentAlarmActive(makeStatus({alarms: [{type: AlarmType.EQUIPMENT_ALARM, active: false}]}).alarms)).toBe(false);
+    expect(isEquipmentAlarmActive(makeStatus({alarms: [{type: AlarmType.EQUIPMENT_ALARM, active: true}]}).alarms)).toBe(true);
   });
   it('derives an active brewing process from process.state ACTIVE only', () => {
     expect(isBrewingProcessActive(undefined)).toBe(false);


### PR DESCRIPTION
### Motivation
- Fix TypeScript `TS2345` test errors by ensuring the alarm-display helper receives an `Alarm[]` instead of a full `BrewingStatus` object.

### Description
- Update `src/utils/brewingStatus/selectors.test.ts` to call `isEquipmentAlarmActive(...)` with the normalized `alarms` array (`makeStatus(...).alarms`) for empty, unknown, inactive, and active alarm cases.
- The change only adjusts test inputs and preserves the existing assertions and coverage for equipment alarm detection.

### Testing
- No unit tests were executed because dependency installation with `npm ci` failed due to an npm registry `403` error, which prevented running `npm test` and `tsc --noEmit` in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a9469bdcc98832fa63808c19c67461c)