### PR TITLE
Fix production tests: complete realtime agitator snapshots and update reducer fixtures

### DIFF
--- a/src/containers/Production/Production.test.tsx
+++ b/src/containers/Production/Production.test.tsx
@@ -188,7 +188,7 @@ describe('Production agitator controller integration', () => {
     it('keeps confirmed config when a realtime snapshot updates runtime only', async () => {
         const {props, rerender} = renderProduction();
         await screen.findByText('36 %');
-        rerender(<Production {...props} socketConnected={true} realtimeState={{alarms: [], alarmsReceived: true, agitator: {mode: 'AUTOMATIC', paused: true, operation: 'INTERVAL', intervalPhase: 'BREAK', actualOutputOn: false}}} />);
+        rerender(<Production {...props} socketConnected={true} realtimeState={{alarms: [], alarmsReceived: true, agitator: {mode: 'AUTOMATIC', paused: true, operation: 'INTERVAL', intervalPhase: 'BREAK', actualOutputOn: false, speedPercent: 36, runningMinutes: 2, breakMinutes: 7}}} />);
         expect(await screen.findByText('36 %')).toBeInTheDocument();
         expect(screen.getByRole('switch', {name: 'Automatik'})).toBeChecked();
         expect(screen.getByRole('button', {name: 'Rührwerk fortsetzen'})).toBeInTheDocument();
@@ -199,10 +199,10 @@ describe('Production agitator controller integration', () => {
         const {props, rerender} = renderProduction();
         await screen.findByText('36 %');
         (ProductionRepository.setAgitatorConfig as jest.Mock).mockClear();
-        rerender(<Production {...props} socketConnected={true} realtimeState={{alarms: [], alarmsReceived: true, agitator: {mode: 'CONTINUOUS', paused: false, operation: 'CONTINUOUS', intervalPhase: 'IDLE', actualOutputOn: true}}} />);
+        rerender(<Production {...props} socketConnected={true} realtimeState={{alarms: [], alarmsReceived: true, agitator: {mode: 'CONTINUOUS', paused: false, operation: 'CONTINUOUS', intervalPhase: 'IDLE', actualOutputOn: true, speedPercent: 36, runningMinutes: 2, breakMinutes: 7}}} />);
         expect(await screen.findByRole('switch', {name: 'Durchgehend rühren'})).toBeChecked();
         expect(screen.getByRole('switch', {name: 'Automatik'})).not.toBeChecked();
-        rerender(<Production {...props} socketConnected={true} realtimeState={{alarms: [], alarmsReceived: true, agitator: {mode: 'OFF', paused: false, operation: 'STOPPED', intervalPhase: 'IDLE', actualOutputOn: false}}} />);
+        rerender(<Production {...props} socketConnected={true} realtimeState={{alarms: [], alarmsReceived: true, agitator: {mode: 'OFF', paused: false, operation: 'STOPPED', intervalPhase: 'IDLE', actualOutputOn: false, speedPercent: 36, runningMinutes: 2, breakMinutes: 7}}} />);
         await waitFor(() => expect(screen.getByRole('switch', {name: 'Durchgehend rühren'})).not.toBeChecked());
         expect(screen.getByRole('switch', {name: 'Automatik'})).not.toBeChecked();
         expect(ProductionRepository.setAgitatorConfig).not.toHaveBeenCalled();

--- a/src/reducers/productionReducer.test.ts
+++ b/src/reducers/productionReducer.test.ts
@@ -97,7 +97,7 @@ describe('productionReducer confirm lifecycle', () => {
     });
 
     it('clears pending on failure while preserving the current waiting status', () => {
-        const waitingStatus = {...statusWithAlarms([]), waiting: {waitingFor: WaitingFor.IODINE_TEST, canConfirm: true}};
+        const waitingStatus = {...status(), waiting: {waitingFor: WaitingFor.IODINE_TEST, canConfirm: true}};
         const waiting = productionReducer(initialProductionState, ProductionActions.setBrewingStatus(waitingStatus));
         const pending = productionReducer(waiting, ProductionActions.confirm(ConfirmStates.IODINE));
         const failed = productionReducer(pending, ProductionActions.confirmFailure('HTTP 500'));
@@ -120,11 +120,11 @@ describe('productionReducer next-step lifecycle', () => {
 
 describe('productionReducer stale status', () => {
     it('marks an existing status stale while offline and clears stale on a fresh status', () => {
-        const withStatus = productionReducer(initialProductionState, ProductionActions.setBrewingStatus(statusWithAlarms([])));
+        const withStatus = productionReducer(initialProductionState, ProductionActions.setBrewingStatus(status()));
         const offline = productionReducer(withStatus, ProductionActions.isBackenAvailable({isBackenAvailable: false, statusText: 'offline'}));
         expect(offline.brewingStatus).toBe(withStatus.brewingStatus);
         expect(offline.isBrewingStatusStale).toBe(true);
-        const refreshed = productionReducer(offline, ProductionActions.setBrewingStatus(statusWithAlarms([])));
+        const refreshed = productionReducer(offline, ProductionActions.setBrewingStatus(status()));
         expect(refreshed.isBrewingStatusStale).toBe(false);
     });
 });


### PR DESCRIPTION
### Motivation

- Resolve TypeScript test failures where realtime agitator snapshots in tests lacked required fields from the `AgitatorRealtimeState` contract. 
- Update reducer tests that referenced a removed helper so the tests use the current process-status fixture.

### Description

- Add the required agitator config fields `speedPercent`, `runningMinutes`, and `breakMinutes` to the realtime `agitator` snapshots used in `src/containers/Production/Production.test.tsx`.
- Replace usages of the removed `statusWithAlarms` helper with the current `status()` fixture in `src/reducers/productionReducer.test.ts`.
- Modified only test files `src/containers/Production/Production.test.tsx` and `src/reducers/productionReducer.test.ts` to restore type compatibility with the realtime state contract.

### Testing

- Ran `git diff --check` which reported no spacing or patch errors. 
- Attempted to run the targeted Jest tests with `CI=true npm test -- --runInBand src/containers/Production/Production.test.tsx src/reducers/productionReducer.test.ts`, but the test run could not complete because project dependencies (including `react-scripts`) were not installed in this environment. 
- Attempted `npm ci` and `npm run build`, both of which failed due to npm registry access errors (HTTP 403), so a full test run / build could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a94730ea8b4832fb3d0e59beff9d2ea)