### PR TITLE
Globale Behandlung von Temperatursensor-Fehlern (Socket→Redux→UI)

### DIFF
--- a/docs/codex/compatibility/cross-repo-contracts.md
+++ b/docs/codex/compatibility/cross-repo-contracts.md
@@ -228,7 +228,11 @@ interface AgitatorRealtimeState {
 interface AlarmRealtimeState { alarms: Alarm[]; }
 
 // temperature-sensor-state-changed
-interface TemperatureSensorRealtimeState { health: string; sensorId?: string; }
+interface TemperatureSensorRealtimeState {
+  current: number | null;
+  health: 'OK' | 'MISSING' | 'STALE' | 'INVALID_READING' | 'MULTIPLE_SENSORS_FOUND' | 'NOT_CONFIGURED';
+  sensorId: string | null;
+}
 ```
 
-`running` is the controller-reported heater on/off state, while `actualOutputOn` is agitator hardware feedback. An alarm payload replaces the complete alarm collection. Sensor `health` values are controller-owned and must not be synthesized by the UI. These snapshots are the sole UI source of truth for physical heater feedback, agitator output, alarms, and sensor health. After disconnect, received snapshots are stale/unknown; REST process availability remains independent. `GET /Agitator/Status` continues only to initialize editable agitator configuration, not as a live-state fallback. Deployment and reconnect snapshot behavior **Needs verification** with Braumeister #109 and two real clients.
+`running` is the controller-reported heater on/off state, while `actualOutputOn` is agitator hardware feedback. An alarm payload replaces the complete alarm collection. Sensor `health` values are controller-owned and must not be synthesized by the UI; `current: null` means that no valid measurement exists, while numeric zero is valid. These snapshots are the sole UI source of truth for physical heater feedback, agitator output, alarms, and sensor health. After disconnect, received snapshots are stale/unknown; REST process availability remains independent. The controller sends a fresh sensor snapshot after connect/reconnect, so the UI clears the previous sensor snapshot during connection changes and does not add polling. `GET /Agitator/Status` continues only to initialize editable agitator configuration, not as a live-state fallback. Deployment and reconnect snapshot behavior **Needs verification** with Braumeister #109 and two real clients.

--- a/docs/codex/interfaces.md
+++ b/docs/codex/interfaces.md
@@ -73,7 +73,7 @@ The desktop header sends `POST /api/system/shutdown` without a request body only
 ## Socket.io
 
 - URL is derived from `BaseURL` by replacing leading `http` with `ws`.
-- `WebSocketController` uses `socket.io-client` and subscribes to event names `overheat` and `brew-session-running` on one shared connection.
+- `WebSocketController` uses `socket.io-client` and subscribes to `overheat`, `brew-session-running`, and all Realtime State Contract events on one shared connection.
 - On `overheat`, it calls the configured handler with `{ event: 'overheat', data }`.
 - On `brew-session-running`, it calls the same configured handler with `{ event: 'brew-session-running', data }`; `data` may be absent. The UI converts this to `BREW_SESSION_RUNNING_RECEIVED`, loads `GET /BrewSession`, reconstructs the scaled recipe, and starts the existing status poll if it is not already running.
 - The production epic maps the controller's structured handler object directly and ignores unknown event names.
@@ -117,4 +117,4 @@ These paths are consumed through the existing relative UI base URL `/api/control
 
 ### Realtime State Contract v1
 
-The exact events `heating-running-changed`, `agitator-state-changed`, `alarm-state-changed`, and `temperature-sensor-state-changed` use the existing shared connection. Payloads are respectively `{ running: boolean }`; the complete agitator snapshot with `mode: OFF|CONTINUOUS|AUTOMATIC`, `operation: STOPPED|CONTINUOUS|INTERVAL`, `paused`, optional `intervalPhase`, `actualOutputOn`, `speedPercent`, `runningMinutes`, and `breakMinutes`; `{ alarms: Alarm[] }`; and `{ health: string, sensorId?: string }`. Alarm arrays replace rather than merge state. Socket disconnect makes received hardware state stale. Braumeister #109 reconnect snapshots **Needs verification** on hardware.
+The exact events `heating-running-changed`, `agitator-state-changed`, `alarm-state-changed`, and `temperature-sensor-state-changed` use the existing shared connection. The temperature snapshot is `{ current: number | null, health: 'OK' | 'MISSING' | 'STALE' | 'INVALID_READING' | 'MULTIPLE_SENSORS_FOUND' | 'NOT_CONFIGURED', sensorId: string | null }`. Numeric zero is valid; `null` means that no valid reading exists. Alarm arrays replace rather than merge state. Socket disconnect makes received hardware state stale. The controller sends a fresh temperature snapshot to new and reconnected clients; end-to-end behavior on hardware **Needs verification**.

--- a/src/containers/App.tsx
+++ b/src/containers/App.tsx
@@ -1,13 +1,24 @@
-import React, { Suspense } from 'react';
+import React, { Suspense, useEffect } from 'react';
+import {useDispatch} from 'react-redux';
 import Header from './MainView/Header/Header.connect';
 import './App.css';
 import Index from "./index.connect";
+import {ProductionActions} from '../actions/actions';
 
 const MobileProductionView = React.lazy(() => import('./Mobile/MobileStatusView/MobileProductionView.connect'));
 
 const App: React.FC = () => {
     const isMobile = window.innerWidth < 768;
     const isDashboardRoute = window.location.pathname === '/dashboard';
+    const dispatch = useDispatch();
+
+    useEffect(() => {
+        // Desktop owns the same central connection through Index. The mobile
+        // shell bypasses Index, so keep that PWA shell subscribed as well.
+        if (!isMobile || isDashboardRoute) return undefined;
+        dispatch(ProductionActions.webSocketConnect());
+        return () => { dispatch(ProductionActions.webSocketDisconnect()); };
+    }, [dispatch, isDashboardRoute, isMobile]);
 
     if (isMobile && !isDashboardRoute) {
         return (

--- a/src/containers/Dashboard/DashboardPage.tsx
+++ b/src/containers/Dashboard/DashboardPage.tsx
@@ -15,6 +15,7 @@ import { buildActiveBrewRows, calculateAdditionalStats, calculateCareHints, calc
 import './DashboardPage.css';
 import {RealtimeControllerState} from '../../model/RealtimeControllerState';
 import {getAgitatorActive, getHeatingActive} from '../Production/utils/productionStatus';
+import {formatTemperature} from '../../utils/temperatureSensor';
 
 interface DashboardPageProps {
   beers?: Beer[];
@@ -43,7 +44,7 @@ export class DashboardPage extends React.Component<DashboardPageProps> {
   private renderProductionStatus(): React.ReactNode {
     const { brewingStatus, beerToBrew, isBackendAvailable } = this.props;
     const isActive = isProcessActive(brewingStatus);
-    const currentTemp = safeNumber(brewingStatus?.temperature.current, NaN);
+    const currentTemp = this.props.socketConnected ? this.props.realtimeState?.temperatureSensor?.current : null;
     const targetTemp = safeNumber(brewingStatus?.temperature.target, NaN);
     const duration = safeNumber(brewingStatus?.currentStep.duration);
     const elapsed = safeNumber(brewingStatus?.currentStep.elapsedTime);
@@ -58,7 +59,7 @@ export class DashboardPage extends React.Component<DashboardPageProps> {
         {isActive && <div className="dashboard-production-details">
           <div className="dashboard-production-heading"><h3>{beerToBrew?.name ?? 'Unbekanntes Bier'}</h3><span className="dashboard-badge dashboard-badge-production">{getBrewingStatusLabel(brewingStatus)}</span></div>
           <p className="dashboard-step">{brewingStatus?.currentStep.name || brewingStatus?.currentStep.phase || 'Aktueller Schritt'}</p>
-          <div className="dashboard-temperature"><strong>{Number.isFinite(currentTemp) ? currentTemp.toLocaleString('de-DE', { maximumFractionDigits: 1 }) : '–'} °C</strong><span>Ziel: {Number.isFinite(targetTemp) ? targetTemp.toLocaleString('de-DE', { maximumFractionDigits: 1 }) : '–'} °C</span></div>
+          <div className="dashboard-temperature"><strong>{formatTemperature(currentTemp)}</strong><span>Ziel: {Number.isFinite(targetTemp) ? targetTemp.toLocaleString('de-DE', { maximumFractionDigits: 1 }) : '–'} °C</span></div>
           <div className="dashboard-progress" aria-label={`Fortschritt ${progress} Prozent`}><span style={{ width: `${progress}%` }} /></div>
           <div className="dashboard-time"><span>{canShowProgress ? `${formatSeconds(elapsed)} / ${formatSeconds(duration)}` : brewingStatus?.currentStep.mode === ProcessMode.HEATING ? 'Zieltemperatur wird erreicht' : 'Prozess läuft'}</span>{canShowProgress && <strong>{progress} %</strong>}</div>
           <dl className="dashboard-hardware">

--- a/src/containers/MainView/Header/Header.test.tsx
+++ b/src/containers/MainView/Header/Header.test.tsx
@@ -16,6 +16,7 @@ const brewingStatus = (): BrewingStatus => ({
 });
 
 describe('Header navigation', () => {
+    const healthyRealtime = {alarms: [], alarmsReceived: true, temperatureSensor: {current: 55.4, health: 'OK' as const, sensorId: '28-1'}};
     beforeEach(() => {
         jest.clearAllMocks();
         mockedShutdown.mockResolvedValue();
@@ -71,6 +72,14 @@ describe('Header navigation', () => {
         rerender(<Header {...props} brewingStatus={brewingStatus()} socketConnected={true} realtimeState={inactiveRealtime} />);
         expect(screen.queryByRole('alert')).not.toBeInTheDocument();
         expect(screen.getByText('Aufheizen')).toBeInTheDocument();
+    });
+
+    it('shows translated sensor failures globally and removes the warning after recovery', () => {
+        const props = {setViewState: jest.fn(), currentView: Views.SETTINGS, removeAllMessages: jest.fn(), backendStatus: true, messages: []};
+        const {rerender} = render(<Header {...props} socketConnected={true} realtimeState={{...healthyRealtime, temperatureSensor: {current: null, health: 'MULTIPLE_SENSORS_FOUND', sensorId: null}}} />);
+        expect(screen.getByRole('alert')).toHaveTextContent('Mehrere Temperatursensoren erkannt');
+        rerender(<Header {...props} socketConnected={true} realtimeState={healthyRealtime} />);
+        expect(screen.queryByText(/Temperatursensor:/)).not.toBeInTheDocument();
     });
 
     it('asks for confirmation without performing a shutdown action', (): void => {

--- a/src/containers/MainView/Header/Header.tsx
+++ b/src/containers/MainView/Header/Header.tsx
@@ -14,6 +14,7 @@ import ModalDialog, {DialogType} from '../../../components/ModalDialog/ModalDial
 import {SystemRepository} from '../../../repositorys/SystemRepository';
 import {RealtimeControllerState} from '../../../model/RealtimeControllerState';
 import {getAlarmSnapshot} from '../../Production/utils/productionStatus';
+import {getTemperatureSensorMessage} from '../../../utils/temperatureSensor';
 
 
 
@@ -112,6 +113,10 @@ export class Header extends React.Component<HeaderProps, HeaderState> {
     render() {
        const { messages = [] , removeAllMessages, backendStatus, brewingStatus } = this.props; // Default-Wert für messages ist ein leeres Array
        const equipmentAlarmText = isEquipmentAlarmActive(getAlarmSnapshot(this.props.realtimeState, this.props.socketConnected)) ? equipmentAlarmDisplay.headerText : undefined;
+       const temperatureSensor = this.props.realtimeState?.temperatureSensor;
+       const sensorWarning = !this.props.socketConnected || temperatureSensor?.health !== 'OK'
+           ? `⚠ Temperatursensor: ${getTemperatureSensorMessage(temperatureSensor)}`
+           : undefined;
        const uiMode = getUiMode();
        const navigationViews = getNavigationViews(uiMode);
        const isVisible = (view: Views) => navigationViews.includes(view);
@@ -201,7 +206,7 @@ export class Header extends React.Component<HeaderProps, HeaderState> {
                 </div>
                 <div className="header-status">
                   <div className="status-display-wrapper">
-                    <StatusDisplay backendStatus={backendStatus} messages={messages} priorityMessage={equipmentAlarmText} disableScrollAnimation={true} removeAllMessages={removeAllMessages}/>
+                    <StatusDisplay backendStatus={backendStatus} messages={messages} priorityMessage={equipmentAlarmText ?? sensorWarning} disableScrollAnimation={true} removeAllMessages={removeAllMessages}/>
                   </div>
                   <div className="time">
                     <span>{this.state.currentDate}</span>

--- a/src/containers/Mobile/MobileStatusView/MobileProductionView.tsx
+++ b/src/containers/Mobile/MobileStatusView/MobileProductionView.tsx
@@ -9,6 +9,7 @@ import {ConfirmStates} from '../../../enums/eConfirmStates';
 import {ControlConfirmationNotice} from '../../Production/components/InlineProcessNotice';
 import {getAgitatorActive, getHeatingActive} from '../../Production/utils/productionStatus';
 import {RealtimeControllerState} from '../../../model/RealtimeControllerState';
+import {formatTemperature} from '../../../utils/temperatureSensor';
 
 interface MobileProductionViewProps {
     temperature: number;
@@ -120,7 +121,7 @@ export class MobileProductionView extends React.Component<MobileProductionViewPr
                         <div className="mobile-info-list">
                             <div className="mobile-info-block">
                                 <span className="mobile-label">Temperatur:</span>
-                                <span className="mobile-value">{this.props.isBrewingStatusStale ? '-' : (brewingStatus?.temperature?.current ?? '-')} °C</span>
+                                <span className="mobile-value">{formatTemperature(this.props.socketConnected ? this.props.realtimeState?.temperatureSensor?.current : null)}</span>
                             </div>
                             <div className="mobile-info-block">
                                 <span className="mobile-label">Zieltemperatur:</span>

--- a/src/containers/Production/Production.css
+++ b/src/containers/Production/Production.css
@@ -124,6 +124,23 @@
     padding: 0 0.75rem;
 }
 
+.temperatureUnavailable {
+    display: flex;
+    min-height: 220px;
+    align-items: center;
+    justify-content: center;
+    color: var(--color-text-secondary);
+    font-size: 2rem;
+    font-weight: 700;
+}
+
+.sensorStartWarning {
+    margin: 0.4rem 0 0;
+    color: var(--color-warning);
+    font-size: 0.85rem;
+    line-height: 1.25;
+}
+
 /* Settings Panel */
 .containerProduction .settings {
     grid-area: settings;

--- a/src/containers/Production/Production.test.tsx
+++ b/src/containers/Production/Production.test.tsx
@@ -80,6 +80,8 @@ const renderProduction = (aOverrides: Partial<React.ComponentProps<typeof Produc
         confirm: jest.fn(),
         isConfirmPending: false,
         debug: true,
+        realtimeState: {alarms: [], alarmsReceived: true, temperatureSensor: {current: 55.4, health: 'OK', sensorId: '28-1'}},
+        socketConnected: true,
         ...aOverrides
     };
     return {props, ...render(<Production {...props} />)};
@@ -328,6 +330,38 @@ describe('Production finished-brew persistence', () => {
 });
 
 describe('Production start button', () => {
+
+    it('blocks startup safely until the first sensor snapshot arrives', () => {
+        renderProduction({realtimeState: {alarms: [], alarmsReceived: false}});
+        expect(screen.getByRole('button', {name: 'Start'})).toBeDisabled();
+        expect(screen.getByRole('alert')).toHaveTextContent('Temperatursensorstatus wird ermittelt');
+        expect(screen.getByLabelText('Aktuelle Temperatur: -- °C')).toBeInTheDocument();
+    });
+
+    it.each([
+        ['MISSING' as const, 'Temperatursensor nicht verfügbar'],
+        ['INVALID_READING' as const, 'Ungültiger Temperaturwert'],
+    ])('blocks startup for %s and explains the sensor problem', (health, message) => {
+        const {props} = renderProduction({realtimeState: {alarms: [], alarmsReceived: true, temperatureSensor: {current: null, health, sensorId: '28-1'}}});
+        fireEvent.click(screen.getByRole('button', {name: 'Start'}));
+        expect(props.sendBrewingData).not.toHaveBeenCalled();
+        expect(screen.getByRole('button', {name: 'Start'})).toBeDisabled();
+        expect(screen.getByRole('alert')).toHaveTextContent(message);
+        expect(screen.getByLabelText('Aktuelle Temperatur: -- °C')).toBeInTheDocument();
+        expect(screen.queryByLabelText('Aktuelle Temperatur: 0 °C')).not.toBeInTheDocument();
+    });
+
+    it('keeps a real zero valid and recovers immediately after a healthy snapshot', () => {
+        const missing = {alarms: [], alarmsReceived: true, temperatureSensor: {current: null, health: 'MISSING' as const, sensorId: '28-1'}};
+        const {rerender, props} = renderProduction({realtimeState: missing});
+        expect(screen.getByRole('button', {name: 'Start'})).toBeDisabled();
+        rerender(<Production {...props} realtimeState={{...missing, temperatureSensor: {current: 0, health: 'OK', sensorId: '28-1'}}} />);
+        expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+        expect(screen.getByLabelText('Aktuelle Temperatur: 0 °C')).toBeInTheDocument();
+        expect(screen.getByRole('button', {name: 'Start'})).toBeEnabled();
+        rerender(<Production {...props} realtimeState={{...missing, temperatureSensor: {current: 55.8, health: 'OK', sensorId: '28-1'}}} />);
+        expect(screen.getByLabelText('Aktuelle Temperatur: 55,8 °C')).toBeInTheDocument();
+    });
 
     it('starts status polling when the desktop production view is restored', () => {
         const startPolling = jest.fn();

--- a/src/containers/Production/Production.tsx
+++ b/src/containers/Production/Production.tsx
@@ -39,6 +39,7 @@ import {ConfirmStates} from '../../enums/eConfirmStates';
 import {AgitatorConfig, AgitatorMode, AgitatorRuntimeStatus} from '../../model/Agitator';
 import {ProductionRepository} from '../../repositorys/ProductionRepository';
 import {RealtimeControllerState} from '../../model/RealtimeControllerState';
+import {formatTemperature, getTemperatureSensorMessage, isTemperatureSensorReady} from '../../utils/temperatureSensor';
 
 export const AGITATOR_SPEED_DEBOUNCE_MS = 300;
 
@@ -552,7 +553,7 @@ export class Production extends React.Component<ProductionProps, ProductionState
 
     isStartButtonDisabled = (): boolean => {
         const {selectedBeer} = this.props;
-        return isUndefined(selectedBeer) || !this.isControllerAvailable() || this.state.brewingIsRunning || this.isBrewingStartRequestPending || !this.isControlBrewingStartAvailable();
+        return isUndefined(selectedBeer) || !this.isControllerAvailable() || !isTemperatureSensorReady(this.props.realtimeState?.temperatureSensor, this.props.socketConnected) || this.state.brewingIsRunning || this.isBrewingStartRequestPending || !this.isControlBrewingStartAvailable();
     }
 
     startBrewing = (): void => {
@@ -616,20 +617,14 @@ export class Production extends React.Component<ProductionProps, ProductionState
     }
 
     renderTemperature() {
-        const {brewingStatus, temperature} = this.props;
-        let value: number;
-        if (this.props.isBrewingStatusStale) {
-            value = 0;
-        } else if (brewingStatus?.temperature?.current === undefined || Number(brewingStatus?.temperature?.current) === 0) {
-            value = temperature;
-        } else {
-            value = isNaN(Number(brewingStatus?.temperature?.current)) ? 0 : Number(brewingStatus?.temperature?.current);
-        }
+        const {brewingStatus} = this.props;
+        const sensor = this.props.realtimeState?.temperatureSensor;
+        const value = isTemperatureSensorReady(sensor, this.props.socketConnected) ? sensor.current : null;
         const targetValue = isNaN(Number(brewingStatus?.temperature?.target)) ? 0 : Number(brewingStatus?.temperature?.target);
-        return (<div className="Temp">
-            <Gauge showAreas={true} value={value} targetValue={targetValue}
+        return (<div className="Temp" aria-label={`Aktuelle Temperatur: ${formatTemperature(value)}`}>
+            {value === null ? <div className="temperatureUnavailable" role="status">{formatTemperature(value)}</div> : <Gauge showAreas={true} value={value} targetValue={targetValue}
                    height={220}
-                   offset={1} minValue={0} maxValue={100} label={"°C"}/>
+                   offset={1} minValue={0} maxValue={100} label={"°C"}/>}
         </div>);
     }
 
@@ -730,6 +725,9 @@ export class Production extends React.Component<ProductionProps, ProductionState
                 </section>
                 <div className="startBtnDiv">
                     <button className="startBtn" disabled={this.isStartButtonDisabled()} onClick={this.startBrewing}>Start</button>
+                    {!isTemperatureSensorReady(this.props.realtimeState?.temperatureSensor, this.props.socketConnected) && <p className="sensorStartWarning" role="alert">
+                        Brauvorgang kann nicht gestartet werden: {getTemperatureSensorMessage(this.props.realtimeState?.temperatureSensor)}.
+                    </p>}
                 </div>
             </div>);
     }

--- a/src/epics/productionEpics.test.ts
+++ b/src/epics/productionEpics.test.ts
@@ -188,7 +188,7 @@ describe('mapControlSocketEvent', () => {
     const heating = {running: true};
     const agitator = {mode: 'AUTOMATIC' as const, paused: false, operation: 'INTERVAL' as const, intervalPhase: 'RUNNING', actualOutputOn: true, speedPercent: 42, runningMinutes: 3, breakMinutes: 2};
     const alarm = {alarms: [{type: 'EQUIPMENT_ALARM', active: true}]};
-    const sensor = {health: 'OK', sensorId: '28-1'};
+    const sensor = {current: 55.4, health: 'OK' as const, sensorId: '28-1'};
     expect(mapControlSocketEvent({event: 'heating-running-changed', data: heating})).toEqual(ProductionActions.heatingRunningChanged(heating));
     expect(mapControlSocketEvent({event: 'agitator-state-changed', data: agitator})).toEqual(ProductionActions.agitatorStateChanged(agitator));
     expect(mapControlSocketEvent({event: 'alarm-state-changed', data: alarm})).toEqual(ProductionActions.alarmStateChanged(alarm));

--- a/src/model/RealtimeControllerState.ts
+++ b/src/model/RealtimeControllerState.ts
@@ -4,7 +4,12 @@ import {Alarm} from './brewingStatus.types';
 export interface HeatingRunningState { running: boolean; }
 export type AgitatorRealtimeState = Required<Pick<AgitatorRuntimeStatus, 'mode' | 'paused' | 'operation' | 'actualOutputOn' | 'speedPercent' | 'runningMinutes' | 'breakMinutes'>> & Pick<AgitatorRuntimeStatus, 'intervalPhase'>;
 export interface AlarmRealtimeState { alarms: Alarm[]; }
-export interface TemperatureSensorRealtimeState { health: string; sensorId?: string; }
+export type TemperatureSensorHealth = 'OK' | 'MISSING' | 'STALE' | 'INVALID_READING' | 'MULTIPLE_SENSORS_FOUND' | 'NOT_CONFIGURED';
+export interface TemperatureSensorRealtimeState {
+    current: number | null;
+    health: TemperatureSensorHealth;
+    sensorId: string | null;
+}
 
 export interface RealtimeControllerState {
     heatingRunning?: boolean;

--- a/src/reducers/productionReducer.test.ts
+++ b/src/reducers/productionReducer.test.ts
@@ -50,6 +50,17 @@ describe('productionReducer socket connection', () => {
         const reconnected = productionReducer(disconnected, ProductionActions.socketConnectionChanged(true, 'xyz789'));
         expect(reconnected.socketConnection).toEqual({connected: true, socketId: 'xyz789'});
     });
+
+    it('uses a fresh complete sensor snapshot and makes reconnect unknown until the next snapshot', () => {
+        const connected = productionReducer(initialProductionState, ProductionActions.socketConnectionChanged(true, 'abc123'));
+        const missing = productionReducer(connected, ProductionActions.temperatureSensorStateChanged({current: null, health: 'MISSING', sensorId: '28-1'}));
+        expect(missing.realtimeState.temperatureSensor).toEqual({current: null, health: 'MISSING', sensorId: '28-1'});
+
+        const reconnected = productionReducer(missing, ProductionActions.socketConnectionChanged(true, 'xyz789'));
+        expect(reconnected.realtimeState.temperatureSensor).toBeUndefined();
+        const recovered = productionReducer(reconnected, ProductionActions.temperatureSensorStateChanged({current: 55.8, health: 'OK', sensorId: '28-1'}));
+        expect(recovered.realtimeState.temperatureSensor?.current).toBe(55.8);
+    });
 });
 
 describe('productionReducer brewingStatus alarms', () => {

--- a/src/reducers/productionReducer.ts
+++ b/src/reducers/productionReducer.ts
@@ -157,7 +157,8 @@ const productionReducer = (
                 socketConnection: {
                     connected: aAction.payload.connected,
                     socketId: aAction.payload.connected ? aAction.payload.socketId : undefined
-                }
+                },
+                realtimeState: {...aState.realtimeState, temperatureSensor: undefined}
             };
         }
         case ProductionActions.ActionTypes.HEATING_RUNNING_CHANGED:
@@ -169,7 +170,7 @@ const productionReducer = (
         case ProductionActions.ActionTypes.TEMPERATURE_SENSOR_STATE_CHANGED:
             return {...aState, realtimeState: {...aState.realtimeState, temperatureSensor: aAction.payload}};
         case ProductionActions.ActionTypes.WEBSOCKET_DISCONNECT: {
-            return {...aState, socketConnection: {connected: false}};
+            return {...aState, socketConnection: {connected: false}, realtimeState: {...aState.realtimeState, temperatureSensor: undefined}};
         }
 
         default:

--- a/src/utils/WebSocketController.test.ts
+++ b/src/utils/WebSocketController.test.ts
@@ -77,6 +77,18 @@ describe('WebSocketController', () => {
     expect(handler).toHaveBeenCalledWith({event: 'brew-session-running', data: undefined});
   });
 
+  it('forwards complete temperature snapshots on the shared connection', () => {
+    const handler = jest.fn();
+    const controller = new WebSocketController('ws://controller');
+    controller.onMessage(handler);
+    controller.connect();
+    const snapshot = {current: null, health: 'MISSING', sensorId: '28-1'};
+
+    listeners['temperature-sensor-state-changed'](snapshot);
+
+    expect(handler).toHaveBeenCalledWith({event: 'temperature-sensor-state-changed', data: snapshot});
+  });
+
   it('forwards connect and disconnect with the current technical socket id', () => {
     const handler = jest.fn();
     const controller = new WebSocketController('ws://controller');

--- a/src/utils/temperatureSensor.ts
+++ b/src/utils/temperatureSensor.ts
@@ -1,0 +1,21 @@
+import {TemperatureSensorHealth, TemperatureSensorRealtimeState} from '../model/RealtimeControllerState';
+
+const healthMessages: Record<TemperatureSensorHealth, string> = {
+    OK: 'Temperatursensor betriebsbereit',
+    MISSING: 'Temperatursensor nicht verfügbar',
+    STALE: 'Temperaturmessung nicht aktuell',
+    INVALID_READING: 'Ungültiger Temperaturwert',
+    MULTIPLE_SENSORS_FOUND: 'Mehrere Temperatursensoren erkannt',
+    NOT_CONFIGURED: 'Temperatursensor nicht konfiguriert',
+};
+
+export const getTemperatureSensorMessage = (sensor?: TemperatureSensorRealtimeState): string =>
+    sensor ? healthMessages[sensor.health] : 'Temperatursensorstatus wird ermittelt';
+
+export const isTemperatureSensorReady = (sensor: TemperatureSensorRealtimeState | undefined, socketConnected: boolean | undefined): sensor is TemperatureSensorRealtimeState & {current: number} =>
+    socketConnected === true && sensor?.health === 'OK' && typeof sensor.current === 'number' && Number.isFinite(sensor.current);
+
+export const formatTemperature = (current: number | null | undefined): string =>
+    current === null || current === undefined || !Number.isFinite(current)
+        ? '-- °C'
+        : `${current.toLocaleString('de-DE', {maximumFractionDigits: 1})} °C`;


### PR DESCRIPTION
### Motivation

- Das Backend liefert jetzt vollständige Temperatursensor-Snapshots (`{ current: number | null, health, sensorId }`) über das bestehende Socket.io-Event `temperature-sensor-state-changed`, und der Frontend-Client soll diesen global verwenden.  
- UI-Verhalten muss sicherstellen, dass `current: null` nie als `0 °C` dargestellt wird und dass ein nicht-OK-Sensor das Starten eines Brauvorgangs verhindert, bis ein gültiger Snapshot vorliegt.

### Description

- Erweiterung des Realtime-Modells um vollständige Sensor-Snapshots mit `current: number | null`, konkreten Health-Strings und `sensorId: string | null` (`src/model/RealtimeControllerState.ts`).
- Neues Hilfsmodul `src/utils/temperatureSensor.ts` mit Mapping-Texten für Health-Zustände, Helpern `isTemperatureSensorReady()` und `formatTemperature()` zur konsistenten UI-Darstellung.
- Produktion-Reducer sichert globalen Sensorzustand in `productionReducer.realtimeState.temperatureSensor` und verwirft vorherige Snapshots bei Socket-Connect/Disconnect, sodass Reconnect-Zustände sicher als "unbekannt" gelten (`src/reducers/productionReducer.ts`).
- Socket-Integration weiter über die vorhandene Produktion-Epic-/`WebSocketController`-Pfad; `temperature-sensor-state-changed` wird weiterhin zentral gemappt und als komplette Snapshot-Aktion übernommen (`src/epics/productionEpics.ts`, Tests aktualisiert).
- Header/Statusleiste zeigt kompakte, designkonforme Warnung an, wenn `health !== 'OK'` oder die Socket-Verbindung fehlt; bereits vorhandene Anlagenalarme behalten höhere Priorität (`src/containers/MainView/Header/Header.tsx`, `StatusDisplay` verwendet `priorityMessage`).
- Produktion-Komponente nutzt jetzt den globalen Snapshot als Quelle für die Temperaturanzeige; fehlende Messwerte werden als `-- °C` angezeigt, echte `0 °C` bleiben sichtbar (`src/containers/Production/Production.tsx`, `src/containers/Production/Production.css`).
- Start-Button-Sperre: UI erlaubt Start nur wenn `isTemperatureSensorReady(...)` wahr ist; zusätzlich wird der Start-Handler vor einem Request geschützt und der Sperrgrund als Inline-Hinweis angezeigt (`src/containers/Production/Production.tsx`).
- Mobile Shell sichert, dass auch beim Umgehen des Desktop-`Index` die Socket-Verbindung aufgebaut/abgeräumt wird (PWA Shell subscribes/unsubscribes) (`src/containers/App.tsx`).
- Dokumentation (`docs/codex/interfaces.md`, `docs/codex/compatibility/cross-repo-contracts.md`) auf die vollständige Snapshot-Struktur und `null`-Semantik aktualisiert.
- Tests ergänzt/aktualisiert: Header-, Production-, WebSocket- und Reducer-Tests erweitern Coverage für: initial unbekannter Zustand, `MISSING`/`INVALID_READING`, echte `0 °C`, Recovery nach OK, Reconnect-Verhalten und Weiterleitung vollständiger Snapshots (`src/containers/Production/Production.test.tsx`, `src/containers/MainView/Header/Header.test.tsx`, `src/utils/WebSocketController.test.ts`, `src/reducers/productionReducer.test.ts`, `src/epics/productionEpics.test.ts`).
- Keine neue Polling-Logik, kein zusätzlicher Socket-Kanal, kein zweiter Store, keine neuen generischen `ERROR`-Enums eingeführt.

### Testing

- Hinzugefügte/aktualisierte Unit-Tests (Jest/RTL) umfassen die geforderten Fälle: Sensor OK, Sensor fehlt (`MISSING`), invalid reading, echte `0 °C`, Recovery, Fehler während Navigation/Reconnect, initial unbekannter Zustand und WebSocket-Forwarding; die Testdateien wurden aktualisiert unter `src/containers/Production/Production.test.tsx`, `src/containers/MainView/Header/Header.test.tsx`, `src/utils/WebSocketController.test.ts`, `src/reducers/productionReducer.test.ts`, `src/epics/productionEpics.test.ts`.
- Lokaler Testlauf: `CI=true npm test ...` bzw. `npx react-scripts test ...` konnte in dieser Umgebung nicht vollständig ausgeführt werden, weil `node_modules`/`react-scripts` nicht verfügbar sind bzw. das Registry-Download (react-scripts) fehlschlug (HTTP 403). Deshalb konnten die neuen Tests nicht vollständig in dieser Laufzeit validiert werden.
- Statische Prüfungen bestanden: `git diff --check` und Repository-Checks (kein Trailing-change-Error nach Bereinigung); Änderungen committet als `05c1b3d` (`Handle temperature sensor failures globally`).

Hinweis: Die Implementierung folgt strikt der vorhandenen Architektur (zentrale Socket-Verbindung + globaler Production-Store) und vermeidet Polling oder parallele Stores; End-to-end-Reconnect- und Mehrclient-Verhalten bleiben als Hardware-/Backend-Verifikation vermerkt und sind in den aktualisierten Docs als `Needs verification` gekennzeichnet.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a9512d4155c832fb46d2e0fe3bb2a1b)