### PR TITLE
Separate realtime sensor/state from /Status/ polling; start polling only for active brews

### DIFF
--- a/docs/codex/app-context.md
+++ b/docs/codex/app-context.md
@@ -52,10 +52,10 @@ Redux Observable epics drive async API calls and polling. Thunk middleware is co
 
 Epics exist for beer, production, hops, malts, yeast, and additional ingredients. Production epics include:
 
-- Temperature read on `GET_TEMPERATURES`.
+- A legacy one-shot temperature read remains available through `GET_TEMPERATURES`, but Production no longer dispatches it on mount; current temperature and sensor health/ID come from the app-lifetime Socket.IO sensor snapshot.
 - Agitator toggle and speed commands.
 - Automatic water filling command plus a 1 second water-status polling stream while filling.
-- Send brewing recipe, start brewing, then poll brewing status every 1000 ms until process state is `FINISHED`, `ABORTED`, or `ERROR`.
+- Send brewing recipe and start brewing (including the optional connected default-namespace Socket.IO ID as `X-Socket-ID`), then emit `START_POLLING` after success. The single polling epic reads brewing status every 1000 ms until process state is `FINISHED`, `ABORTED`, or `ERROR`; Production view mount/unmount does not own that lifecycle.
 - Backend availability polling every 20000 ms after `CHECK_IS_BACKEND_AVAILABLE`.
 - `POST /next` workflow step advancement.
 - Socket.io connection for `overheat` events. Needs verification: the epic currently tries `JSON.parse(event.data)`, but `WebSocketController` passes an object `{ event, data }`, not a browser `MessageEvent`.

--- a/docs/codex/compatibility/cross-repo-contracts.md
+++ b/docs/codex/compatibility/cross-repo-contracts.md
@@ -208,6 +208,8 @@ Push notifications are triggered by the control service when `waiting.canConfirm
 
 The existing single Socket.IO connection on namespace `/` and path `/socket.io` publishes complete controller snapshots. REST remains rooted at `/api/controller`; `GET /Status/` continues polling process state, steps, temperatures, timing, waiting/confirmation, and `heating.followsDecoction` every second.
 
+The UI treats `/` as the actual Socket.IO namespace even though REST uses `/api/controller`. On a locally initiated start it passes the connected `/` namespace SID in the optional `X-Socket-ID` header. `/Status/` polling begins only after that start succeeds or after `brew-session-running` restoration, never from a Production view mount; repeated lifecycle signals cannot create parallel polling loops.
+
 ```ts
 // heating-running-changed
 interface HeatingRunningState { running: boolean; }

--- a/docs/codex/data-flow.md
+++ b/docs/codex/data-flow.md
@@ -32,6 +32,9 @@ Needs verification: backend ordering of `GET beers`, because the UI treats the l
 - Production view reads `beerDataReducer.beerToBrew` as `selectedBeer`.
 - `mapBeerToBrewingData(selectedBeer)` extracts Einmaischen and Abmaischen temperatures, cooking temperature/time, and normalized timed/decoction steps. It emits explicit `RAST`/`DECOCTION` procedure types and upgrades legacy `CONFIRMATION_HOLD` steps to `DECOCTION`. Missing or invalid top-level cooking temperature is replaced with `99` °C in the UI mapping before sending control data.
 - On success, `SEND_BREWING_DATA` posts `BrewingData` to `POST Recipe/` and expects HTTP 201.
+- After recipe submission, the UI calls `StartBrewing` with the connected default-namespace Socket.IO SID in the optional `X-Socket-ID` header. Only a successful controller response emits `START_POLLING`; `startPollingEpic$` owns the single `/Status/` loop and ignores repeated starts while it is active.
+- Mounting or unmounting desktop/mobile Production never starts or stops process polling. A remote, refreshed, or reconnected client instead receives `brew-session-running`, restores `GET /BrewSession`, reconstructs the scaled beer, and emits `START_POLLING` when no poll is active.
+- Temperature, sensor health/ID, heater output, agitator output, and alarms remain available without a brew through the app-lifetime Socket.IO connection. A new/reconnected controller snapshot `temperature-sensor-state-changed` replaces the global sensor snapshot; disconnect clears it as unknown. Production does not issue the legacy temperature REST read on mount.
 - If successful, UI posts `Command/StartBrewing:""` and then begins status polling.
 
 ## Runtime status polling flow

--- a/docs/codex/interfaces.md
+++ b/docs/codex/interfaces.md
@@ -78,6 +78,7 @@ The desktop header sends `POST /api/system/shutdown` without a request body only
 - On `brew-session-running`, it calls the same configured handler with `{ event: 'brew-session-running', data }`; `data` may be absent. The UI converts this to `BREW_SESSION_RUNNING_RECEIVED`, loads `GET /BrewSession`, reconstructs the scaled recipe, and starts the existing status poll if it is not already running.
 - The production epic maps the controller's structured handler object directly and ignores unknown event names.
 - The same shared connection reports `connect` as `{ connected: true, socketId: socket.id }` and `disconnect` as `{ connected: false, socketId: undefined }` through the production Redux flow. The Socket.IO ID is transient diagnostic data only; the UI does not persist it or use it as a client/device identity.
+- When this client starts a brew, it sends that transient default-namespace SID as optional `X-Socket-ID` on `POST Command/StartBrewing:""`. The header is omitted while disconnected. This lets the controller suppress only the initiating client's `brew-session-running` notification; the successful REST response starts that client's polling instead.
 
 ## Normalized brewing status expected by UI
 

--- a/src/containers/Mobile/MobileStatusView/MobileProductionView.connect.ts
+++ b/src/containers/Mobile/MobileStatusView/MobileProductionView.connect.ts
@@ -6,7 +6,6 @@ import {ConfirmStates} from '../../../enums/eConfirmStates';
 const mapStateToProps = (state: any) => ({
     temperature: state.productionReducer.temperature,
     brewingStatus: state.productionReducer.brewingStatus,
-    isPollingRunning: state.productionReducer.isPollingRunning,
     isConfirmPending: state.productionReducer.isConfirmPending,
     confirmError: state.productionReducer.confirmError,
     isBrewingStatusStale: state.productionReducer.isBrewingStatusStale
@@ -15,8 +14,6 @@ const mapStateToProps = (state: any) => ({
 });
 
 const mapDispatchToProps = (dispatch: any) => ({
-    startPolling: () => dispatch(ProductionActions.startPolling()),
-    stopPolling: () => dispatch(ProductionActions.stopPolling()),
     confirm: (confirmState: ConfirmStates) => dispatch(ProductionActions.confirm(confirmState))
 });
 

--- a/src/containers/Mobile/MobileStatusView/MobileProductionView.test.tsx
+++ b/src/containers/Mobile/MobileStatusView/MobileProductionView.test.tsx
@@ -33,11 +33,8 @@ const renderMobileView = (overrides: Partial<React.ComponentProps<typeof MobileP
     const props = {
         temperature: 24,
         brewingStatus: makeStatus(),
-        startPolling: jest.fn(),
-        stopPolling: jest.fn(),
         isConfirmPending: false,
         isBrewingStatusStale: false,
-        isPollingRunning: false,
         confirm: jest.fn(),
         ...overrides,
     };
@@ -168,38 +165,10 @@ describe('MobileProductionView heater status', () => {
 
 
 describe('MobileProductionView polling lifecycle', () => {
-    it('starts polling when the mobile status page opens', () => {
-        const startPolling = jest.fn();
-
-        renderMobileView({startPolling});
-
-        expect(startPolling).toHaveBeenCalledTimes(1);
-    });
-
-    it('does not start a second polling instance when polling is already running', () => {
-        const startPolling = jest.fn();
-
-        renderMobileView({startPolling, isPollingRunning: true});
-
-        expect(startPolling).not.toHaveBeenCalled();
-    });
-
-    it('stops polling when the mobile status page unmounts', () => {
-        const stopPolling = jest.fn();
-        const {unmount} = renderMobileView({stopPolling});
-
+    it('does not start or stop global polling as the mobile view mounts and unmounts', () => {
+        const {unmount} = renderMobileView();
         unmount();
-
-        expect(stopPolling).toHaveBeenCalledTimes(1);
-    });
-
-    it('manual refresh dispatches exactly one START_POLLING request', () => {
-        const startPolling = jest.fn();
-        renderMobileView({startPolling});
-        startPolling.mockClear();
-
-        fireEvent.click(screen.getByRole('button', {name: 'Aktualisieren'}));
-
-        expect(startPolling).toHaveBeenCalledTimes(1);
+        expect((MobileProductionView.prototype as any).componentDidMount).toBeUndefined();
+        expect((MobileProductionView.prototype as any).componentWillUnmount).toBeUndefined();
     });
 });

--- a/src/containers/Mobile/MobileStatusView/MobileProductionView.tsx
+++ b/src/containers/Mobile/MobileStatusView/MobileProductionView.tsx
@@ -14,9 +14,6 @@ import {formatTemperature} from '../../../utils/temperatureSensor';
 interface MobileProductionViewProps {
     temperature: number;
     brewingStatus: BrewingStatus;
-    startPolling: () => void;
-    stopPolling: () => void;
-    isPollingRunning: boolean;
     confirm: (confirmState: ConfirmStates) => void;
     isConfirmPending: boolean;
     confirmError?: string;
@@ -40,16 +37,6 @@ export class MobileProductionView extends React.Component<MobileProductionViewPr
     handleTabChange = (tab: MobileTab) => {
         this.setState({ activeTab: tab });
     };
-
-    componentDidMount() {
-        if (!this.props.isPollingRunning) {
-            this.props.startPolling();
-        }
-    }
-
-    componentWillUnmount() {
-        this.props.stopPolling();
-    }
 
     componentDidUpdate(prevProps: MobileProductionViewProps) {
         const prevStatus = getStatusChangeKey(prevProps.brewingStatus);
@@ -137,11 +124,11 @@ export class MobileProductionView extends React.Component<MobileProductionViewPr
                             </div>
                             <div className="mobile-info-block">
                                 <span className="mobile-label">Heizung:</span>
-                                <span className="mobile-value">{this.props.isBrewingStatusStale || getHeatingActive(this.props.realtimeState, this.props.socketConnected) === undefined ? 'Unbekannt' : getHeatingActive(this.props.realtimeState, this.props.socketConnected) ? 'An' : 'Aus'}</span>
+                                <span className="mobile-value">{getHeatingActive(this.props.realtimeState, this.props.socketConnected) === undefined ? 'Unbekannt' : getHeatingActive(this.props.realtimeState, this.props.socketConnected) ? 'An' : 'Aus'}</span>
                             </div>
                             <div className="mobile-info-block">
                                 <span className="mobile-label">Rührwerk:</span>
-                                <span className="mobile-value">{this.props.isBrewingStatusStale ? 'Unbekannt' : (getAgitatorActive(this.props.realtimeState, this.props.socketConnected) === undefined ? 'Unbekannt' : getAgitatorActive(this.props.realtimeState, this.props.socketConnected) ? 'An' : 'Aus')}</span>
+                                <span className="mobile-value">{getAgitatorActive(this.props.realtimeState, this.props.socketConnected) === undefined ? 'Unbekannt' : getAgitatorActive(this.props.realtimeState, this.props.socketConnected) ? 'An' : 'Aus'}</span>
                             </div>
                             <div className="mobile-info-block">
                                 <span className="mobile-label">Laufzeit:</span>

--- a/src/containers/Production/Production.connect.ts
+++ b/src/containers/Production/Production.connect.ts
@@ -9,9 +9,6 @@ import {Production} from './Production';
 import {ConfirmStates} from '../../enums/eConfirmStates';
 
 const mapDispatchToProps = (dispatch: Dispatch) => ({
-    getTemperatures: () => {
-        dispatch(ProductionActions.getTemperatures())
-    },
     toggleAgitator: (agitatorState: MashAgitatorStates) => {
         dispatch(ProductionActions.toggleAgitator(agitatorState))
     },
@@ -24,13 +21,6 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
     sendBrewingData: (brewingData: BrewingData) => {
         dispatch(ProductionActions.sendBrewingData(brewingData))
     },
-    startPolling: () => {
-        dispatch(ProductionActions.startPolling())
-    },
-    stopPolling: () => {
-        dispatch(ProductionActions.stopPolling())
-    },
-
     addFinishedBrew: (finishedBrew: FinishedBrewCreatePayload) => {
         dispatch(BeerActions.addFinishedBrew(finishedBrew))
     },

--- a/src/containers/Production/Production.test.tsx
+++ b/src/containers/Production/Production.test.tsx
@@ -57,7 +57,6 @@ const renderProduction = (aOverrides: Partial<React.ComponentProps<typeof Produc
         currentAgitatorSpeed: 5,
         agitatorSpeed: 5,
         agitatorIsRunning: ToggleState.OFF,
-        getTemperatures: jest.fn(),
         toggleAgitator: jest.fn(),
         setAgitatorSpeed: jest.fn(),
         startWaterFilling: jest.fn(),
@@ -66,8 +65,6 @@ const renderProduction = (aOverrides: Partial<React.ComponentProps<typeof Produc
         sendBrewingData: jest.fn(),
         brewingStatus: createBrewingStatus(),
         isPollingRunning: false,
-        startPolling: jest.fn(),
-        stopPolling: jest.fn(),
         isBackenAvailable: {isBackenAvailable: true, statusText: 'OK'},
         waterStatus: {filledLiters: 0, targetLiters: 0, openClose: false},
         addFinishedBrew: jest.fn(),
@@ -363,23 +360,16 @@ describe('Production start button', () => {
         expect(screen.getByLabelText('Aktuelle Temperatur: 55,8 °C')).toBeInTheDocument();
     });
 
-    it('starts status polling when the desktop production view is restored', () => {
-        const startPolling = jest.fn();
-        renderProduction({startPolling, isPollingRunning: false});
-        expect(startPolling).toHaveBeenCalledTimes(1);
+    it('does not start status polling when the desktop production view is mounted', () => {
+        renderProduction({isPollingRunning: false});
+        expect(Production.prototype.componentDidMount.toString()).not.toContain('startPolling');
     });
 
-    it('does not start a duplicate poller when polling is already active', () => {
-        const startPolling = jest.fn();
-        renderProduction({startPolling, isPollingRunning: true});
-        expect(startPolling).not.toHaveBeenCalled();
-    });
-
-    it('warns about stale controller data and suppresses the stale heater flame', () => {
+    it('keeps realtime heater feedback independent from stale process status', () => {
         const status = createBrewingStatus(ProcessState.ACTIVE);
         const {container} = renderProduction({brewingStatus: status, isBrewingStatusStale: true});
         expect(screen.getByRole('alert')).toHaveTextContent('Braustatus ist veraltet');
-        expect(container.querySelector('.flame-strip')).toBeNull();
+        expect(container.querySelector('.flame-strip')).not.toBeNull();
     });
 
     it('places the current step above the sole temperature gauge and keeps the process column focused on the upcoming flow', () => {

--- a/src/containers/Production/Production.tsx
+++ b/src/containers/Production/Production.tsx
@@ -50,7 +50,6 @@ export interface ProductionProps {
     currentAgitatorSpeed: number;
     agitatorSpeed: number;
     agitatorIsRunning: ToggleState;
-    getTemperatures: () => void;
     toggleAgitator: (agitatorState: MashAgitatorStates) => void; // legacy Redux connection
     setAgitatorSpeed: (agitatorSpeed: number) => void;
     startWaterFilling: (liters: number) => void;
@@ -58,8 +57,6 @@ export interface ProductionProps {
     isToggleAgitatorSuccess: boolean;
     sendBrewingData: (brewingData: BrewingData) => void;
     brewingStatus?: BrewingStatus;
-    startPolling: () => void;
-    stopPolling: () => void;
     isBackenAvailable: BackendAvailable | boolean;
     waterStatus: WaterStatus;
     addFinishedBrew: (finishedBrew: FinishedBrewCreatePayload) => void;
@@ -146,15 +143,11 @@ export class Production extends React.Component<ProductionProps, ProductionState
 
     componentDidMount() {
         this.isMountedComponent = true;
-        const {getTemperatures, selectedBeer, isPollingRunning, startPolling} = this.props;
+        const {selectedBeer} = this.props;
         if (!isUndefined(selectedBeer)) {
             this.calculateTheHopTimes();
         }
-        getTemperatures();
         this.loadAgitatorStatus();
-        if (!isPollingRunning) {
-            startPolling();
-        }
         this.syncRemainingTimeFromStatus();
         this.remainingTimeInterval = setInterval(this.tickRemainingTime, 1000);
     }
@@ -208,6 +201,10 @@ export class Production extends React.Component<ProductionProps, ProductionState
             this.isBrewingStartRequestPending = false;
             this.setState({brewingIsRunning: false});
         }
+        if (prevProps.brewingStartError !== this.props.brewingStartError && this.props.brewingStartError) {
+            this.isBrewingStartRequestPending = false;
+            this.setState({brewingIsRunning: false});
+        }
 
         if (this.state.recipeWaterFill.isFillActive && waterStatus?.openClose === true && !prevProps.waterStatus?.openClose) {
             this.setState((prevState) => ({recipeWaterFill: markValveOpened(prevState.recipeWaterFill)}));
@@ -250,7 +247,6 @@ export class Production extends React.Component<ProductionProps, ProductionState
                 this.setState({showFinishDialog: true, brewingFinished: false});
             } else {
                 dataCollector.reset();
-                this.props.stopPolling();
                 this.setState({showFinishDialog: false, brewingFinished: true});
             }
         }
@@ -588,7 +584,7 @@ export class Production extends React.Component<ProductionProps, ProductionState
     }
 
     renderFlames() {
-        const isHeating = !this.props.isBrewingStatusStale && getHeatingActive(this.props.realtimeState, this.props.socketConnected) === true;
+        const isHeating = getHeatingActive(this.props.realtimeState, this.props.socketConnected) === true;
 
         return (
             <div className='Flame'>

--- a/src/epics/productionEpics.test.ts
+++ b/src/epics/productionEpics.test.ts
@@ -462,84 +462,82 @@ describe('startPollingEpic$', (): void => {
     expect(mockedProductionRepository.getBrewingStatus).toHaveBeenCalledTimes(1);
     subscription.unsubscribe();
   });
+
+  it('ignores repeated START_POLLING while one loop is active', async (): Promise<void> => {
+    mockedProductionRepository.getBrewingStatus.mockResolvedValue(createStatusResponse(ProcessState.ACTIVE));
+    const action$ = new Subject<ProductionActions.AllProductionActions>();
+    const subscription = startPollingEpic$(action$).subscribe();
+
+    action$.next(ProductionActions.startPolling());
+    action$.next(ProductionActions.startPolling());
+    await flushPromises();
+
+    expect(mockedProductionRepository.getBrewingStatus).toHaveBeenCalledTimes(1);
+    jest.advanceTimersByTime(1000);
+    await flushPromises();
+    expect(mockedProductionRepository.getBrewingStatus).toHaveBeenCalledTimes(2);
+    subscription.unsubscribe();
+  });
+
+  it.each([ProcessState.FINISHED, ProcessState.ABORTED, ProcessState.ERROR])('stops for terminal process state %s', async (terminalState): Promise<void> => {
+    mockedProductionRepository.getBrewingStatus.mockResolvedValue(createStatusResponse(terminalState));
+    const action$ = new Subject<ProductionActions.AllProductionActions>();
+    const subscription = startPollingEpic$(action$).subscribe();
+
+    action$.next(ProductionActions.startPolling());
+    await flushPromises();
+    jest.advanceTimersByTime(5000);
+    await flushPromises();
+
+    expect(mockedProductionRepository.getBrewingStatus).toHaveBeenCalledTimes(1);
+    subscription.unsubscribe();
+  });
 });
 
 describe('sendBrewingDataEpic$', (): void => {
   beforeEach((): void => {
-    jest.useFakeTimers();
     jest.clearAllMocks();
     mockedProductionRepository.sendBrewingData.mockResolvedValue(true);
     mockedProductionRepository.startBrewing.mockResolvedValue(true);
   });
 
-  afterEach((): void => {
-    jest.useRealTimers();
+  const stateWithSocket = (connected: boolean, socketId?: string): any => ({
+    beerDataReducer: initialBeerState,
+    productionReducer: {
+      ...initialProductionState,
+      socketConnection: {connected, socketId},
+    },
   });
 
-  it('does not start another brewing status request while the previous one is still running', async (): Promise<void> => {
-    const aDeferredStatus = createDeferred<{ available: BackendAvailable; brewingStatus: BrewingStatus }>();
-    mockedProductionRepository.getBrewingStatus.mockReturnValue(aDeferredStatus.promise);
-
+  it('emits exactly one START_POLLING after a successful own brew start', async (): Promise<void> => {
     const action$ = new Subject<ProductionActions.SendBrewingData>();
-    const subscription = sendBrewingDataEpic$(action$).subscribe();
+    const state$ = new BehaviorSubject(stateWithSocket(true, 'socket-123'));
+    const emitted: ProductionActions.AllProductionActions[] = [];
+    const subscription = sendBrewingDataEpic$(action$, state$).subscribe((action) => emitted.push(action));
 
     action$.next(ProductionActions.sendBrewingData(createBrewingData()));
     await flushPromises();
-    jest.advanceTimersByTime(5000);
-    await flushPromises();
 
-    expect(mockedProductionRepository.getBrewingStatus).toHaveBeenCalledTimes(1);
-    expect(mockedProductionRepository.getBrewingStatus).toHaveBeenCalledWith(BREWING_STATUS_REQUEST_TIMEOUT);
-
-    aDeferredStatus.resolve(createStatusResponse(ProcessState.ACTIVE));
-    await flushPromises();
-    jest.advanceTimersByTime(1000);
-    await flushPromises();
-
-    expect(mockedProductionRepository.getBrewingStatus).toHaveBeenCalledTimes(2);
+    expect(mockedProductionRepository.sendBrewingData).toHaveBeenCalledTimes(1);
+    expect(mockedProductionRepository.startBrewing).toHaveBeenCalledWith('socket-123');
+    expect(emitted).toEqual([ProductionActions.startPolling()]);
+    expect(mockedProductionRepository.getBrewingStatus).not.toHaveBeenCalled();
     subscription.unsubscribe();
   });
 
-  it.each([ProcessState.FINISHED, ProcessState.ABORTED, ProcessState.ERROR])('stops polling for terminal state %s', async (aTerminalState: ProcessState): Promise<void> => {
-    mockedProductionRepository.getBrewingStatus.mockResolvedValue(createStatusResponse(aTerminalState));
-
+  it('omits the socket id and does not poll when StartBrewing fails', async (): Promise<void> => {
+    mockedProductionRepository.startBrewing.mockResolvedValue(false);
     const action$ = new Subject<ProductionActions.SendBrewingData>();
-    const emittedActions: ProductionActions.AllProductionActions[] = [];
-    const subscription = sendBrewingDataEpic$(action$).subscribe((aAction: ProductionActions.AllProductionActions): void => {
-      emittedActions.push(aAction);
-    });
-
-    action$.next(ProductionActions.sendBrewingData(createBrewingData()));
-    await flushPromises();
-    jest.advanceTimersByTime(5000);
-    await flushPromises();
-
-    expect(mockedProductionRepository.getBrewingStatus).toHaveBeenCalledTimes(1);
-    expect(emittedActions).toEqual([ProductionActions.setBrewingStatus(createBrewingStatus(aTerminalState))]);
-    subscription.unsubscribe();
-  });
-
-  it('continues at the configured interval after a failed status request without increasing frequency', async (): Promise<void> => {
-    mockedProductionRepository.getBrewingStatus
-      .mockRejectedValueOnce(new Error('timeout'))
-      .mockResolvedValueOnce(createStatusResponse(ProcessState.ACTIVE));
-
-    const action$ = new Subject<ProductionActions.SendBrewingData>();
-    const emittedActions: ProductionActions.AllProductionActions[] = [];
-    const subscription = sendBrewingDataEpic$(action$).subscribe((aAction: ProductionActions.AllProductionActions): void => {
-      emittedActions.push(aAction);
-    });
+    const state$ = new BehaviorSubject(stateWithSocket(false));
+    const emitted: ProductionActions.AllProductionActions[] = [];
+    const subscription = sendBrewingDataEpic$(action$, state$).subscribe((action) => emitted.push(action));
 
     action$.next(ProductionActions.sendBrewingData(createBrewingData()));
     await flushPromises();
 
-    expect(mockedProductionRepository.getBrewingStatus).toHaveBeenCalledTimes(1);
-
-    jest.advanceTimersByTime(1000);
-    await flushPromises();
-
-    expect(mockedProductionRepository.getBrewingStatus).toHaveBeenCalledTimes(2);
-    expect(emittedActions).toEqual([ProductionActions.setBrewingStatus(createBrewingStatus(ProcessState.ACTIVE))]);
+    expect(mockedProductionRepository.startBrewing).toHaveBeenCalledWith(undefined);
+    expect(emitted).toEqual([ProductionActions.brewingStartFailure('Der Controller konnte den Brauvorgang nicht starten.')]);
+    expect(mockedProductionRepository.getBrewingStatus).not.toHaveBeenCalled();
     subscription.unsubscribe();
   });
 });

--- a/src/epics/productionEpics.ts
+++ b/src/epics/productionEpics.ts
@@ -144,7 +144,9 @@ const createBrewingStatusPolling$ = (action$: any) =>
 export const startPollingEpic$ = (action$: any) =>
   action$.pipe(
     ofType(ProductionActions.ActionTypes.START_POLLING),
-    switchMap(() => createBrewingStatusPolling$(action$))
+    // START_POLLING is a process lifecycle signal. Ignore repeats while the
+    // current process poll is active instead of restarting or duplicating it.
+    exhaustMap(() => createBrewingStatusPolling$(action$))
   );
 
 const isValidBrewSession = (session: BrewSession): boolean =>
@@ -194,7 +196,7 @@ export const restoreBrewSessionEpic$ = (action$: any, state$: {value: RootState}
     ))
   );
 
-export const sendBrewingDataEpic$ = (action$: any) =>
+export const sendBrewingDataEpic$ = (action$: any, state$: {value: RootState}) =>
   action$.pipe(
     ofType(ProductionActions.ActionTypes.SEND_BREWING_DATA),
     switchMap((action: any) =>
@@ -202,8 +204,13 @@ export const sendBrewingDataEpic$ = (action$: any) =>
         switchMap((sendResult) => {
           if (sendResult) {
             // Start the brewing process
-            return from(ProductionRepository.startBrewing()).pipe(
-              switchMap((startResult) => startResult ? createBrewingStatusPolling$(action$) : of(ProductionActions.brewingStartFailure('Der Controller konnte den Brauvorgang nicht starten.')))
+            const socketId = state$.value.productionReducer.socketConnection.connected
+              ? state$.value.productionReducer.socketConnection.socketId
+              : undefined;
+            return from(ProductionRepository.startBrewing(socketId)).pipe(
+              map((startResult) => startResult
+                ? ProductionActions.startPolling()
+                : ProductionActions.brewingStartFailure('Der Controller konnte den Brauvorgang nicht starten.'))
             );
           } else {
             return of(ProductionActions.brewingStartFailure('Das Rezept konnte nicht an den Controller übertragen werden.'));

--- a/src/reducers/productionReducer.test.ts
+++ b/src/reducers/productionReducer.test.ts
@@ -142,6 +142,7 @@ describe('productionReducer stale status', () => {
 
 it('makes a brewing start failure visible and releases polling pending state', () => {
     const pending = productionReducer(initialProductionState, ProductionActions.sendBrewingData({} as any));
+    expect(pending.isPollingRunning).toBe(false);
     const failed = productionReducer(pending, ProductionActions.brewingStartFailure('HTTP 500'));
     expect(failed.isPollingRunning).toBe(false);
     expect(failed.brewingStartError).toBe('HTTP 500');

--- a/src/reducers/productionReducer.ts
+++ b/src/reducers/productionReducer.ts
@@ -96,7 +96,7 @@ const productionReducer = (
         }
 
         case ProductionActions.ActionTypes.SEND_BREWING_DATA: {
-            return { ...aState, isPollingRunning: true, brewingStartError: undefined };
+            return { ...aState, brewingStartError: undefined };
         }
         case ProductionActions.ActionTypes.BREWING_START_FAILURE: {
             return {...aState, isPollingRunning: false, brewingStartError: aAction.payload.error};

--- a/src/repositorys/ProductionRepository.test.ts
+++ b/src/repositorys/ProductionRepository.test.ts
@@ -65,6 +65,16 @@ describe('ProductionRepository API method/path usage', () => {
     expect(mockedAxios.post).toHaveBeenCalledWith(expect.stringContaining('/Command/Speed:22'));
   });
 
+  it('sends the namespace socket id only when starting a brew with a connected socket', async () => {
+    await ProductionRepository.startBrewing('socket-123');
+
+    expect(mockedAxios.post).toHaveBeenCalledWith(
+      expect.stringContaining('/Command/StartBrewing:""'),
+      undefined,
+      {headers: {'X-Socket-ID': 'socket-123'}}
+    );
+  });
+
   it('keeps heater commands as no-value aliases', async () => {
     await ProductionRepository.toggleHeater(ToggleState.ON);
     await ProductionRepository.toggleHeater(ToggleState.OFF);

--- a/src/repositorys/ProductionRepository.ts
+++ b/src/repositorys/ProductionRepository.ts
@@ -125,8 +125,8 @@ export class ProductionRepository {
         return await ProductionRepository._doToggleHeater(aIsTurnOn);
     }
 
-    static async startBrewing() {
-        return await ProductionRepository._doStartBrewing();
+    static async startBrewing(aSocketId?: string) {
+        return await ProductionRepository._doStartBrewing(aSocketId);
     }
 
     static async nextProcedureStep() {
@@ -174,9 +174,12 @@ export class ProductionRepository {
         }
     }
 
-    private static async _doStartBrewing() {
+    private static async _doStartBrewing(aSocketId?: string) {
         try {
-            const response = await axios.post(CommandsURL + `StartBrewing:""`);
+            const config = aSocketId ? {headers: {'X-Socket-ID': aSocketId}} : undefined;
+            const response = config
+                ? await axios.post(CommandsURL + `StartBrewing:""`, undefined, config)
+                : await axios.post(CommandsURL + `StartBrewing:""`);
             return response.status === 200;
         } catch (error) {
             console.error('Fehler beim API-Aufruf', error);


### PR DESCRIPTION
### Motivation
- Decouple hardware/sensor realtime state from the high-frequency `/Status/` brewing poll so sensor data is available even when no brew is running. 
- Prevent Production view mount/unmount from starting or stopping the global process polling lifecycle. 
- Ensure a single, well-defined path starts `/Status/` polling: either a successful local brew start or receiving `brew-session-running` for an already-running session.

### Description
- Removed automatic calls to `startPolling()`/`stopPolling()` from `Production.componentDidMount()` / `MobileProductionView.componentDidMount()` / `componentWillUnmount()` so mounting Production no longer triggers process polling. 
- Stopped Production view from issuing the legacy one-shot temperature read on mount; Production now reads temperature, `sensorHealth`, `sensorId`, heater and agitator states from the global Socket.IO realtime snapshot (`temperature-sensor-state-changed`, `heating-running-changed`, `agitator-state-changed`, `alarm-state-changed`). 
- Made brew start path consistent: `SEND_BREWING_DATA` → `startBrewing()` (now accepts optional namespace `socketId`) → on success emit `START_POLLING`; the request includes `X-Socket-ID` header when a socket is connected. 
- Prevented duplicate polling loops by changing `startPollingEpic$` to use `exhaustMap()` instead of `switchMap()`, so repeated `START_POLLING` signals are ignored while a poll is active; terminal states still stop the loop. 
- Adjusted reducer/epics/tests to remove the assumption that a Production view mount starts polling: `SEND_BREWING_DATA` no longer sets `isPollingRunning` in the reducer and `sendBrewingDataEpic$` returns a `START_POLLING` action after successful `startBrewing`. 
- Updated unit tests and test expectations to reflect the new lifecycle and the optional `X-Socket-ID` header, and updated Codex docs to document the revised lifecycle and namespace behavior. Files changed include Production components/connectors, `productionEpics.ts`, `productionReducer.ts`, `ProductionRepository.ts`, tests and docs under `docs/codex/`.

### Testing
- Updated unit tests: `src/epics/productionEpics.test.ts`, `src/containers/Mobile/MobileStatusView/MobileProductionView.test.tsx`, `src/containers/Production/Production.test.tsx`, `src/reducers/productionReducer.test.ts`, and `src/repositorys/ProductionRepository.test.ts` to assert the new lifecycle, prevent duplicate pollers, and verify `X-Socket-ID` header behavior; these test files were modified to align with the new design. 
- Ran repository checks: `git diff --check` and other local static verifications passed. 
- Attempted to run the Jest/CRA test suite, but full test execution failed in this environment because installing dependencies / running `react-scripts` was blocked (npm registry access returned HTTP 403 / dependency resolution warnings), so the updated tests could not be executed here; the test code was adjusted and is ready to run in an environment with working npm access. 
- Notes: integration with the controller (fresh sensor snapshot on connect/reconnect and the controller behavior regarding `brew-session-running` suppression for the initiating client) still needs end-to-end verification with the Braumeister backend and real hardware.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a951fa33ff8832f8303702158ab9f0e)