### PR TITLE
Do not treat PUT /Agitator/Config as confirmed state; keep local agitator drafts and reconcile with socket

### DIFF
--- a/docs/codex/data-flow.md
+++ b/docs/codex/data-flow.md
@@ -46,6 +46,12 @@ Needs verification: backend ordering of `GET beers`, because the UI treats the l
 - Normalized status is stored in `productionReducer.brewingStatus` and in `dataCollector`.
 - Polling stops when normalized process state is `FINISHED`, `ABORTED`, or `ERROR`.
 
+## Production agitator configuration flow
+
+- Production applies speed, interval, and mode edits as local drafts immediately. `PUT /Agitator/Config` is command-only; HTTP success does not confirm or replace controller state.
+- The complete `agitator-state-changed` Socket.IO snapshot remains authoritative and is received by every client, including the client that sent the command. A local field draft is removed only when the snapshot contains the requested value; unrelated or older snapshots update confirmed state without making the edited value jump backwards.
+- Normal configuration requests do not globally disable the agitator controls. The existing 300 ms speed debounce still coalesces slider movement before sending the complete desired configuration.
+
 ## Availability polling
 
 - `CHECK_IS_BACKEND_AVAILABLE` starts a 20000 ms interval with an immediate first check.

--- a/docs/codex/exports/ui-context-for-control.md
+++ b/docs/codex/exports/ui-context-for-control.md
@@ -11,6 +11,7 @@
 - Water status via `GET /WaterStatus` returning `{ filledLiters, targetLiters, openClose }`; control also supports `GET /WaterStatus/`.
 - Hardware commands for water, heater, agitator speed, and agitator interval.
 - Confirm endpoints only for concrete waiting states: `Iodine`, `Mashup`, `Cooking`, `Boiling`, and `Decoction`. `Wait` may be displayed as a status but must not be sent as `/Confirm/Wait`.
+- `PUT /Agitator/Config` acknowledges a command but does not return confirmed configuration. The complete `agitator-state-changed` snapshot is the authoritative runtime configuration and must continue to be broadcast to all clients, including the initiating client.
 
 ## UI-owned behavior
 

--- a/docs/codex/interfaces.md
+++ b/docs/codex/interfaces.md
@@ -45,7 +45,7 @@ Base URL: `BaseURL` (`/api/controller`), `CommandsURL` (`/api/controller/Command
 | GET | `WaterStatus` | Water fill status | `200`, `{ filledLiters, targetLiters, openClose }`; PI control also supports `WaterStatus/` |
 | GET | `Status/` | Runtime brewing status | `200`, structured or legacy status |
 | GET | `Agitator/Status` | Load current production agitator state; active modes take priority over defaults | `200`, full `{ config, inputs, runtime }` detail status |
-| PUT | `Agitator/Config` | Replace agitator configuration | Full `{ mode, speedPercent, runningMinutes, breakMinutes }` payload |
+| PUT | `Agitator/Config` | Replace agitator configuration | Full `{ mode, speedPercent, runningMinutes, breakMinutes }` payload; success acknowledges only the command, while `agitator-state-changed` confirms controller state |
 | GET | `Agitator/Defaults` | Load persistent agitator defaults for Settings and initial Production runtime values | `{ speed, intervalOnMinutes, intervalOffMinutes }` in percent/minutes |
 | PUT | `Agitator/Defaults` | Replace persistent agitator defaults without changing runtime | Full `{ speed, intervalOnMinutes, intervalOffMinutes }`; response contains the confirmed configuration |
 | POST | `Agitator/Pause` | Pause the selected active mode | `200` success |

--- a/src/containers/Production/Production.test.tsx
+++ b/src/containers/Production/Production.test.tsx
@@ -96,7 +96,7 @@ describe('Production agitator controller integration', () => {
         jest.spyOn(AgitatorSettingsRepository, 'get').mockResolvedValue({speed: 26, intervalOnMinutes: 2, intervalOffMinutes: 2});
         jest.spyOn(AgitatorSettingsRepository, 'update').mockResolvedValue({speed: 26, intervalOnMinutes: 2, intervalOffMinutes: 2});
         jest.spyOn(ProductionRepository, 'getAgitatorStatus').mockResolvedValue(detail);
-        jest.spyOn(ProductionRepository, 'setAgitatorConfig').mockImplementation(async config => config);
+        jest.spyOn(ProductionRepository, 'setAgitatorConfig').mockResolvedValue();
         jest.spyOn(ProductionRepository, 'pauseAgitator').mockResolvedValue();
         jest.spyOn(ProductionRepository, 'resumeAgitator').mockResolvedValue();
     });
@@ -187,15 +187,15 @@ describe('Production agitator controller integration', () => {
         await waitFor(() => expect(ProductionRepository.setAgitatorConfig).toHaveBeenCalledWith({mode: 'OFF', speedPercent: 36, runningMinutes: 2, breakMinutes: 7}));
     });
 
-    it('keeps both mode switches disabled while a config request is pending', async () => {
-        let resolveConfig!: (config: any) => void;
-        jest.spyOn(ProductionRepository, 'setAgitatorConfig').mockImplementation(config => new Promise(resolve => { resolveConfig = resolve; }));
+    it('keeps agitator controls enabled and the optimistic mode visible while a config request is pending', async () => {
+        let resolveConfig!: () => void;
+        jest.spyOn(ProductionRepository, 'setAgitatorConfig').mockImplementation(() => new Promise<void>(resolve => { resolveConfig = resolve; }));
         renderProduction();
         fireEvent.click(await screen.findByRole('switch', {name: 'Durchgehend rühren'}));
-        expect(screen.getByRole('switch', {name: 'Durchgehend rühren'})).toBeDisabled();
-        expect(screen.getByRole('switch', {name: 'Intervallbetrieb'})).toBeDisabled();
-        resolveConfig({...detail.config, mode: 'CONTINUOUS'});
-        await waitFor(() => expect(screen.getByRole('switch', {name: 'Durchgehend rühren'})).toBeEnabled());
+        expect(screen.getByRole('switch', {name: 'Durchgehend rühren'})).toBeEnabled();
+        expect(screen.getByRole('switch', {name: 'Durchgehend rühren'})).toBeChecked();
+        expect(screen.getByRole('switch', {name: 'Intervallbetrieb'})).toBeEnabled();
+        resolveConfig();
     });
 
     it('debounces speed drafts and sends only the latest complete config', async () => {
@@ -243,6 +243,41 @@ describe('Production agitator controller integration', () => {
         expect(await screen.findByText('42 %')).toBeInTheDocument();
         expect(within(screen.getByTestId('running-minutes-stepper')).getByText('4')).toBeInTheDocument();
         expect(within(screen.getByTestId('break-minutes-stepper')).getByText('10')).toBeInTheDocument();
+    });
+
+    it('keeps a speed draft through HTTP success and reconciles it only with the matching socket state', async () => {
+        jest.useFakeTimers();
+        const {props, rerender} = renderProduction();
+        await act(async () => { await Promise.resolve(); });
+        fireEvent.change(screen.getByRole('slider'), {target: {value: '42'}});
+        expect(screen.getByText('42 %')).toBeInTheDocument();
+        act(() => jest.advanceTimersByTime(AGITATOR_SPEED_DEBOUNCE_MS));
+        await act(async () => { await Promise.resolve(); });
+        expect(screen.getByText('42 %')).toBeInTheDocument();
+
+        rerender(<Production {...props} realtimeState={{...props.realtimeState, agitator: {...detail.config, paused: false, operation: 'INTERVAL', actualOutputOn: true, speedPercent: 36}}} />);
+        expect(await screen.findByText('42 %')).toBeInTheDocument();
+        rerender(<Production {...props} realtimeState={{...props.realtimeState, agitator: {...detail.config, paused: false, operation: 'INTERVAL', actualOutputOn: true, speedPercent: 42}}} />);
+        expect(await screen.findByText('42 %')).toBeInTheDocument();
+        jest.useRealTimers();
+    });
+
+    it.each([
+        ['runningMinutes', 'Laufzeit', 'Laufzeit erhöhen', 3, 7],
+        ['breakMinutes', 'Pausenzeit', 'Pausenzeit verringern', 2, 6],
+    ] as const)('keeps the %s draft stable until an identical socket snapshot confirms it', async (_field, label, buttonName, runningMinutes, breakMinutes) => {
+        const {props, rerender} = renderProduction();
+        await screen.findByLabelText(label);
+        const button = screen.getByRole('button', {name: buttonName});
+        fireEvent.mouseDown(button);
+        fireEvent.mouseUp(button);
+        expect(screen.getByLabelText(label)).toHaveTextContent(String(label === 'Laufzeit' ? runningMinutes : breakMinutes));
+        expect(button).toBeEnabled();
+
+        rerender(<Production {...props} realtimeState={{...props.realtimeState, agitator: {...detail.config, paused: false, operation: 'INTERVAL', actualOutputOn: true}}} />);
+        expect(await screen.findByLabelText(label)).toHaveTextContent(String(label === 'Laufzeit' ? runningMinutes : breakMinutes));
+        rerender(<Production {...props} realtimeState={{...props.realtimeState, agitator: {...detail.config, paused: false, operation: 'INTERVAL', actualOutputOn: true, runningMinutes, breakMinutes}}} />);
+        expect(await screen.findByLabelText(label)).toHaveTextContent(String(label === 'Laufzeit' ? runningMinutes : breakMinutes));
     });
 
     it('keeps interval settings visible but only editable in AUTOMATIC mode and places speed afterwards', async () => {

--- a/src/containers/Production/Production.tsx
+++ b/src/containers/Production/Production.tsx
@@ -83,6 +83,7 @@ interface ProductionState {
     agitatorRuntime?: AgitatorRuntimeStatus;
     agitatorSpeedDraft?: number;
     agitatorIntervalDraft?: Pick<AgitatorConfig, 'runningMinutes' | 'breakMinutes'>;
+    agitatorModeDraft?: AgitatorMode;
     agitatorRequestPending: boolean;
     agitatorStatusLoadFailed: boolean;
     waterSwitchState: boolean
@@ -120,6 +121,7 @@ export class Production extends React.Component<ProductionProps, ProductionState
             agitatorRuntime: undefined,
             agitatorSpeedDraft: undefined,
             agitatorIntervalDraft: undefined,
+            agitatorModeDraft: undefined,
             agitatorRequestPending: false,
             agitatorStatusLoadFailed: false,
             waterSwitchState: false,
@@ -318,35 +320,63 @@ export class Production extends React.Component<ProductionProps, ProductionState
                 ...(typeof poll.runningMinutes === 'number' ? {runningMinutes: poll.runningMinutes} : {}),
                 ...(typeof poll.breakMinutes === 'number' ? {breakMinutes: poll.breakMinutes} : {}),
             } : previous.agitatorConfig,
-            agitatorIntervalDraft: typeof poll.runningMinutes === 'number' || typeof poll.breakMinutes === 'number'
+            agitatorSpeedDraft: previous.agitatorSpeedDraft !== undefined && poll.speedPercent === previous.agitatorSpeedDraft
+                ? undefined
+                : previous.agitatorSpeedDraft,
+            agitatorIntervalDraft: previous.agitatorIntervalDraft
+                && poll.runningMinutes === previous.agitatorIntervalDraft.runningMinutes
+                && poll.breakMinutes === previous.agitatorIntervalDraft.breakMinutes
                 ? undefined
                 : previous.agitatorIntervalDraft,
+            agitatorModeDraft: previous.agitatorModeDraft !== undefined && poll.mode === previous.agitatorModeDraft
+                ? undefined
+                : previous.agitatorModeDraft,
         }));
     }
 
+    getDesiredAgitatorConfig = (): AgitatorConfig | undefined => {
+        const {agitatorConfig, agitatorSpeedDraft, agitatorIntervalDraft, agitatorModeDraft} = this.state;
+        if (!agitatorConfig) return undefined;
+        return {
+            ...agitatorConfig,
+            ...(agitatorModeDraft !== undefined ? {mode: agitatorModeDraft} : {}),
+            ...(agitatorSpeedDraft !== undefined ? {speedPercent: agitatorSpeedDraft} : {}),
+            ...agitatorIntervalDraft,
+        };
+    }
+
     submitAgitatorConfig = async (config: AgitatorConfig): Promise<boolean> => {
-        this.setState({agitatorRequestPending: true, mainAgitatorError: false});
+        this.setState({mainAgitatorError: false});
         try {
-            const confirmed = await ProductionRepository.setAgitatorConfig(config);
-            if (this.isMountedComponent) this.setState((previous) => ({
-                agitatorConfig: confirmed,
-                agitatorRuntime: previous.agitatorRuntime ? {...previous.agitatorRuntime, mode: confirmed.mode} : previous.agitatorRuntime,
-                agitatorSpeedDraft: undefined,
-                agitatorIntervalDraft: undefined,
-                agitatorRequestPending: false,
-            }));
+            await ProductionRepository.setAgitatorConfig(config);
             return true;
         } catch (error) {
-            if (this.isMountedComponent) this.setState({agitatorSpeedDraft: undefined, agitatorIntervalDraft: undefined, agitatorRequestPending: false, mainAgitatorError: true});
+            if (this.isMountedComponent) this.setState((previous) => {
+                const desired = this.getDesiredAgitatorConfig();
+                const requestIsStillCurrent = desired !== undefined
+                    && desired.mode === config.mode
+                    && desired.speedPercent === config.speedPercent
+                    && desired.runningMinutes === config.runningMinutes
+                    && desired.breakMinutes === config.breakMinutes;
+                return {
+                    agitatorSpeedDraft: requestIsStillCurrent ? undefined : previous.agitatorSpeedDraft,
+                    agitatorIntervalDraft: requestIsStillCurrent ? undefined : previous.agitatorIntervalDraft,
+                    agitatorModeDraft: requestIsStillCurrent ? undefined : previous.agitatorModeDraft,
+                    mainAgitatorError: true,
+                };
+            });
             return false;
         }
     }
 
     toggleAgitatorMode = (mode: Exclude<AgitatorMode, 'OFF'>, checked: boolean): void => {
-        const {agitatorConfig, agitatorRequestPending} = this.state;
-        if (!this.isControllerAvailable() || !agitatorConfig || agitatorRequestPending) return;
-        const nextMode: AgitatorMode = checked ? mode : (agitatorConfig.mode === mode ? 'OFF' : agitatorConfig.mode);
-        if (nextMode !== agitatorConfig.mode) void this.submitAgitatorConfig({...agitatorConfig, mode: nextMode});
+        const config = this.getDesiredAgitatorConfig();
+        if (!this.isControllerAvailable() || !config) return;
+        const nextMode: AgitatorMode = checked ? mode : (config.mode === mode ? 'OFF' : config.mode);
+        if (nextMode !== config.mode) this.setState({agitatorModeDraft: nextMode}, () => {
+            const desired = this.getDesiredAgitatorConfig();
+            if (desired) void this.submitAgitatorConfig(desired);
+        });
     }
 
     toggleAgitatorPause = async (): Promise<void> => {
@@ -420,7 +450,7 @@ export class Production extends React.Component<ProductionProps, ProductionState
         this.agitatorSpeedDebounceTimeout = setTimeout(() => {
             this.agitatorSpeedDebounceTimeout = null;
             if (this.isControllerAvailable()) {
-                const config = this.state.agitatorConfig;
+                const config = this.getDesiredAgitatorConfig();
                 if (config) void this.submitAgitatorConfig({...config, speedPercent: value});
             }
         }, AGITATOR_SPEED_DEBOUNCE_MS);
@@ -434,18 +464,20 @@ export class Production extends React.Component<ProductionProps, ProductionState
     }
 
     onIntervalChangeBreakTime = (value: number) => {
-        const config = this.state.agitatorConfig;
-        if (!this.isControllerAvailable() || !config || this.state.agitatorRequestPending) return;
+        const config = this.getDesiredAgitatorConfig();
+        if (!this.isControllerAvailable() || !config) return;
         this.setState({agitatorIntervalDraft: {runningMinutes: config.runningMinutes, breakMinutes: value}}, () => {
-            void this.submitAgitatorConfig({...config, breakMinutes: value});
+            const desired = this.getDesiredAgitatorConfig();
+            if (desired) void this.submitAgitatorConfig(desired);
         });
     }
 
     onIntervalChangeRunningTime = (value: number) => {
-        const config = this.state.agitatorConfig;
-        if (!this.isControllerAvailable() || !config || this.state.agitatorRequestPending) return;
+        const config = this.getDesiredAgitatorConfig();
+        if (!this.isControllerAvailable() || !config) return;
         this.setState({agitatorIntervalDraft: {runningMinutes: value, breakMinutes: config.breakMinutes}}, () => {
-            void this.submitAgitatorConfig({...config, runningMinutes: value});
+            const desired = this.getDesiredAgitatorConfig();
+            if (desired) void this.submitAgitatorConfig(desired);
         });
     }
 
@@ -657,7 +689,8 @@ export class Production extends React.Component<ProductionProps, ProductionState
     }
 
     renderSettings() {
-        const {waterSwitchState, agitatorConfig, agitatorRuntime, agitatorSpeedDraft, agitatorIntervalDraft, agitatorRequestPending, agitatorStatusLoadFailed} = this.state;
+        const {waterSwitchState, agitatorConfig, agitatorRuntime, agitatorSpeedDraft, agitatorIntervalDraft, agitatorModeDraft, agitatorRequestPending, agitatorStatusLoadFailed} = this.state;
+        const displayedAgitatorMode = agitatorModeDraft ?? agitatorConfig?.mode;
         const settingsDisabled = !this.isControllerAvailable();
         const mashWaterDisabled = settingsDisabled || this.isRecipeWaterButtonDisabled('mash');
         const spargeWaterDisabled = settingsDisabled || this.isRecipeWaterButtonDisabled('sparge');
@@ -690,31 +723,31 @@ export class Production extends React.Component<ProductionProps, ProductionState
                         {agitatorStatusLoadFailed || settingsDisabled ? 'Rührwerk-Konfiguration nicht verfügbar' : 'Rührwerk-Konfiguration wird geladen'}
                     </p>}
                     <div className="agitatorPrimaryMode">
-                        {renderSwitch('Durchgehend rühren', agitatorConfig?.mode === 'CONTINUOUS',
-                            (checked) => this.toggleAgitatorMode('CONTINUOUS', checked), settingsDisabled || !agitatorConfig || agitatorRequestPending)}
+                        {renderSwitch('Durchgehend rühren', displayedAgitatorMode === 'CONTINUOUS',
+                            (checked) => this.toggleAgitatorMode('CONTINUOUS', checked), settingsDisabled || !agitatorConfig)}
                     </div>
-                    <div className={`intervalSettings agitatorAutomaticSettings ${agitatorConfig?.mode === 'AUTOMATIC' ? 'is-active' : ''}`} aria-labelledby="interval-settings-title">
+                    <div className={`intervalSettings agitatorAutomaticSettings ${displayedAgitatorMode === 'AUTOMATIC' ? 'is-active' : ''}`} aria-labelledby="interval-settings-title">
                         <div className="agitatorAutomaticHeader">
                             <div>
                                 <h5 id="interval-settings-title">Intervallbetrieb</h5>
                                 <p>Beim Heizen durchgehend, sonst im Intervall</p>
                             </div>
                             <Switch className="productionSwitch" onChange={(checked) => this.toggleAgitatorMode('AUTOMATIC', checked)}
-                                checked={agitatorConfig?.mode === 'AUTOMATIC'} height={24} width={44} handleDiameter={18}
-                                checkedIcon={false} uncheckedIcon={false} disabled={settingsDisabled || !agitatorConfig || agitatorRequestPending}
+                                checked={displayedAgitatorMode === 'AUTOMATIC'} height={24} width={44} handleDiameter={18}
+                                checkedIcon={false} uncheckedIcon={false} disabled={settingsDisabled || !agitatorConfig}
                                 aria-label="Intervallbetrieb" />
                         </div>
                         <div className="intervalTimeControls">
                             <div className="intervalTimeControl" data-testid="running-minutes-stepper">
                                 <QuantityPicker initialValue={agitatorIntervalDraft?.runningMinutes ?? agitatorConfig?.runningMinutes}
                                     min={0} max={Number.MAX_SAFE_INTEGER} onChange={this.onIntervalChangeRunningTime}
-                                    isDisabled={settingsDisabled || !agitatorConfig || agitatorRequestPending || agitatorConfig.mode !== 'AUTOMATIC'} label="Laufzeit" labelPosition="above"/>
+                                    isDisabled={settingsDisabled || !agitatorConfig || displayedAgitatorMode !== 'AUTOMATIC'} label="Laufzeit" labelPosition="above"/>
                                 <span className="intervalTimeUnit">min</span>
                             </div>
                             <div className="intervalTimeControl" data-testid="break-minutes-stepper">
                                 <QuantityPicker initialValue={agitatorIntervalDraft?.breakMinutes ?? agitatorConfig?.breakMinutes}
                                     min={0} max={Number.MAX_SAFE_INTEGER} onChange={this.onIntervalChangeBreakTime}
-                                    isDisabled={settingsDisabled || !agitatorConfig || agitatorRequestPending || agitatorConfig.mode !== 'AUTOMATIC'} label="Pausenzeit" labelPosition="above"/>
+                                    isDisabled={settingsDisabled || !agitatorConfig || displayedAgitatorMode !== 'AUTOMATIC'} label="Pausenzeit" labelPosition="above"/>
                                 <span className="intervalTimeUnit">min</span>
                             </div>
                         </div>

--- a/src/repositorys/ProductionRepository.test.ts
+++ b/src/repositorys/ProductionRepository.test.ts
@@ -20,7 +20,7 @@ describe('ProductionRepository API method/path usage', () => {
     const detail = {config: {mode: 'AUTOMATIC', speedPercent: 36, runningMinutes: 2, breakMinutes: 7}, inputs: {heatingActive: false}, runtime: {paused: false, desiredOperation: 'INTERVAL', actualOutputOn: false}};
     mockedAxios.get.mockResolvedValueOnce({status: 200, data: detail} as any);
     await expect(ProductionRepository.getAgitatorStatus()).resolves.toEqual(detail);
-    await ProductionRepository.setAgitatorConfig(detail.config as any);
+    await expect(ProductionRepository.setAgitatorConfig(detail.config as any)).resolves.toBeUndefined();
     await ProductionRepository.pauseAgitator();
     await ProductionRepository.resumeAgitator();
 

--- a/src/repositorys/ProductionRepository.ts
+++ b/src/repositorys/ProductionRepository.ts
@@ -72,9 +72,8 @@ export class ProductionRepository {
         return response.data;
     }
 
-    static async setAgitatorConfig(config: AgitatorConfig): Promise<AgitatorConfig> {
+    static async setAgitatorConfig(config: AgitatorConfig): Promise<void> {
         await axios.put(`${BaseURL}/Agitator/Config`, config);
-        return config;
     }
 
     static async pauseAgitator(): Promise<void> {


### PR DESCRIPTION
### Motivation

- Fix sichtbares Blinken der Rührwerk-UI durch Vermischung von lokalem Draft, HTTP-Erfolg und autoritativem Socket-State.\
- `PUT /Agitator/Config` ist nur ein Command; die autoritative Bestätigung kommt per `agitator-state-changed` Socket.IO-Event.\
- Ziel ist, lokale Benutzereingaben sofort sichtbar zu lassen, HTTP nur als Command-Ack zu behandeln und Drafts nur zu entfernen, wenn der Socket exakt bestätigt.

### Description

- `ProductionRepository.setAgitatorConfig()` changed to return `Promise<void>` and no longer returns the request payload as a confirmed controller state. (src/repositorys/ProductionRepository.ts)\
- Production component keeps explicit local drafts: `agitatorSpeedDraft`, `agitatorIntervalDraft`, plus a new `agitatorModeDraft`, and introduced `getDesiredAgitatorConfig()` to build the full desired config from drafts. (src/containers/Production/Production.tsx)\
- `mergeAgitatorPoll()` now reconciles incoming socket snapshots with local drafts conservatively and only clears a draft when the snapshot matches the requested value; speed/interval/mode drafts are handled separately to avoid blind overwrites. (src/containers/Production/Production.tsx)\
- `submitAgitatorConfig()` no longer writes the HTTP-request body into `agitatorConfig` after success; it treats PUT success as command completion only and leaves reconciliation to socket events; on error it only clears drafts if the failed request still matches the current desired draft. (src/containers/Production/Production.tsx)\
- Removed the visible global “disable everything while agitatorRequestPending” UX; controls remain interactable except for functionally required disables (controller offline, mode mismatch, pause/resume action). Debounce for speed (`AGITATOR_SPEED_DEBOUNCE_MS = 300`) is preserved. (src/containers/Production/Production.tsx)\
- Tests and documentation updated to reflect the new semantics: adjusted assertions and added scenarios for draft persistence, socket confirmation and optimistic mode visibility. (src/containers/Production/Production.test.tsx, src/repositorys/ProductionRepository.test.ts, docs/codex/data-flow.md, docs/codex/interfaces.md, docs/codex/exports/ui-context-for-control.md)

### Testing

- Ran repository checks (`git diff --check`) and updated unit tests to match the new semantics; the repository diffs show the targeted changes. (passed)\
- Updated/extended targeted Jest tests in `src/containers/Production/Production.test.tsx` and `src/repositorys/ProductionRepository.test.ts` to cover: immediate local draft visibility, debounce behavior, HTTP success not overwriting controller state, socket confirmation removing drafts, and no global disabled flash. (tests modified)\
- Attempted to run the local Jest command for the modified tests, but the local test runner failed to start `react-scripts` due to environment/registry access issues (npm registry returned HTTP 403 in this environment); the updated tests are expected to run in CI or a network-enabled dev environment. (test run blocked by environment)\

Files with notable changes

- src/repositorys/ProductionRepository.ts (change `setAgitatorConfig` return type/semantics)\
- src/containers/Production/Production.tsx (draft-state management, reconciliation logic, remove global visual pending)\
- src/containers/Production/Production.test.tsx (adjusted/added tests for drafts and socket reconciliation)\
- src/repositorys/ProductionRepository.test.ts (expect `setAgitatorConfig` to resolve to void)\
- docs/codex/data-flow.md, docs/codex/interfaces.md, docs/codex/exports/ui-context-for-control.md (documented that PUT is command-only and socket is authoritative)

Short summary of what fixed the blinking

- Ursache: PUT behandelte die gesendete Request-Payload als bestätigten Controller-State und setzte lokale state/Drafts unmittelbar zurück; gleichzeitig kam der echte Controller-State per Socket, was zu conflicting updates und einem Disabled-Flash führte.\
- Änderung der Verantwortlichkeiten: HTTP = Command ack only; Socket.IO = authoritative state; UI = show local drafts immediately and remove them only after exact socket confirmation.\
- Reconciliation: local drafts are kept and compared to incoming `agitator-state-changed` snapshots; a draft is cleared only when the snapshot matches the desired value, otherwise snapshot updates update only confirmed fields and do not cause UI jumpbacks.

If you want, I can run the full test-suite in CI or re-run the local Jest tests once the environment has network access to install dependencies.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a9551ac8c98832f89b1174beb8e76ed)