### PR TITLE
Fix realtime state typing in Production tests

### DIFF
--- a/src/containers/Production/Production.test.tsx
+++ b/src/containers/Production/Production.test.tsx
@@ -255,9 +255,9 @@ describe('Production agitator controller integration', () => {
         await act(async () => { await Promise.resolve(); });
         expect(screen.getByText('42 %')).toBeInTheDocument();
 
-        rerender(<Production {...props} realtimeState={{...props.realtimeState, agitator: {...detail.config, paused: false, operation: 'INTERVAL', actualOutputOn: true, speedPercent: 36}}} />);
+        rerender(<Production {...props} realtimeState={{...props.realtimeState!, agitator: {...detail.config, paused: false, operation: 'INTERVAL', actualOutputOn: true, speedPercent: 36}}} />);
         expect(await screen.findByText('42 %')).toBeInTheDocument();
-        rerender(<Production {...props} realtimeState={{...props.realtimeState, agitator: {...detail.config, paused: false, operation: 'INTERVAL', actualOutputOn: true, speedPercent: 42}}} />);
+        rerender(<Production {...props} realtimeState={{...props.realtimeState!, agitator: {...detail.config, paused: false, operation: 'INTERVAL', actualOutputOn: true, speedPercent: 42}}} />);
         expect(await screen.findByText('42 %')).toBeInTheDocument();
         jest.useRealTimers();
     });
@@ -274,9 +274,9 @@ describe('Production agitator controller integration', () => {
         expect(screen.getByLabelText(label)).toHaveTextContent(String(label === 'Laufzeit' ? runningMinutes : breakMinutes));
         expect(button).toBeEnabled();
 
-        rerender(<Production {...props} realtimeState={{...props.realtimeState, agitator: {...detail.config, paused: false, operation: 'INTERVAL', actualOutputOn: true}}} />);
+        rerender(<Production {...props} realtimeState={{...props.realtimeState!, agitator: {...detail.config, paused: false, operation: 'INTERVAL', actualOutputOn: true}}} />);
         expect(await screen.findByLabelText(label)).toHaveTextContent(String(label === 'Laufzeit' ? runningMinutes : breakMinutes));
-        rerender(<Production {...props} realtimeState={{...props.realtimeState, agitator: {...detail.config, paused: false, operation: 'INTERVAL', actualOutputOn: true, runningMinutes, breakMinutes}}} />);
+        rerender(<Production {...props} realtimeState={{...props.realtimeState!, agitator: {...detail.config, paused: false, operation: 'INTERVAL', actualOutputOn: true, runningMinutes, breakMinutes}}} />);
         expect(await screen.findByLabelText(label)).toHaveTextContent(String(label === 'Laufzeit' ? runningMinutes : breakMinutes));
     });
 


### PR DESCRIPTION
### Motivation
- Resolve TypeScript errors in Production agitator tests caused by spreading a possibly-undefined `realtimeState` and producing a shape incompatible with `RealtimeControllerState` (required `alarms` array).

### Description
- Add non-null assertions when spreading `props.realtimeState` in several `rerender` calls in `src/containers/Production/Production.test.tsx` so constructed realtime snapshots satisfy the `RealtimeControllerState` type.

### Testing
- Ran repository checks including `git diff --check` which reported no issues; static verification passed locally.
- Attempted to run the test runner with `CI=true npm test -- --runInBand --watchAll=false src/containers/Production/Production.test.tsx` and `npx react-scripts test --runInBand --watchAll=false src/containers/Production/Production.test.tsx` but both test invocations could not complete due to missing local `react-scripts` / blocked npm registry access in this environment, so automated tests could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a95637413b0832faa8903b4171b0722)