### PR TITLE
Move production start action into ProcessList (show ‘Brauvorgang starten’ in Active Step card)

### DIFF
--- a/src/containers/Production/ProcessList/ProcessList.css
+++ b/src/containers/Production/ProcessList/ProcessList.css
@@ -67,6 +67,19 @@
     flex: 0 0 auto;
 }
 
+.process-start-state {
+    display: flex;
+    min-height: clamp(7rem, 12vh, 9rem);
+    flex-direction: column;
+    align-items: flex-start;
+    justify-content: center;
+    gap: 0.65rem;
+}
+
+.process-start-state .startBtn {
+    width: 100%;
+}
+
 .current-step-heading {
     display: flex;
     justify-content: space-between;

--- a/src/containers/Production/ProcessList/ProcessList.test.tsx
+++ b/src/containers/Production/ProcessList/ProcessList.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {render, screen} from '@testing-library/react';
+import {fireEvent, render, screen} from '@testing-library/react';
 import '@testing-library/jest-dom';
 import {Beer} from '../../../model/Beer';
 import {BrewingStatus, ProcessMode, ProcessPhase, ProcessState, WaitingFor} from '../../../model/brewingStatus.types';
@@ -345,11 +345,24 @@ describe('ProcessList compact production overview', () => {
     it('shows the selected beer process before an active brewing process starts', () => {
         render(<ProcessList selectedBeer={selectedBeer} currentStepIndex={0} />);
 
-        expect(screen.getByText('Noch kein Brauvorgang gestartet')).toBeInTheDocument();
-        expect(screen.getByText('Geplanter Ablauf')).toBeInTheDocument();
-        expect(screen.getByText('Bereit zum Start')).toBeInTheDocument();
+        expect(screen.getAllByText('Brauprozess')).toHaveLength(2);
+        expect(screen.getByRole('button', {name: 'Brauvorgang starten'})).toBeInTheDocument();
         expect(screen.getAllByText('Aufheizen für Einmaischen').length).toBeGreaterThan(0);
         expect(screen.queryByText(/\d+ \/ \d+/)).not.toBeInTheDocument();
+    });
+
+    it('reuses the supplied start handler and disabled state only before process start', () => {
+        const onStartBrewing = jest.fn();
+        const {rerender} = render(<ProcessList selectedBeer={selectedBeer} currentStepIndex={0} onStartBrewing={onStartBrewing} isStartBrewingDisabled />);
+        expect(screen.getByRole('button', {name: 'Brauvorgang starten'})).toBeDisabled();
+
+        rerender(<ProcessList selectedBeer={selectedBeer} currentStepIndex={0} onStartBrewing={onStartBrewing} />);
+        fireEvent.click(screen.getByRole('button', {name: 'Brauvorgang starten'}));
+        expect(onStartBrewing).toHaveBeenCalledTimes(1);
+
+        rerender(<ProcessList selectedBeer={selectedBeer} currentStepIndex={1} brewingStatus={activeStatus(1)} onStartBrewing={onStartBrewing} />);
+        expect(screen.queryByRole('button', {name: 'Brauvorgang starten'})).not.toBeInTheDocument();
+        expect(screen.getByText('Aktiver Schritt')).toBeInTheDocument();
     });
 
     it('shows a clear empty state if no recipe process is available', () => {

--- a/src/containers/Production/ProcessList/ProcessList.tsx
+++ b/src/containers/Production/ProcessList/ProcessList.tsx
@@ -61,6 +61,9 @@ export interface ProcessListProps {
     onConfirmWaiting?: () => void;
     hopReminderName?: string;
     onCompleteHopReminder?: () => void;
+    onStartBrewing?: () => void;
+    isStartBrewingDisabled?: boolean;
+    startBrewingWarning?: string;
 }
 
 interface ProcessListState {
@@ -333,17 +336,24 @@ export class ProcessList extends React.Component<ProcessListProps, ProcessListSt
 
         const currentStepCard = hasRecipeProcess ? (
             <>
-                <div className="current-process-label">Aktiver Schritt</div>
+                <div className="current-process-label">{isProcessStarted ? 'Aktiver Schritt' : 'Brauprozess'}</div>
                 <section className={`current-process-step${confirmationRequest ? ' current-process-step--action-required' : ''}`} aria-label="Aktueller Prozessschritt">
-                    <div className="current-step-heading">
-                        <div>
-                            <h4>{isProcessStarted ? this.getCurrentStepTitle(activeStep) : 'Noch kein Brauvorgang gestartet'}</h4>
-                            {!isProcessStarted && <span className="current-step-badge">Geplanter Ablauf</span>}
+                    {!isProcessStarted ? (
+                        <div className="process-start-state">
+                            <h4>Brauprozess</h4>
+                            <button className="startBtn" type="button" disabled={this.props.isStartBrewingDisabled} onClick={this.props.onStartBrewing}>Brauvorgang starten</button>
+                            {this.props.startBrewingWarning && <p className="sensorStartWarning" role="alert">{this.props.startBrewingWarning}</p>}
                         </div>
-                        {this.getCurrentStepMeta(activeStep, isProcessStarted)}
-                    </div>
-                    {!confirmationRequest && this.renderStatusSection(isProcessStarted)}
-                    {this.renderInlineNotice()}
+                    ) : (
+                        <>
+                            <div className="current-step-heading">
+                                <div><h4>{this.getCurrentStepTitle(activeStep)}</h4></div>
+                                {this.getCurrentStepMeta(activeStep, true)}
+                            </div>
+                            {!confirmationRequest && this.renderStatusSection(true)}
+                            {this.renderInlineNotice()}
+                        </>
+                    )}
                 </section>
             </>
         ) : <div className="process-empty-state">Kein Bier für den Brauvorgang ausgewählt.</div>;

--- a/src/containers/Production/Production.css
+++ b/src/containers/Production/Production.css
@@ -353,16 +353,6 @@
 .settings .quantity-picker-input-disabled { background: var(--color-disabled-bg); }
 
 /* Buttons */
-.startBtnDiv {
-    margin-top: auto;
-    display: block;
-    position: sticky;
-    bottom: 0;
-    z-index: 2;
-    flex: 0 0 auto;
-    padding-top: var(--spacing-xs);
-    background: var(--color-surface-2);
-}
 .startBtn {
     height: var(--control-height);
     width: 100%;
@@ -618,10 +608,4 @@
         padding-block: 0.35rem;
     }
 
-    .startBtnDiv {
-        position: static;
-        flex: 0 0 auto;
-        margin-top: clamp(0.2rem, 0.45vh, 0.35rem);
-        padding-top: 0;
-    }
 }

--- a/src/containers/Production/Production.test.tsx
+++ b/src/containers/Production/Production.test.tsx
@@ -518,7 +518,7 @@ describe('Production start button', () => {
 
     it('blocks startup safely until the first sensor snapshot arrives', () => {
         renderProduction({realtimeState: {alarms: [], alarmsReceived: false}});
-        expect(screen.getByRole('button', {name: 'Start'})).toBeDisabled();
+        expect(screen.getByRole('button', {name: 'Brauvorgang starten'})).toBeDisabled();
         expect(screen.getByRole('alert')).toHaveTextContent('Temperatursensorstatus wird ermittelt');
         expect(screen.getByLabelText('Aktuelle Temperatur: -- °C')).toBeInTheDocument();
     });
@@ -528,9 +528,9 @@ describe('Production start button', () => {
         ['INVALID_READING' as const, 'Ungültiger Temperaturwert'],
     ])('blocks startup for %s and explains the sensor problem', (health, message) => {
         const {props} = renderProduction({realtimeState: {alarms: [], alarmsReceived: true, temperatureSensor: {current: null, health, sensorId: '28-1'}}});
-        fireEvent.click(screen.getByRole('button', {name: 'Start'}));
+        fireEvent.click(screen.getByRole('button', {name: 'Brauvorgang starten'}));
         expect(props.sendBrewingData).not.toHaveBeenCalled();
-        expect(screen.getByRole('button', {name: 'Start'})).toBeDisabled();
+        expect(screen.getByRole('button', {name: 'Brauvorgang starten'})).toBeDisabled();
         expect(screen.getByRole('alert')).toHaveTextContent(message);
         expect(screen.getByLabelText('Aktuelle Temperatur: -- °C')).toBeInTheDocument();
         expect(screen.queryByLabelText('Aktuelle Temperatur: 0 °C')).not.toBeInTheDocument();
@@ -539,11 +539,11 @@ describe('Production start button', () => {
     it('keeps a real zero valid and recovers immediately after a healthy snapshot', () => {
         const missing = {alarms: [], alarmsReceived: true, temperatureSensor: {current: null, health: 'MISSING' as const, sensorId: '28-1'}};
         const {rerender, props} = renderProduction({realtimeState: missing});
-        expect(screen.getByRole('button', {name: 'Start'})).toBeDisabled();
+        expect(screen.getByRole('button', {name: 'Brauvorgang starten'})).toBeDisabled();
         rerender(<Production {...props} realtimeState={{...missing, temperatureSensor: {current: 0, health: 'OK', sensorId: '28-1'}}} />);
         expect(screen.queryByRole('alert')).not.toBeInTheDocument();
         expect(screen.getByLabelText('Aktuelle Temperatur: 0 °C')).toBeInTheDocument();
-        expect(screen.getByRole('button', {name: 'Start'})).toBeEnabled();
+        expect(screen.getByRole('button', {name: 'Brauvorgang starten'})).toBeEnabled();
         rerender(<Production {...props} realtimeState={{...missing, temperatureSensor: {current: 55.8, health: 'OK', sensorId: '28-1'}}} />);
         expect(screen.getByLabelText('Aktuelle Temperatur: 55,8 °C')).toBeInTheDocument();
     });
@@ -568,7 +568,9 @@ describe('Production start button', () => {
         expect(meters.querySelector('.current-step-panel')).toBeInTheDocument();
         expect(meters.querySelector('.Temp')).toBeInTheDocument();
         expect(meters.querySelectorAll('.GaugeContainer')).toHaveLength(1);
-        expect(meters.querySelector('[aria-label="Aktueller Prozessschritt"]')).toHaveTextContent('Noch kein Brauvorgang gestartet');
+        expect(meters.querySelector('[aria-label="Aktueller Prozessschritt"]')).toHaveTextContent('Brauprozess');
+        expect(meters).toContainElement(screen.getByRole('button', {name: 'Brauvorgang starten'}));
+        expect(container.querySelector('.settings')).not.toContainElement(screen.getByRole('button', {name: 'Brauvorgang starten'}));
         expect(processColumn).toHaveTextContent('Ablauf');
         expect(processColumn.querySelector('.current-process-step')).not.toBeInTheDocument();
         expect(container.querySelector('.Water')).toHaveTextContent('0,0 l');
@@ -576,22 +578,24 @@ describe('Production start button', () => {
 
     it('keeps the start button enabled when no brew is running', () => {
         renderProduction({brewingStatus: createBrewingStatus(ProcessState.IDLE), isPollingRunning: false});
-        expect(screen.getByRole('button', {name: 'Start'})).not.toBeDisabled();
+        expect(screen.getByRole('button', {name: 'Brauvorgang starten'})).not.toBeDisabled();
     });
 
-    it('disables the start button while a brew is active', () => {
+    it('hides the start state and shows the existing active-step state while a brew is active', () => {
         renderProduction({brewingStatus: createBrewingStatus(ProcessState.ACTIVE), isPollingRunning: false});
-        expect(screen.getByRole('button', {name: 'Start'})).toBeDisabled();
+        expect(screen.queryByRole('button', {name: 'Brauvorgang starten'})).not.toBeInTheDocument();
+        expect(screen.getByText('Aktiver Schritt')).toBeInTheDocument();
+        expect(screen.getAllByRole('button', {name: 'Brauvorgang starten'})).toHaveLength(0);
     });
 
     it('disables the start button while a start request is running', () => {
         renderProduction({brewingStatus: createBrewingStatus(ProcessState.IDLE), isPollingRunning: true});
-        expect(screen.getByRole('button', {name: 'Start'})).toBeDisabled();
+        expect(screen.getByRole('button', {name: 'Brauvorgang starten'})).toBeDisabled();
     });
 
     it('sends the brewing data only once for fast repeated start clicks', () => {
         const {props} = renderProduction({brewingStatus: createBrewingStatus(ProcessState.IDLE), isPollingRunning: false});
-        const startButton = screen.getByRole('button', {name: 'Start'});
+        const startButton = screen.getByRole('button', {name: 'Brauvorgang starten'});
         fireEvent.click(startButton);
         fireEvent.click(startButton);
         expect(props.sendBrewingData).toHaveBeenCalledTimes(1);
@@ -599,37 +603,35 @@ describe('Production start button', () => {
 
     it('does not send another start request when a brew is already active', () => {
         const {props} = renderProduction({brewingStatus: createBrewingStatus(ProcessState.ACTIVE), isPollingRunning: false});
-        fireEvent.click(screen.getByRole('button', {name: 'Start'}));
+        expect(screen.queryByRole('button', {name: 'Brauvorgang starten'})).not.toBeInTheDocument();
         expect(props.sendBrewingData).not.toHaveBeenCalled();
     });
 
-    it('enables the start button again after finished, aborted, reset, or failed idle states', () => {
+    it('keeps the start state hidden for terminal processes and restores it when control returns to idle', () => {
         const {rerender, props} = renderProduction({brewingStatus: createBrewingStatus(ProcessState.ACTIVE), isPollingRunning: true});
-        expect(screen.getByRole('button', {name: 'Start'})).toBeDisabled();
+        expect(screen.queryByRole('button', {name: 'Brauvorgang starten'})).not.toBeInTheDocument();
         rerender(<Production {...props} brewingStatus={createBrewingStatus(ProcessState.FINISHED)} isPollingRunning={false} />);
-        expect(screen.getByRole('button', {name: 'Start'})).not.toBeDisabled();
+        expect(screen.queryByRole('button', {name: 'Brauvorgang starten'})).not.toBeInTheDocument();
         rerender(<Production {...props} brewingStatus={createBrewingStatus(ProcessState.ABORTED)} isPollingRunning={false} />);
-        expect(screen.getByRole('button', {name: 'Start'})).not.toBeDisabled();
+        expect(screen.queryByRole('button', {name: 'Brauvorgang starten'})).not.toBeInTheDocument();
         rerender(<Production {...props} brewingStatus={createBrewingStatus(ProcessState.IDLE)} isPollingRunning={false} />);
-        expect(screen.getByRole('button', {name: 'Start'})).not.toBeDisabled();
-        rerender(<Production {...props} brewingStatus={createBrewingStatus(ProcessState.IDLE)} isPollingRunning={false} />);
-        expect(screen.getByRole('button', {name: 'Start'})).not.toBeDisabled();
+        expect(screen.getByRole('button', {name: 'Brauvorgang starten'})).not.toBeDisabled();
     });
 
 
     it('enables the start button again after a failed start request without active control status', () => {
         const {rerender, props} = renderProduction({brewingStatus: createBrewingStatus(ProcessState.IDLE), isPollingRunning: false});
-        fireEvent.click(screen.getByRole('button', {name: 'Start'}));
-        expect(screen.getByRole('button', {name: 'Start'})).toBeDisabled();
+        fireEvent.click(screen.getByRole('button', {name: 'Brauvorgang starten'}));
+        expect(screen.getByRole('button', {name: 'Brauvorgang starten'})).toBeDisabled();
         rerender(<Production {...props} brewingStatus={createBrewingStatus(ProcessState.IDLE)} isPollingRunning={true} />);
-        expect(screen.getByRole('button', {name: 'Start'})).toBeDisabled();
+        expect(screen.getByRole('button', {name: 'Brauvorgang starten'})).toBeDisabled();
         rerender(<Production {...props} brewingStatus={createBrewingStatus(ProcessState.IDLE)} isPollingRunning={false} />);
-        expect(screen.getByRole('button', {name: 'Start'})).not.toBeDisabled();
+        expect(screen.getByRole('button', {name: 'Brauvorgang starten'})).not.toBeDisabled();
     });
 
     it('keeps the existing recipe transfer and start flow unchanged', () => {
         const {props} = renderProduction({brewingStatus: createBrewingStatus(ProcessState.IDLE), isPollingRunning: false});
-        fireEvent.click(screen.getByRole('button', {name: 'Start'}));
+        fireEvent.click(screen.getByRole('button', {name: 'Brauvorgang starten'}));
         expect(props.sendBrewingData).toHaveBeenCalledTimes(1);
     });
 
@@ -1121,7 +1123,7 @@ describe('Production recipe water filling', () => {
         expect(screen.getByText('22,0 l')).toBeInTheDocument();
 
         // Starting the brewing process is not a physical water transition.
-        fireEvent.click(screen.getByRole('button', {name: 'Start'}));
+        fireEvent.click(screen.getByRole('button', {name: 'Brauvorgang starten'}));
         expect(screen.getByText('22,0 l')).toBeInTheDocument();
 
         // Leaving the explicit mashing-out confirmation adds actual prepared sparge once.
@@ -1146,7 +1148,7 @@ describe('Production recipe water filling', () => {
         });
 
         expect(container.querySelector('.Settings')).toHaveClass('Settings--disabled');
-        expect(screen.getByRole('button', {name: 'Start'})).toBeDisabled();
+        expect(screen.getByRole('button', {name: 'Brauvorgang starten'})).toBeDisabled();
         expect(screen.getByRole('button', {name: /Nachguss/})).toBeDisabled();
         expect(screen.getByRole('button', {name: /Hauptguss/})).toBeDisabled();
         expect(container.querySelectorAll('.Settings .quantity-picker-content button:not(:disabled)')).toHaveLength(0);

--- a/src/containers/Production/Production.tsx
+++ b/src/containers/Production/Production.tsx
@@ -853,12 +853,6 @@ export class Production extends React.Component<ProductionProps, ProductionState
                         <button className="recipeWaterBtn" disabled={mashWaterDisabled} onClick={this.startMashWaterFilling}>{this.getRecipeWaterButtonLabel('mash')}</button>
                     </div>
                 </section>
-                <div className="startBtnDiv">
-                    <button className="startBtn" disabled={this.isStartButtonDisabled()} onClick={this.startBrewing}>Start</button>
-                    {!isTemperatureSensorReady(this.props.realtimeState?.temperatureSensor, this.props.socketConnected) && <p className="sensorStartWarning" role="alert">
-                        Brauvorgang kann nicht gestartet werden: {getTemperatureSensorMessage(this.props.realtimeState?.temperatureSensor)}.
-                    </p>}
-                </div>
             </div>);
     }
 
@@ -934,7 +928,8 @@ export class Production extends React.Component<ProductionProps, ProductionState
         if (selectedBeer === undefined) {
             return null;
         }
-        return <ProcessList displayMode="current" selectedBeer={selectedBeer} currentStepIndex={brewingStatus?.currentStep?.index ?? 0} currentStep={brewingStatus?.currentStep} brewingStatus={brewingStatus} remainingSeconds={this.state.displayedRemainingSeconds} confirmationPending={this.props.isConfirmPending} confirmationError={this.props.confirmError} onConfirmWaiting={this.confirmCurrentWaitingState} hopReminderName={this.state.showHopsDialog ? this.state.hopName : undefined} onCompleteHopReminder={this.confirmHopDialog} />;
+        const sensorReady = isTemperatureSensorReady(this.props.realtimeState?.temperatureSensor, this.props.socketConnected);
+        return <ProcessList displayMode="current" selectedBeer={selectedBeer} currentStepIndex={brewingStatus?.currentStep?.index ?? 0} currentStep={brewingStatus?.currentStep} brewingStatus={brewingStatus} remainingSeconds={this.state.displayedRemainingSeconds} confirmationPending={this.props.isConfirmPending} confirmationError={this.props.confirmError} onConfirmWaiting={this.confirmCurrentWaitingState} hopReminderName={this.state.showHopsDialog ? this.state.hopName : undefined} onCompleteHopReminder={this.confirmHopDialog} onStartBrewing={this.startBrewing} isStartBrewingDisabled={this.isStartButtonDisabled()} startBrewingWarning={!sensorReady ? `Brauvorgang kann nicht gestartet werden: ${getTemperatureSensorMessage(this.props.realtimeState?.temperatureSensor)}.` : undefined} />;
     }
 
 


### PR DESCRIPTION
### Motivation

- The Start action semantically belongs to the process/active-step area, not the Settings column; the UI must show a clear start state before a brew is running and reuse the existing start logic. 

### Description

- Moved the Start button from the right Settings column into the Process card rendered by `ProcessList` and renamed the label to `Brauvorgang starten`. 
- Added props to `ProcessList`: `onStartBrewing`, `isStartBrewingDisabled`, and `startBrewingWarning`, and render a start state when `brewingStatus.process.state === IDLE` (otherwise render the existing "Aktiver Schritt" view). 
- Wired `Production.renderCurrentStep()` to pass the existing `startBrewing` handler and the exact disabled/validation state and sensor warning (no new backend calls or validation logic). 
- Removed the old start button markup from the Settings panel and cleaned up related CSS rules; introduced `.process-start-state` styling in `ProcessList.css` to integrate into the existing card look. 
- Updated unit tests to reflect the relocated button, new label, disabled logic, and visibility rules: `src/containers/Production/Production.test.tsx` and `src/containers/Production/ProcessList/ProcessList.test.tsx` were adjusted to assert the new location, text, click behavior, disabled state and that no duplicate start button is shown in Settings.

Files changed (key):
- `src/containers/Production/ProcessList/ProcessList.tsx`
- `src/containers/Production/ProcessList/ProcessList.css`
- `src/containers/Production/Production.tsx`
- `src/containers/Production/Production.css`
- `src/containers/Production/Production.test.tsx` (updated assertions)
- `src/containers/Production/ProcessList/ProcessList.test.tsx` (updated/added assertions)

### Testing

- Ran static checks: `git diff --check` produced no issues. 
- Updated and added Jest/RTL assertions in `Production.test.tsx` and `ProcessList.test.tsx` to cover: pre-start shows `Brauvorgang starten` in the process card, Settings no longer contains the start button, click invokes the existing start flow once, disabled states follow existing logic, and the start UI is removed when the process is running. 
- Attempted to run full JS test/install (`npm ci` / `npm test`) but dependency installation failed due to a registry HTTP 403 in this environment, so the test runner could not be executed here; the modified tests are included and ready to run in CI or a dev environment with network/npm access.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a95844935dc832f89182bbe25d17809)