### PR TITLE
Production: Einstellungen vertikal aufteilen und Pause‑Button stets anzeigen

### DIFF
--- a/src/containers/Production/Production.css
+++ b/src/containers/Production/Production.css
@@ -172,12 +172,27 @@
     border-bottom: 1px solid var(--color-border-soft);
 }
 
+.settingsContent {
+    flex: 1 1 auto;
+    min-height: 0;
+    display: grid;
+    grid-template-rows: minmax(max-content, 3fr) minmax(max-content, 2fr);
+    gap: var(--spacing-sm);
+}
+
 .settingsGroup {
     padding: var(--spacing-sm);
     background: var(--color-brew-bg);
     border: 1px solid var(--color-border);
     border-left: 0.25rem solid var(--color-accent);
     border-radius: var(--border-radius-large);
+    min-height: 0;
+}
+
+.agitatorSettingsGroup,
+.waterSettingsGroup {
+    display: flex;
+    flex-direction: column;
 }
 
 .settingsGroup h4 {
@@ -202,10 +217,26 @@
     font-weight: 700;
 }
 
-.agitatorPauseButton { border: 1px solid var(--color-accent-border); border-radius: var(--border-radius-medium); background: var(--color-surface-2); color: var(--color-text); padding: 0.55rem 0.35rem; font-weight: 700; }
+.agitatorPauseButton {
+    width: 100%;
+    border: 1px solid var(--color-accent-border);
+    border-radius: var(--border-radius-medium);
+    background: var(--color-surface-2);
+    color: var(--color-text);
+    padding: 0.55rem 0.35rem;
+    font-weight: 700;
+    cursor: pointer;
+}
+.agitatorPauseButton:hover:not(:disabled) { background: var(--color-accent-subtle-hover); }
+.agitatorPauseButton:disabled {
+    background: var(--color-disabled-bg);
+    border-color: var(--color-disabled-border);
+    color: var(--color-disabled-text);
+    cursor: not-allowed;
+}
 .agitatorAvailability { margin: 0 0 var(--spacing-xs); color: var(--color-text-muted); font-size: var(--font-size-small); }
 .agitatorPrimaryMode { padding-inline: var(--spacing-sm); }
-.agitatorSpeedControl { display: grid; gap: 0.35rem; margin-top: var(--spacing-sm); color: var(--color-text); }
+.agitatorSpeedControl { display: grid; gap: 0.35rem; margin-top: var(--spacing-md); color: var(--color-text); }
 .agitatorSpeedControl span { display: flex; justify-content: space-between; }
 .agitatorSpeedControl input { width: 100%; accent-color: var(--color-accent); }
 .agitatorAutomaticSettings { background: var(--color-surface-2); border: 0; box-shadow: inset 0 0 0 1px var(--color-accent-border); }
@@ -217,7 +248,7 @@
 .agitatorIntervalStepper { display: grid; grid-template-columns: minmax(0, 1fr) auto; align-items: end; gap: var(--spacing-xs); min-width: 0; }
 .agitatorIntervalUnit { display: flex; align-items: center; height: 2rem; color: var(--color-text-secondary); }
 .agitatorAutomaticSettings .quantity-picker-input-disabled { color: var(--color-text-secondary); }
-.agitatorPauseButton { width: 100%; margin-top: var(--spacing-sm); padding-top: var(--spacing-sm); border-top-color: var(--color-border-soft); }
+.agitatorFooter { margin-top: auto; padding-top: var(--spacing-sm); }
 .agitatorError { color: var(--color-error); margin: 0.5rem 0 0; }
 
 .intervalHeader {
@@ -418,7 +449,7 @@
 }
 
 .recipeWaterGroup {
-    margin-top: var(--spacing-sm);
+    margin-top: auto;
     padding-top: var(--spacing-sm);
     border-top: 1px solid var(--color-border-soft);
 }
@@ -522,9 +553,9 @@
     .recipeWaterButtons { flex-direction: column; }
 }
 
-/* The kiosk settings column remains in normal document flow. The cards keep
- * their content-defined height and use a little more of the available vertical
- * space before the footer action without allowing them to shrink below content. */
+/* At kiosk widths the settings grid consumes the full column height. Its 3:2
+ * tracks give the denser agitator controls more room while keeping both cards
+ * stable as runtime states change. */
 @media (min-width: 1281px) {
     .containerProduction .settings {
         display: flex;
@@ -543,9 +574,13 @@
     }
 
     .settingsGroup {
-        flex: 0 0 auto;
-        min-height: max-content;
         padding: clamp(0.425rem, 0.8vh, 0.625rem) 0.65rem;
+    }
+
+    .settingsContent {
+        grid-template-rows: minmax(0, 3fr) minmax(0, 2fr);
+        gap: clamp(0.3rem, 0.65vh, 0.5rem);
+        overflow: hidden;
     }
 
     .settingsGroup h4 {
@@ -608,8 +643,11 @@
     }
 
     .agitatorPauseButton {
-        margin-top: 0.35rem;
         padding: 0.4rem;
+    }
+
+    .agitatorFooter {
+        padding-top: 0.35rem;
     }
 
     .manualWaterControls,

--- a/src/containers/Production/Production.test.tsx
+++ b/src/containers/Production/Production.test.tsx
@@ -186,7 +186,52 @@ describe('Production agitator controller integration', () => {
         within(screen.getByTestId('break-minutes-stepper')).getAllByRole('button').forEach(button => expect(button).toBeDisabled());
         expect(screen.getByRole('slider')).toBeDisabled();
         expect(screen.getByText('Geschwindigkeit')).toBeInTheDocument();
+        expect(screen.getByRole('button', {name: 'Rührwerk pausieren'})).toBeDisabled();
         expect(ProductionRepository.setAgitatorConfig).not.toHaveBeenCalled();
+    });
+
+    it.each([
+        ['OFF', true],
+        ['CONTINUOUS', false],
+        ['AUTOMATIC', false],
+    ] as const)('always renders the pause action in %s mode and disabled=%s', async (mode, disabled) => {
+        jest.spyOn(ProductionRepository, 'getAgitatorStatus').mockResolvedValue({
+            ...detail,
+            config: {...detail.config, mode},
+            runtime: {...detail.runtime, desiredOperation: mode === 'OFF' ? 'STOPPED' : detail.runtime.desiredOperation},
+        });
+        renderProduction();
+
+        const pauseButton = await screen.findByRole('button', {name: 'Rührwerk pausieren'});
+        if (disabled) expect(pauseButton).toBeDisabled();
+        else expect(pauseButton).toBeEnabled();
+    });
+
+    it('keeps the pause action mounted across mode and paused-state updates', async () => {
+        const {props, rerender} = renderProduction();
+        const pauseButton = await screen.findByRole('button', {name: 'Rührwerk pausieren'});
+
+        rerender(<Production {...props} realtimeState={{...props.realtimeState!, agitator: {
+            mode: 'OFF', paused: false, operation: 'STOPPED', actualOutputOn: false,
+            speedPercent: 36, runningMinutes: 2, breakMinutes: 7,
+        }}} />);
+        expect(screen.getByRole('button', {name: 'Rührwerk pausieren'})).toBe(pauseButton);
+        expect(pauseButton).toBeDisabled();
+
+        rerender(<Production {...props} realtimeState={{...props.realtimeState!, agitator: {
+            mode: 'CONTINUOUS', paused: false, operation: 'CONTINUOUS', actualOutputOn: true,
+            speedPercent: 36, runningMinutes: 2, breakMinutes: 7,
+        }}} />);
+        expect(screen.getByRole('button', {name: 'Rührwerk pausieren'})).toBe(pauseButton);
+        expect(pauseButton).toBeEnabled();
+
+        rerender(<Production {...props} realtimeState={{...props.realtimeState!, agitator: {
+            mode: 'AUTOMATIC', paused: true, operation: 'STOPPED', actualOutputOn: false,
+            speedPercent: 36, runningMinutes: 2, breakMinutes: 7,
+        }}} />);
+        expect(screen.getByRole('button', {name: 'Rührwerk fortsetzen'})).toBe(pauseButton);
+        expect(pauseButton).toBeEnabled();
+        expect(screen.getByRole('progressbar', {name: 'Intervallfortschritt'})).toBeInTheDocument();
     });
 
     it.each([

--- a/src/containers/Production/Production.tsx
+++ b/src/containers/Production/Production.tsx
@@ -792,79 +792,84 @@ export class Production extends React.Component<ProductionProps, ProductionState
                     <h3>Einstellungen</h3>
                 </div>
 
-                <section className="settingsGroup" aria-labelledby="agitator-settings-title">
-                    <h4 id="agitator-settings-title">Rührwerk</h4>
-                    {(settingsDisabled || !agitatorConfig) && <p className="agitatorAvailability" role="status">
-                        {agitatorStatusLoadFailed || settingsDisabled ? 'Rührwerk-Konfiguration nicht verfügbar' : 'Rührwerk-Konfiguration wird geladen'}
-                    </p>}
-                    <div className="agitatorPrimaryMode">
-                        {renderSwitch('Durchgehend rühren', displayedAgitatorMode === 'CONTINUOUS',
-                            (checked) => this.toggleAgitatorMode('CONTINUOUS', checked), settingsDisabled || !agitatorConfig)}
-                    </div>
-                    <div className={`intervalSettings agitatorAutomaticSettings ${displayedAgitatorMode === 'AUTOMATIC' ? 'is-active' : ''}`} aria-labelledby="interval-settings-title">
-                        <div className="agitatorAutomaticHeader">
-                            <div>
-                                <h5 id="interval-settings-title">Intervallbetrieb</h5>
-                                <p>Beim Heizen durchgehend, sonst im Intervall</p>
+                <div className="settingsContent">
+                    <section className="settingsGroup agitatorSettingsGroup" aria-labelledby="agitator-settings-title">
+                        <h4 id="agitator-settings-title">Rührwerk</h4>
+                        {(settingsDisabled || !agitatorConfig) && <p className="agitatorAvailability" role="status">
+                            {agitatorStatusLoadFailed || settingsDisabled ? 'Rührwerk-Konfiguration nicht verfügbar' : 'Rührwerk-Konfiguration wird geladen'}
+                        </p>}
+                        <div className="agitatorPrimaryMode">
+                            {renderSwitch('Durchgehend rühren', displayedAgitatorMode === 'CONTINUOUS',
+                                (checked) => this.toggleAgitatorMode('CONTINUOUS', checked), settingsDisabled || !agitatorConfig)}
+                        </div>
+                        <div className={`intervalSettings agitatorAutomaticSettings ${displayedAgitatorMode === 'AUTOMATIC' ? 'is-active' : ''}`} aria-labelledby="interval-settings-title">
+                            <div className="agitatorAutomaticHeader">
+                                <div>
+                                    <h5 id="interval-settings-title">Intervallbetrieb</h5>
+                                    <p>Beim Heizen durchgehend, sonst im Intervall</p>
+                                </div>
+                                <div className="agitatorAutomaticActions">
+                                    <AgitatorIntervalProgress active={intervalProgressActive} paused={agitatorRuntime?.paused ?? false}
+                                        progress={agitatorRuntime?.intervalProgressPercent} />
+                                    <Switch className="productionSwitch" onChange={(checked) => this.toggleAgitatorMode('AUTOMATIC', checked)}
+                                        checked={displayedAgitatorMode === 'AUTOMATIC'} height={24} width={44} handleDiameter={18}
+                                        checkedIcon={false} uncheckedIcon={false} disabled={settingsDisabled || !agitatorConfig}
+                                        aria-label="Intervallbetrieb" />
+                                </div>
                             </div>
-                            <div className="agitatorAutomaticActions">
-                                <AgitatorIntervalProgress active={intervalProgressActive} paused={agitatorRuntime?.paused ?? false}
-                                    progress={agitatorRuntime?.intervalProgressPercent} />
-                                <Switch className="productionSwitch" onChange={(checked) => this.toggleAgitatorMode('AUTOMATIC', checked)}
-                                    checked={displayedAgitatorMode === 'AUTOMATIC'} height={24} width={44} handleDiameter={18}
-                                    checkedIcon={false} uncheckedIcon={false} disabled={settingsDisabled || !agitatorConfig}
-                                    aria-label="Intervallbetrieb" />
+                            <div className="intervalTimeControls">
+                                <div className="intervalTimeControl" data-testid="running-minutes-stepper">
+                                    <QuantityPicker value={agitatorIntervalDraft?.runningMinutes ?? agitatorConfig?.runningMinutes}
+                                        min={0} max={Number.MAX_SAFE_INTEGER} onChange={this.onIntervalChangeRunningTime}
+                                        isDisabled={settingsDisabled || !agitatorConfig || displayedAgitatorMode !== 'AUTOMATIC'} label="Laufzeit" labelPosition="above"/>
+                                    <span className="intervalTimeUnit">min</span>
+                                </div>
+                                <div className="intervalTimeControl" data-testid="break-minutes-stepper">
+                                    <QuantityPicker value={agitatorIntervalDraft?.breakMinutes ?? agitatorConfig?.breakMinutes}
+                                        min={0} max={Number.MAX_SAFE_INTEGER} onChange={this.onIntervalChangeBreakTime}
+                                        isDisabled={settingsDisabled || !agitatorConfig || displayedAgitatorMode !== 'AUTOMATIC'} label="Pausenzeit" labelPosition="above"/>
+                                    <span className="intervalTimeUnit">min</span>
+                                </div>
                             </div>
                         </div>
-                        <div className="intervalTimeControls">
-                            <div className="intervalTimeControl" data-testid="running-minutes-stepper">
-                                <QuantityPicker value={agitatorIntervalDraft?.runningMinutes ?? agitatorConfig?.runningMinutes}
-                                    min={0} max={Number.MAX_SAFE_INTEGER} onChange={this.onIntervalChangeRunningTime}
-                                    isDisabled={settingsDisabled || !agitatorConfig || displayedAgitatorMode !== 'AUTOMATIC'} label="Laufzeit" labelPosition="above"/>
-                                <span className="intervalTimeUnit">min</span>
-                            </div>
-                            <div className="intervalTimeControl" data-testid="break-minutes-stepper">
-                                <QuantityPicker value={agitatorIntervalDraft?.breakMinutes ?? agitatorConfig?.breakMinutes}
-                                    min={0} max={Number.MAX_SAFE_INTEGER} onChange={this.onIntervalChangeBreakTime}
-                                    isDisabled={settingsDisabled || !agitatorConfig || displayedAgitatorMode !== 'AUTOMATIC'} label="Pausenzeit" labelPosition="above"/>
-                                <span className="intervalTimeUnit">min</span>
-                            </div>
+                        <label className="agitatorSpeedControl">
+                            <span>Geschwindigkeit <strong>{agitatorConfig ? `${agitatorSpeedDraft ?? agitatorConfig.speedPercent} %` : '–'}</strong></span>
+                            <input type="range" min="0" max="100" value={agitatorSpeedDraft ?? agitatorConfig?.speedPercent ?? 0}
+                                   disabled={settingsDisabled || !agitatorConfig} onChange={(event) => this.onAgitatorSpeedChange(Number(event.target.value))}/>
+                        </label>
+                        <div className="agitatorFooter">
+                            <button className="agitatorPauseButton" type="button"
+                                disabled={settingsDisabled || agitatorRequestPending || !agitatorRuntime || agitatorRuntime.mode === 'OFF'}
+                                onClick={this.toggleAgitatorPause}>
+                                {agitatorRuntime?.paused ? 'Rührwerk fortsetzen' : 'Rührwerk pausieren'}
+                            </button>
+                            {this.state.mainAgitatorError && <p className="agitatorError" role="alert">Rührwerk konnte nicht aktualisiert werden.</p>}
                         </div>
-                    </div>
-                    <label className="agitatorSpeedControl">
-                        <span>Geschwindigkeit <strong>{agitatorConfig ? `${agitatorSpeedDraft ?? agitatorConfig.speedPercent} %` : '–'}</strong></span>
-                        <input type="range" min="0" max="100" value={agitatorSpeedDraft ?? agitatorConfig?.speedPercent ?? 0}
-                               disabled={settingsDisabled || !agitatorConfig} onChange={(event) => this.onAgitatorSpeedChange(Number(event.target.value))}/>
-                    </label>
-                    {agitatorRuntime && agitatorRuntime.mode !== 'OFF' && <button className="agitatorPauseButton" type="button"
-                        disabled={settingsDisabled || agitatorRequestPending} onClick={this.toggleAgitatorPause}>
-                        {agitatorRuntime.paused ? 'Rührwerk fortsetzen' : 'Rührwerk pausieren'}
-                    </button>}
-                    {this.state.mainAgitatorError && <p className="agitatorError" role="alert">Rührwerk konnte nicht aktualisiert werden.</p>}
-                </section>
+                    </section>
 
-                <section className="settingsGroup" aria-labelledby="water-settings-title">
-                    <h4 id="water-settings-title">Wasser</h4>
-                    <div className="intervalSettings manualWaterSettings" aria-labelledby="manual-water-settings-title">
-                        <h5 id="manual-water-settings-title">Manuelle Wasserzufuhr</h5>
-                        <div className="settingsRowWater manualWaterControls">
-                            <div className="leftAligned">
-                                {renderSwitch('Wasser aktivieren', waterSwitchState, this.toggleWaterSwitchState)}
-                            </div>
-                            <div className="rightAligned">
-                                <QuantityPicker value={this.state.liters} min={1} max={this.MAX_WATER_LEVEL} onChange={this.onSetWaterChangeQuantity}
-                                                isDisabled={settingsDisabled || waterSwitchState} label="Liter" labelPosition="above"/>
+                    <section className="settingsGroup waterSettingsGroup" aria-labelledby="water-settings-title">
+                        <h4 id="water-settings-title">Wasser</h4>
+                        <div className="intervalSettings manualWaterSettings" aria-labelledby="manual-water-settings-title">
+                            <h5 id="manual-water-settings-title">Manuelle Wasserzufuhr</h5>
+                            <div className="settingsRowWater manualWaterControls">
+                                <div className="leftAligned">
+                                    {renderSwitch('Wasser aktivieren', waterSwitchState, this.toggleWaterSwitchState)}
+                                </div>
+                                <div className="rightAligned">
+                                    <QuantityPicker value={this.state.liters} min={1} max={this.MAX_WATER_LEVEL} onChange={this.onSetWaterChangeQuantity}
+                                                    isDisabled={settingsDisabled || waterSwitchState} label="Liter" labelPosition="above"/>
+                                </div>
                             </div>
                         </div>
-                    </div>
-                    <div className="recipeWaterGroup" aria-label="Rezeptmengen">
-                        <span className="recipeWaterGroupLabel">Rezeptmengen</span>
-                        <div className="recipeWaterButtons">
-                            <button className="recipeWaterBtn" disabled={spargeWaterDisabled} onClick={this.startSpargeWaterFilling}>{this.getRecipeWaterButtonLabel('sparge')}</button>
-                            <button className="recipeWaterBtn" disabled={mashWaterDisabled} onClick={this.startMashWaterFilling}>{this.getRecipeWaterButtonLabel('mash')}</button>
+                        <div className="recipeWaterGroup" aria-label="Rezeptmengen">
+                            <span className="recipeWaterGroupLabel">Rezeptmengen</span>
+                            <div className="recipeWaterButtons">
+                                <button className="recipeWaterBtn" disabled={spargeWaterDisabled} onClick={this.startSpargeWaterFilling}>{this.getRecipeWaterButtonLabel('sparge')}</button>
+                                <button className="recipeWaterBtn" disabled={mashWaterDisabled} onClick={this.startMashWaterFilling}>{this.getRecipeWaterButtonLabel('mash')}</button>
+                            </div>
                         </div>
-                    </div>
-                </section>
+                    </section>
+                </div>
             </div>);
     }
 


### PR DESCRIPTION
### Motivation

- Die Settings-Spalte nutzte die verfügbare Höhe nicht vollständig, wodurch unter der Wasser-Card ungenutzter Raum entstand; Ziel ist eine robuste, kontainer‑basierte Aufteilung ohne fixe Pixelhöhen.  
- Das Rührwerk benötigt leicht mehr Raum als Wasser und der `Rührwerk pausieren / Rührwerk fortsetzen`-Button soll immer sichtbar, aber nur bei gültigem Runtime‑Zustand aktivierbar sein.  
- Keine funktionalen Änderungen an Steuerungslogik oder REST/Socket-Verhalten sind vorgesehen.

### Description

- Einführung eines inneren Wrappers `settingsContent` und Umstellung auf ein Grid mit `grid-template-rows: 3fr 2fr` für die Settings-Spalte, so dass Rührwerk und Wasser strukturell die verfügbare Höhe teilen.  
- Beide Cards (`.agitatorSettingsGroup`, `.waterSettingsGroup`) sind jetzt `display: flex; flex-direction: column;` und nutzen `margin-top: auto` / Footer‑Spacer, um Footer‑Aktionen (Pause, Rezeptmengen) stabil an den Card‑Boden zu verankern.  
- Der Pause‑Button wird immer im DOM gerendert (kein bedingtes Rendern mehr) und befindet sich in einem `agitatorFooter`; seine `disabled`-Logik ist jetzt `settingsDisabled || agitatorRequestPending || !agitatorRuntime || agitatorRuntime.mode === 'OFF'`, der Text wechselt weiterhin nach `paused`.  
- Konsolidierung der `.agitatorPauseButton`-Styles in `Production.css` mit vorhandenen Theme‑Variablen `--color-disabled-bg`, `--color-disabled-border`, `--color-disabled-text`, `cursor: not-allowed` bei deaktiviertem Zustand und kein Hover für disabled.  
- Tests: `src/containers/Production/Production.test.tsx` erweitert um Fälle, die prüfen, dass der Pause‑Button bei `OFF` bzw. fehlendem Runtime sichtbar aber disabled ist und dass er über Mode/paused‑Wechsel im DOM erhalten bleibt.

### Testing

- Unit tests updated: `src/containers/Production/Production.test.tsx` now includes assertions for always‑rendering pause button and its disabled state for `OFF` / missing runtime and for stable DOM placement across state changes.  
- Attempted automated run: `CI=true npm test -- --watchAll=false src/containers/Production/Production.test.tsx` could not complete in this environment because `node_modules` / `react-scripts` are not installed and the environment's npm access returned HTTP 403, so tests could not be executed here.  
- Repository static checks (`git diff --check`) and local file changes were validated; the commit with these changes is available for CI to run the full test suite in a proper Node environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a95c5509d14832fa2ad1d519a7d04c7)