### PR TITLE
Rührwerk: Intervallblock entfalten und vertikale Abstände in Production-Settings verfeinern

### DIFF
--- a/src/containers/Production/Production.css
+++ b/src/containers/Production/Production.css
@@ -236,13 +236,13 @@
 }
 .agitatorAvailability { margin: 0 0 var(--spacing-xs); color: var(--color-text-muted); font-size: var(--font-size-small); }
 .agitatorPrimaryMode { padding-inline: var(--spacing-sm); }
-.agitatorSpeedControl { display: grid; gap: 0.35rem; margin-top: var(--spacing-md); color: var(--color-text); }
+.agitatorSpeedControl { display: grid; gap: var(--spacing-xs); margin-top: var(--spacing-md); color: var(--color-text); }
 .agitatorSpeedControl span { display: flex; justify-content: space-between; }
 .agitatorSpeedControl input { width: 100%; accent-color: var(--color-accent); }
 .agitatorAutomaticSettings { background: var(--color-surface-2); border: 0; box-shadow: inset 0 0 0 1px var(--color-accent-border); }
 .agitatorAutomaticHeader .settingsToggleRow { width: 100%; }
 .agitatorAutomaticHeader .settingsToggleRow > span { color: var(--color-accent-hover); font-weight: 700; }
-.agitatorAutomaticHeader p { margin: 0.2rem 0 0; color: var(--color-text-muted); font-size: var(--font-size-small); }
+.agitatorAutomaticHeader p { margin: var(--spacing-xs) 0 0; color: var(--color-text-muted); font-size: var(--font-size-small); }
 .agitatorAutomaticActions { display: flex; align-items: center; gap: var(--spacing-sm); flex: 0 0 auto; }
 .agitatorAutomaticSettings h6 { margin: var(--spacing-sm) 0 0; color: var(--color-text); font-size: var(--font-size-small); }
 .agitatorIntervalStepper { display: grid; grid-template-columns: minmax(0, 1fr) auto; align-items: end; gap: var(--spacing-xs); min-width: 0; }
@@ -598,18 +598,39 @@
         padding-inline: 0.2rem;
     }
 
+    .agitatorSettingsGroup {
+        gap: clamp(var(--spacing-xs), 0.7vh, var(--spacing-sm));
+    }
+
+    .agitatorSettingsGroup > h4,
+    .agitatorSettingsGroup > .agitatorAvailability,
+    .agitatorSettingsGroup > .agitatorAutomaticSettings,
+    .agitatorSettingsGroup > .agitatorSpeedControl,
+    .agitatorSettingsGroup > .agitatorFooter {
+        margin-top: 0;
+        margin-bottom: 0;
+    }
+
     .settingsToggleRow {
         min-height: 2rem;
     }
 
     .intervalSettings {
         margin-top: clamp(0.25rem, 0.5vh, 0.4rem);
-        padding: clamp(0.35rem, 0.6vh, 0.45rem) 0.55rem;
+        padding: clamp(var(--spacing-sm), 1vh, var(--spacing-md)) var(--spacing-sm);
+    }
+
+    .agitatorAutomaticSettings {
+        display: flex;
+        flex: 1 1 auto;
+        flex-direction: column;
+        margin-top: 0;
+        min-height: 0;
     }
 
     .agitatorAutomaticHeader {
         display: flex;
-        align-items: flex-start;
+        align-items: center;
         justify-content: space-between;
         gap: 0.75rem;
     }
@@ -619,7 +640,7 @@
     }
 
     .agitatorAutomaticHeader p {
-        margin-top: 0.15rem;
+        margin-top: var(--spacing-xs);
         line-height: 1.15;
     }
 
@@ -629,17 +650,19 @@
     }
 
     .intervalTimeControls {
-        gap: 0.6rem;
-        margin-top: 0.2rem;
+        align-items: end;
+        gap: var(--spacing-sm);
+        margin-top: auto;
+        padding-top: clamp(var(--spacing-md), 1.5vh, var(--spacing-lg));
     }
 
     .intervalTimeControls .quantity-picker-label {
-        padding-bottom: 0.2rem;
+        padding-bottom: var(--spacing-xs);
     }
 
     .agitatorSpeedControl {
-        gap: 0.15rem;
-        margin-top: clamp(0.25rem, 0.5vh, 0.4rem);
+        gap: var(--spacing-xs);
+        margin-top: clamp(var(--spacing-xs), 0.7vh, var(--spacing-sm));
     }
 
     .agitatorPauseButton {
@@ -647,7 +670,8 @@
     }
 
     .agitatorFooter {
-        padding-top: 0.35rem;
+        margin-top: 0;
+        padding-top: clamp(var(--spacing-xs), 0.7vh, var(--spacing-sm));
     }
 
     .manualWaterControls,


### PR DESCRIPTION
### Motivation
- Die Rührwerk-Card hatte innen ungenutzte Fläche zwischen Intervallbereich, Geschwindigkeit und Pause-Button, wobei der Intervallbereich zu gedrängt wirkte.
- Ziel ist eine fachlich logischere, responsive Verteilung des freien Raums ohne fixe Pixelhöhen oder einen einzigen großen Spacer vor dem Pause-Button.

### Description
- Anpassung der CSS-Struktur in `src/containers/Production/Production.css` um die Intervallgruppe (`.agitatorAutomaticSettings` / `.intervalSettings`) als flexibles, spaltfüllendes Element (`flex: 1 1 auto`, `display: flex; flex-direction: column`) zu gestalten, damit sie freien Platz zunächst aufnimmt.
- Vertikale Abstände innerhalb des Intervallblocks wurden token-basiert entzerrt (Header, Beschreibung, Zeitregler) und `intervalTimeControls` wurde so ausgerichtet, dass Laufzeit/Pausenzeit als gleichmäßige Grid-Spalten mit abgestimmten Gaps und Label-Abständen erscheinen; `--spacing-*` Tokens und `clamp()`-Werte wurden verwendet statt harter Pixelwerte.
- Der Header zentriert CircularProgress und Switch (`.agitatorAutomaticHeader { align-items: center; }`) und die Intervall-Controls wurden nach unten gestaffelt (`margin-top: auto` / `padding-top`) damit der Footer/Pause-Button am unteren Rand verbleibt ohne einen einzigen großen flexiblen Spacer zu benötigen.
- Feinschliff im Geschwindigkeitsblock: kleinere, tokenisierte Gaps zwischen Label/Prozentwert und Slider ohne Änderung der Slider-Höhe; zudem wurden gruppeninterne Margins so gesetzt, dass die semantischen Blöcke (Intervall → Geschwindigkeit → Pause) klar getrennt sind.
- Antworten auf die gestellten Punkte: 1) Geänderte CSS-Struktur: `src/containers/Production/Production.css` (u. a. `.agitatorAutomaticSettings`, `.intervalSettings`, `.intervalTimeControls`, `.agitatorSettingsGroup`, `.agitatorSpeedControl`). 2) Wie der Intervallblock Raum aufnimmt: er ist jetzt ein flexibles Column-Container-Element (`flex: 1 1 auto`) und dehnt sich innerhalb der Settings-Card; zusätzlich werden `grid-template-rows` der Settings-Content genutzt, um Verhältnis 3:2 beizubehalten. 3) Verhinderung eines großen Spacers: stattdessen werden flexible Gaps und die Intervallgruppe als primärer flex-grow-Consumer verwendet, außerdem `margin-top: auto`/`padding-top` für die Zeitregler, so dass der Footer nicht durch einen einzelnen Spacer hochgedrückt wird. 4) Scrollbarkeit bei Kiosk-Auflösung: Es wurden keine festen Höhen eingeführt und die Settings-Grid- / Flex-Strategie bewahrt die konzeptionelle Scrollfreiheit für die vorgesehenen Kiosk-/Desktop-Größen, visuelle Bestätigung ist jedoch unten unter Testing erläutert.

### Testing
- `git diff --check` wurde ausgeführt und zeigte keine Fehler, und die Änderungen wurden als Commit (`Refine production agitator spacing`) erfolgreich gespeichert.
- `git status --short` wurde geprüft und die geänderte Datei ist committed.
- Versuchte Ausführung der Unit-Test-Datei mit `CI=true npm test -- --runInBand src/containers/Production/Production.test.tsx` scheiterte in der Umgebung, weil `react-scripts` nicht ausführbar/fehlend war, daher konnten die Jest-Tests nicht lokal ausgeführt werden.
- `npm ci` schlug fehl (HTTP 403 gegen die npm-Registry), weshalb Abhängigkeiten nicht installiert und visuelle Prüfungen / CRA-Server-Starts nicht möglich waren.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a95c8427a6c832f93e4a68707ad13f2)