### PR TITLE
Refactor agitator interval layout and adjust styles; update tests

### DIFF
--- a/src/containers/Production/Production.css
+++ b/src/containers/Production/Production.css
@@ -236,14 +236,12 @@
 }
 .agitatorAvailability { margin: 0 0 var(--spacing-xs); color: var(--color-text-muted); font-size: var(--font-size-small); }
 .agitatorPrimaryMode { padding-inline: var(--spacing-sm); }
-.agitatorSpeedControl { display: grid; gap: 0.35rem; margin-top: var(--spacing-md); color: var(--color-text); }
+.agitatorSpeedControl { display: grid; gap: var(--spacing-xs); margin-top: var(--spacing-md); color: var(--color-text); }
 .agitatorSpeedControl span { display: flex; justify-content: space-between; }
 .agitatorSpeedControl input { width: 100%; accent-color: var(--color-accent); }
 .agitatorAutomaticSettings { background: var(--color-surface-2); border: 0; box-shadow: inset 0 0 0 1px var(--color-accent-border); }
-.agitatorAutomaticHeader .settingsToggleRow { width: 100%; }
-.agitatorAutomaticHeader .settingsToggleRow > span { color: var(--color-accent-hover); font-weight: 700; }
-.agitatorAutomaticHeader p { margin: 0.2rem 0 0; color: var(--color-text-muted); font-size: var(--font-size-small); }
-.agitatorAutomaticActions { display: flex; align-items: center; gap: var(--spacing-sm); flex: 0 0 auto; }
+.agitatorAutomaticHeader { display: flex; align-items: center; justify-content: space-between; gap: var(--spacing-sm); }
+.agitatorIntervalProgressRow { display: flex; flex: 1 1 auto; align-items: center; justify-content: center; min-height: var(--control-height-compact); padding-block: var(--spacing-sm); }
 .agitatorAutomaticSettings h6 { margin: var(--spacing-sm) 0 0; color: var(--color-text); font-size: var(--font-size-small); }
 .agitatorIntervalStepper { display: grid; grid-template-columns: minmax(0, 1fr) auto; align-items: end; gap: var(--spacing-xs); min-width: 0; }
 .agitatorIntervalUnit { display: flex; align-items: center; height: 2rem; color: var(--color-text-secondary); }
@@ -598,18 +596,40 @@
         padding-inline: 0.2rem;
     }
 
+    .agitatorSettingsGroup {
+        gap: clamp(var(--spacing-xs), 0.7vh, var(--spacing-sm));
+    }
+
+    .agitatorSettingsGroup > h4,
+    .agitatorSettingsGroup > .agitatorAvailability,
+    .agitatorSettingsGroup > .agitatorAutomaticSettings,
+    .agitatorSettingsGroup > .agitatorSpeedControl,
+    .agitatorSettingsGroup > .agitatorFooter {
+        margin-top: 0;
+        margin-bottom: 0;
+    }
+
     .settingsToggleRow {
         min-height: 2rem;
     }
 
     .intervalSettings {
         margin-top: clamp(0.25rem, 0.5vh, 0.4rem);
-        padding: clamp(0.35rem, 0.6vh, 0.45rem) 0.55rem;
+        padding: clamp(var(--spacing-sm), 1vh, var(--spacing-md)) var(--spacing-sm)
+            clamp(var(--spacing-md), 1.5vh, var(--spacing-lg));
+    }
+
+    .agitatorAutomaticSettings {
+        display: flex;
+        flex: 1 1 auto;
+        flex-direction: column;
+        margin-top: 0;
+        min-height: 0;
     }
 
     .agitatorAutomaticHeader {
         display: flex;
-        align-items: flex-start;
+        align-items: center;
         justify-content: space-between;
         gap: 0.75rem;
     }
@@ -618,28 +638,25 @@
         line-height: 1.1;
     }
 
-    .agitatorAutomaticHeader p {
-        margin-top: 0.15rem;
-        line-height: 1.15;
-    }
-
     .agitatorAutomaticSettings h6 {
         margin-top: clamp(0.25rem, 0.5vh, 0.4rem);
         line-height: 1.1;
     }
 
     .intervalTimeControls {
-        gap: 0.6rem;
-        margin-top: 0.2rem;
+        align-items: end;
+        gap: var(--spacing-sm);
+        margin-top: 0;
+        padding-top: var(--spacing-xs);
     }
 
     .intervalTimeControls .quantity-picker-label {
-        padding-bottom: 0.2rem;
+        padding-bottom: var(--spacing-xs);
     }
 
     .agitatorSpeedControl {
-        gap: 0.15rem;
-        margin-top: clamp(0.25rem, 0.5vh, 0.4rem);
+        gap: var(--spacing-xs);
+        margin-top: clamp(var(--spacing-xs), 0.7vh, var(--spacing-sm));
     }
 
     .agitatorPauseButton {
@@ -647,7 +664,8 @@
     }
 
     .agitatorFooter {
-        padding-top: 0.35rem;
+        margin-top: 0;
+        padding-top: clamp(var(--spacing-xs), 0.7vh, var(--spacing-sm));
     }
 
     .manualWaterControls,

--- a/src/containers/Production/Production.test.tsx
+++ b/src/containers/Production/Production.test.tsx
@@ -122,15 +122,21 @@ describe('Production agitator controller integration', () => {
         expect(AgitatorSettingsRepository.update).not.toHaveBeenCalled();
     });
 
-    it('places one interval indicator beside the interval switch without inventing progress', async () => {
+    it('places one interval indicator between the interval header and time controls without inventing progress', async () => {
         const {container} = renderProduction();
         await screen.findByRole('switch', {name: 'Intervallbetrieb'});
 
-        const actions = container.querySelector('.agitatorAutomaticActions');
-        expect(actions).toContainElement(screen.getByRole('progressbar', {name: 'Intervallfortschritt'}));
-        expect(actions).toContainElement(screen.getByRole('switch', {name: 'Intervallbetrieb'}));
+        const header = container.querySelector('.agitatorAutomaticHeader') as HTMLElement;
+        const progressRow = container.querySelector('.agitatorIntervalProgressRow') as HTMLElement;
+        const timeControls = container.querySelector('.intervalTimeControls') as HTMLElement;
+        expect(header).toContainElement(screen.getByRole('switch', {name: 'Intervallbetrieb'}));
+        expect(header).not.toContainElement(screen.getByRole('progressbar', {name: 'Intervallfortschritt'}));
+        expect(progressRow).toContainElement(screen.getByRole('progressbar', {name: 'Intervallfortschritt'}));
+        expect(header.compareDocumentPosition(progressRow) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+        expect(progressRow.compareDocumentPosition(timeControls) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
         expect(screen.getAllByRole('progressbar')).toHaveLength(1);
         expect(screen.getByRole('progressbar')).toHaveAttribute('aria-valuenow', '0');
+        expect(screen.queryByText('Beim Heizen durchgehend, sonst im Intervall')).not.toBeInTheDocument();
     });
 
     it('uses controller-owned interval progress only while an interval phase is active', async () => {

--- a/src/containers/Production/Production.tsx
+++ b/src/containers/Production/Production.tsx
@@ -804,18 +804,15 @@ export class Production extends React.Component<ProductionProps, ProductionState
                         </div>
                         <div className={`intervalSettings agitatorAutomaticSettings ${displayedAgitatorMode === 'AUTOMATIC' ? 'is-active' : ''}`} aria-labelledby="interval-settings-title">
                             <div className="agitatorAutomaticHeader">
-                                <div>
-                                    <h5 id="interval-settings-title">Intervallbetrieb</h5>
-                                    <p>Beim Heizen durchgehend, sonst im Intervall</p>
-                                </div>
-                                <div className="agitatorAutomaticActions">
-                                    <AgitatorIntervalProgress active={intervalProgressActive} paused={agitatorRuntime?.paused ?? false}
-                                        progress={agitatorRuntime?.intervalProgressPercent} />
-                                    <Switch className="productionSwitch" onChange={(checked) => this.toggleAgitatorMode('AUTOMATIC', checked)}
-                                        checked={displayedAgitatorMode === 'AUTOMATIC'} height={24} width={44} handleDiameter={18}
-                                        checkedIcon={false} uncheckedIcon={false} disabled={settingsDisabled || !agitatorConfig}
-                                        aria-label="Intervallbetrieb" />
-                                </div>
+                                <h5 id="interval-settings-title">Intervallbetrieb</h5>
+                                <Switch className="productionSwitch" onChange={(checked) => this.toggleAgitatorMode('AUTOMATIC', checked)}
+                                    checked={displayedAgitatorMode === 'AUTOMATIC'} height={24} width={44} handleDiameter={18}
+                                    checkedIcon={false} uncheckedIcon={false} disabled={settingsDisabled || !agitatorConfig}
+                                    aria-label="Intervallbetrieb" />
+                            </div>
+                            <div className="agitatorIntervalProgressRow">
+                                <AgitatorIntervalProgress active={intervalProgressActive} paused={agitatorRuntime?.paused ?? false}
+                                    progress={agitatorRuntime?.intervalProgressPercent} />
                             </div>
                             <div className="intervalTimeControls">
                                 <div className="intervalTimeControl" data-testid="running-minutes-stepper">


### PR DESCRIPTION
### Motivation
- Separate the interval progress indicator from the interval header to improve visual hierarchy and responsive layout.
- Normalize spacing and grouping for agitator settings to make compact and mobile layouts more consistent.
- Update tests to reflect the DOM reordering and ensure the progress indicator is only shown/used in appropriate runtime states.

### Description
- Move the interval progress out of `.agitatorAutomaticHeader` into a new `.agitatorIntervalProgressRow` and update the JSX in `Production.tsx` to render the progress row between the header and time controls.
- Add `.agitatorSettingsGroup`, convert `.agitatorAutomaticSettings` to a column flex layout, and refine several spacing, gap and padding variables in `Production.css` for consistent compact styling.
- Remove the static header paragraph ("Beim Heizen durchgehend, sonst im Intervall") and adjust header alignment and related CSS such as `.agitatorSpeedControl` and `.intervalTimeControls`.
- Update `Production.test.tsx` to rename the test and change assertions to verify the progress element's new container and document order, and to assert the removed paragraph is no longer present.

### Testing
- Ran the production agitator unit test file with `yarn test src/containers/Production/Production.test.tsx` and the updated test suite succeeded.
- Ran the project tests with `jest` targeting the production agitator suite and all modified assertions passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a95c8427a6c832f93e4a68707ad13f2)