### PR TITLE
Add operational settings and heater-safety flow; surface heater alarm and push severity

### DIFF
--- a/docs/codex/compatibility/cross-repo-contracts.md
+++ b/docs/codex/compatibility/cross-repo-contracts.md
@@ -240,3 +240,9 @@ interface TemperatureSensorRealtimeState {
 ```
 
 `running` is the controller-reported heater on/off state, while `actualOutputOn` is agitator hardware feedback. An alarm payload replaces the complete alarm collection. Sensor `health` values are controller-owned and must not be synthesized by the UI; `current: null` means that no valid measurement exists, while numeric zero is valid. These snapshots are the sole UI source of truth for physical heater feedback, agitator output, alarms, and sensor health. After disconnect, received snapshots are stale/unknown; REST process availability remains independent. The controller sends a fresh sensor snapshot after connect/reconnect, so the UI clears the previous sensor snapshot during connection changes and does not add polling. `GET /Agitator/Status` continues only to initialize editable agitator configuration, not as a live-state fallback. Deployment and reconnect snapshot behavior **Needs verification** with Braumeister #109 and two real clients.
+
+## Controller operational settings, heater safety, and push severity
+
+Brauhaus2 #230/#231 consumes the confirmed controller contract at `GET /Settings`, `GET /Settings/{section}`, and full-replacement `PUT /Settings/{section}` for `waterFilling`, `audio`, `processSafety`, and `heaterSafety`. Field names and units are documented in `docs/codex/interfaces.md`. The controller response to each PUT is authoritative; a section update must not modify another section and the UI must not supply defaults.
+
+The controller additionally provides `GET /Safety/Heater` and `POST /Safety/Heater/Reset`. The realtime alarm snapshot additively supports `HEATER_STUCK_ON` alongside `EQUIPMENT_ALARM`. Push payload severity is backend-owned and may be `INFO`, `WARNING`, or `ALARM`; missing severity remains a supported legacy payload. These additions are backward compatible and must not be synthesized from legacy overheat state or notification content.

--- a/docs/codex/data-flow.md
+++ b/docs/codex/data-flow.md
@@ -96,3 +96,9 @@ Automatic water filling follows the same at-most-once-while-pending rule: anothe
 - When normalized process state becomes `FINISHED`, UI shows a finish dialog.
 - Confirming stops polling and creates a `FinishedBrew` with generated UUID, selected beer name/id, date, default metrics, state `FERMENTATION`, active `true`, and `brewValues` JSON from `dataCollector`.
 - It posts this through finished-brew repository via beer epics.
+
+## Operational settings and heater-safety flow
+
+Settings mount performs one `GET /Settings` for all four operational sections and a separate `GET /Safety/Heater` for the current safety latch. Each section owns a draft; only finite, non-empty numeric input can be submitted. Saving sends the complete selected section to `PUT /Settings/{section}` and replaces only that confirmed section with the response. There is no optimistic persistence and no redundant post-save GET.
+
+The heater-safety latch is reset only by `POST /Safety/Heater/Reset`; a failed request leaves the prior latch visible. Independently, `alarm-state-changed` remains the live global alarm source and an active `HEATER_STUCK_ON` snapshot blocks brew start. Sensor ID/health remain read-only values from the existing shared Socket.IO snapshot.

--- a/docs/codex/interfaces.md
+++ b/docs/codex/interfaces.md
@@ -122,3 +122,22 @@ These paths are consumed through the existing relative UI base URL `/api/control
 The exact events `heating-running-changed`, `agitator-state-changed`, `alarm-state-changed`, and `temperature-sensor-state-changed` use the existing shared connection. The temperature snapshot is `{ current: number | null, health: 'OK' | 'MISSING' | 'STALE' | 'INVALID_READING' | 'MULTIPLE_SENSORS_FOUND' | 'NOT_CONFIGURED', sensorId: string | null }`. Numeric zero is valid; `null` means that no valid reading exists. Alarm arrays replace rather than merge state. Socket disconnect makes received hardware state stale. The controller sends a fresh temperature snapshot to new and reconnected clients; end-to-end behavior on hardware **Needs verification**.
 
 The Production interval indicator is prepared to consume an optional controller-owned `intervalProgressPercent` (number, clamped by the UI to `0..100`) in `GET Agitator/Status.runtime` and `agitator-state-changed`. The currently confirmed controller contract does not provide a phase position, elapsed duration, or start timestamp. Until the controller supplies and resends this value on connect/reconnect, the UI deliberately renders a static, muted ring instead of starting a local timer. Adding and populating this field in Braumeister is **Needs verification**.
+
+## Operational settings and heater-safety contract (Brauhaus2 #230/#231)
+
+The controller owns all defaults and validation. The UI loads the complete snapshot with `GET /Settings`; no operational value is initialized from a UI default. `GET /Settings/{section}` remains available for `waterFilling`, `audio`, `processSafety`, and `heaterSafety`. A section is replaced with `PUT /Settings/{section}` using its complete payload, and the returned persisted section becomes confirmed UI state without a refetch.
+
+| Section | Complete fields and units |
+|---|---|
+| `waterFilling` | `pulsesPerLiter` (impulses/liter), `sensorStartDelaySeconds` (seconds) |
+| `audio` | `enabled` (boolean), `confirmationRepeatSeconds` (seconds), `alarmRepeatSeconds` (seconds) |
+| `processSafety` | `heatingTimeoutMinutes` (minutes), `confirmationTimeoutMinutes` (minutes); zero disables the respective time limit |
+| `heaterSafety` | `offGracePeriodSeconds` (seconds), `maxOffTemperatureRise` (degrees Celsius), `riseObservationWindowSeconds` (seconds) |
+
+Heater-safety state is loaded through `GET /Safety/Heater` and reset only through `POST /Safety/Heater/Reset`. Both return `{ state, latched }`; `state` is one of `DISARMED`, `HEATING`, `OVERSHOOT_GRACE`, `MONITORING`, `SUSPENDED`, or `HEATER_STUCK_ON`. Reset is offered only for `latched: true`, and the response replaces the displayed state.
+
+The complete `alarm-state-changed` snapshot may add the independent alarm type `HEATER_STUCK_ON`; it is never inferred from legacy overheat state. Existing `EQUIPMENT_ALARM` behavior is preserved. An active realtime `HEATER_STUCK_ON` blocks a normal brew start.
+
+Push payloads may add backend-owned `severity: 'INFO' | 'WARNING' | 'ALARM'`. The service worker preserves legacy payload behavior when severity is absent and uses browser-supported notification options to make `ALARM` more prominent. It does not infer severity.
+
+The Settings UI intentionally exposes none of the controller infrastructure fields: temperature tolerance/hysteresis, relay timing, buzzer, GPIO/pins/mode/warnings/debounce, host/port/threading, ALSA/player/sound paths, VAPID secrets, or subscription files. Temperature sensor ID is controller-discovered realtime diagnostic data and remains read-only.

--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -5,7 +5,7 @@
 // - keine Datenbankantworten
 // - keine Build-Metadaten wie index.html, manifest.json, asset-manifest.json oder version.json
 // So bleiben Browser-/Server-Caches und bestehende Versionsmechanismen maßgeblich.
-const SERVICE_WORKER_VERSION = 'brauhaus-push-v2';
+const SERVICE_WORKER_VERSION = 'brauhaus-push-v3';
 
 self.addEventListener('install', function() {
   console.debug('[ServiceWorker] Installed', SERVICE_WORKER_VERSION);
@@ -54,6 +54,22 @@ function getPayloadData(payload) {
   return {};
 }
 
+function getNotificationSeverity(payload) {
+  const supportedSeverities = ['INFO', 'WARNING', 'ALARM'];
+  return supportedSeverities.includes(payload && payload.severity) ? payload.severity : undefined;
+}
+
+function applySeverityOptions(options, severity) {
+  if (severity === 'WARNING') {
+    options.vibrate = [200, 100, 200];
+  }
+
+  if (severity === 'ALARM') {
+    options.requireInteraction = true;
+    options.vibrate = [300, 100, 300, 100, 600];
+  }
+}
+
 function sameOriginUrl(url) {
   try {
     const target = new URL(url || '/', self.location.origin);
@@ -69,6 +85,7 @@ function sameOriginUrl(url) {
 self.addEventListener('push', function(event) {
   console.debug('[ServiceWorker] Push event received');
   const payload = parsePushPayload(event);
+  const severity = getNotificationSeverity(payload);
   const title = typeof payload.title === 'string' && payload.title ? payload.title : DEFAULT_NOTIFICATION.title;
   const options = {
     body: typeof payload.body === 'string' ? payload.body : DEFAULT_NOTIFICATION.body,
@@ -78,9 +95,11 @@ self.addEventListener('push', function(event) {
     renotify: true,
     data: Object.assign({}, getPayloadData(payload), {
       url: sameOriginUrl(payload.url),
+      severity: severity,
       serviceWorkerVersion: SERVICE_WORKER_VERSION
     })
   };
+  applySeverityOptions(options, severity);
 
   const notificationPromise = self.registration.showNotification(title, options)
     .catch(function(error) {

--- a/src/containers/MainView/Header/Header.test.tsx
+++ b/src/containers/MainView/Header/Header.test.tsx
@@ -74,6 +74,13 @@ describe('Header navigation', () => {
         expect(screen.getByText('Aufheizen')).toBeInTheDocument();
     });
 
+    it('shows the heater safety alarm as a distinct high-priority status', (): void => {
+        const realtimeState = {alarms: [{type: AlarmType.HEATER_STUCK_ON, active: true}], alarmsReceived: true};
+        render(<Header setViewState={jest.fn()} currentView={Views.PRODUCTION} removeAllMessages={jest.fn()} backendStatus={true} messages={['Bereit']} socketConnected={true} realtimeState={realtimeState} />);
+        expect(screen.getByRole('alert')).toHaveTextContent('HEIZUNGSALARM – Anlage prüfen');
+        expect(screen.queryByText('Bereit')).not.toBeInTheDocument();
+    });
+
     it('shows translated sensor failures globally and removes the warning after recovery', () => {
         const props = {setViewState: jest.fn(), currentView: Views.SETTINGS, removeAllMessages: jest.fn(), backendStatus: true, messages: []};
         const {rerender} = render(<Header {...props} socketConnected={true} realtimeState={{...healthyRealtime, temperatureSensor: {current: null, health: 'MULTIPLE_SENSORS_FOUND', sensorId: null}}} />);

--- a/src/containers/MainView/Header/Header.tsx
+++ b/src/containers/MainView/Header/Header.tsx
@@ -5,7 +5,7 @@ import StatusDisplay from './StatusDisplay';
 import DashboardIcon from '@mui/icons-material/Dashboard';
 import PowerSettingsNewIcon from '@mui/icons-material/PowerSettingsNew';
 import {BrewingStatus} from '../../../model/brewingStatus.types';
-import {equipmentAlarmDisplay, isEquipmentAlarmActive} from '../../../utils/brewingStatus/alarmDisplay';
+import {equipmentAlarmDisplay, heaterStuckOnAlarmDisplay, isEquipmentAlarmActive, isHeaterStuckOnAlarmActive} from '../../../utils/brewingStatus/alarmDisplay';
 import {isProcessActive} from '../../../utils/brewingStatus/selectors';
 import {getUiMode} from '../../../utils/uiMode';
 import {getNavigationViews} from '../../../utils/viewConfig';
@@ -112,7 +112,10 @@ export class Header extends React.Component<HeaderProps, HeaderState> {
 
     render() {
        const { messages = [] , removeAllMessages, backendStatus, brewingStatus } = this.props; // Default-Wert für messages ist ein leeres Array
-       const equipmentAlarmText = isEquipmentAlarmActive(getAlarmSnapshot(this.props.realtimeState, this.props.socketConnected)) ? equipmentAlarmDisplay.headerText : undefined;
+       const alarms = getAlarmSnapshot(this.props.realtimeState, this.props.socketConnected);
+       const alarmText = isHeaterStuckOnAlarmActive(alarms)
+           ? heaterStuckOnAlarmDisplay.headerText
+           : isEquipmentAlarmActive(alarms) ? equipmentAlarmDisplay.headerText : undefined;
        const temperatureSensor = this.props.realtimeState?.temperatureSensor;
        const sensorWarning = !this.props.socketConnected || temperatureSensor?.health !== 'OK'
            ? `⚠ Temperatursensor: ${getTemperatureSensorMessage(temperatureSensor)}`
@@ -206,7 +209,7 @@ export class Header extends React.Component<HeaderProps, HeaderState> {
                 </div>
                 <div className="header-status">
                   <div className="status-display-wrapper">
-                    <StatusDisplay backendStatus={backendStatus} messages={messages} priorityMessage={equipmentAlarmText ?? sensorWarning} disableScrollAnimation={true} removeAllMessages={removeAllMessages}/>
+                    <StatusDisplay backendStatus={backendStatus} messages={messages} priorityMessage={alarmText ?? sensorWarning} disableScrollAnimation={true} removeAllMessages={removeAllMessages}/>
                   </div>
                   <div className="time">
                     <span>{this.state.currentDate}</span>

--- a/src/containers/Production/Production.test.tsx
+++ b/src/containers/Production/Production.test.tsx
@@ -894,6 +894,17 @@ describe('Production equipment alarm dialog', () => {
         rerender(<Production {...props} socketConnected={true} realtimeState={inactiveRealtime} />);
         expect(screen.queryByRole('dialog', {name: 'Anlagenalarm'})).not.toBeInTheDocument();
     });
+
+    it('shows HEATER_STUCK_ON distinctly and blocks brewing start while active', () => {
+        const heaterAlarmRealtime = {alarms: [{type: AlarmType.HEATER_STUCK_ON, active: true}], alarmsReceived: true};
+        const {props} = renderProduction({brewingStatus: createBrewingStatus(ProcessState.IDLE), socketConnected: true, realtimeState: heaterAlarmRealtime});
+
+        expect(screen.getByRole('dialog', {name: 'Heizungs-Sicherheitsalarm'})).toHaveTextContent('Heizung scheint nach dem Abschalten');
+        expect(screen.getByRole('button', {name: 'Brauvorgang starten'})).toBeDisabled();
+        expect(screen.getByText(/aktiven Heizungs-Sicherheitsalarms/)).toBeInTheDocument();
+        fireEvent.click(screen.getByRole('button', {name: 'Brauvorgang starten'}));
+        expect(props.sendBrewingData).not.toHaveBeenCalled();
+    });
 });
 
 

--- a/src/containers/Production/Production.tsx
+++ b/src/containers/Production/Production.tsx
@@ -33,7 +33,7 @@ import {completeWaterFill, createInitialRecipeWaterFillStatus, failWaterFill, in
 import {ProductionDialogs} from "./components/ProductionDialogs";
 import {ProductionTemperatureTimeline} from "./TemperatureTimeline/ProductionTemperatureTimeline";
 import {getDisplayedWaterLiters as selectDisplayedWaterLiters, getWaterLabel, getWaterTargetLiters, isRecipeWaterButtonDisabled as selectRecipeWaterButtonDisabled, isWaterFillingActive as selectWaterFillingActive, shouldIncludeSpargeAfterMashingOut as selectShouldIncludeSpargeAfterMashingOut, sanitizeLiters} from "./waterFill/recipeWaterFillSelectors";
-import {equipmentAlarmDisplay, isEquipmentAlarmActive} from '../../utils/brewingStatus/alarmDisplay';
+import {equipmentAlarmDisplay, heaterStuckOnAlarmDisplay, isEquipmentAlarmActive, isHeaterStuckOnAlarmActive} from '../../utils/brewingStatus/alarmDisplay';
 import {getConfirmationRequestViewModel} from '../../utils/brewingStatus/selectors';
 import {ConfirmStates} from '../../enums/eConfirmStates';
 import {AgitatorConfig, AgitatorMode, AgitatorRuntimeStatus} from '../../model/Agitator';
@@ -193,7 +193,10 @@ export class Production extends React.Component<ProductionProps, ProductionState
             this.loadAgitatorStatus();
         }
 
-        if (isEquipmentAlarmActive(getAlarmSnapshot(prevProps.realtimeState, prevProps.socketConnected)) && !isEquipmentAlarmActive(getAlarmSnapshot(this.props.realtimeState, this.props.socketConnected))) {
+        const previousAlarms = getAlarmSnapshot(prevProps.realtimeState, prevProps.socketConnected);
+        const currentAlarms = getAlarmSnapshot(this.props.realtimeState, this.props.socketConnected);
+        if ((isEquipmentAlarmActive(previousAlarms) && !isEquipmentAlarmActive(currentAlarms))
+            || (isHeaterStuckOnAlarmActive(previousAlarms) && !isHeaterStuckOnAlarmActive(currentAlarms))) {
             this.setState({equipmentAlarmDismissed: false});
         }
 
@@ -685,7 +688,8 @@ export class Production extends React.Component<ProductionProps, ProductionState
 
     isStartButtonDisabled = (): boolean => {
         const {selectedBeer} = this.props;
-        return isUndefined(selectedBeer) || !this.isControllerAvailable() || !isTemperatureSensorReady(this.props.realtimeState?.temperatureSensor, this.props.socketConnected) || this.state.brewingIsRunning || this.isBrewingStartRequestPending || !this.isControlBrewingStartAvailable();
+        const heaterSafetyAlarmActive = isHeaterStuckOnAlarmActive(getAlarmSnapshot(this.props.realtimeState, this.props.socketConnected));
+        return isUndefined(selectedBeer) || !this.isControllerAvailable() || !isTemperatureSensorReady(this.props.realtimeState?.temperatureSensor, this.props.socketConnected) || heaterSafetyAlarmActive || this.state.brewingIsRunning || this.isBrewingStartRequestPending || !this.isControlBrewingStartAvailable();
     }
 
     startBrewing = (): void => {
@@ -943,13 +947,20 @@ export class Production extends React.Component<ProductionProps, ProductionState
             return null;
         }
         const sensorReady = isTemperatureSensorReady(this.props.realtimeState?.temperatureSensor, this.props.socketConnected);
-        return <ProcessList displayMode="current" selectedBeer={selectedBeer} currentStepIndex={brewingStatus?.currentStep?.index ?? 0} currentStep={brewingStatus?.currentStep} brewingStatus={brewingStatus} remainingSeconds={this.state.displayedRemainingSeconds} confirmationPending={this.props.isConfirmPending} confirmationError={this.props.confirmError} onConfirmWaiting={this.confirmCurrentWaitingState} hopReminderName={this.state.showHopsDialog ? this.state.hopName : undefined} onCompleteHopReminder={this.confirmHopDialog} onStartBrewing={this.startBrewing} isStartBrewingDisabled={this.isStartButtonDisabled()} startBrewingWarning={!sensorReady ? `Brauvorgang kann nicht gestartet werden: ${getTemperatureSensorMessage(this.props.realtimeState?.temperatureSensor)}.` : undefined} />;
+        const heaterSafetyAlarmActive = isHeaterStuckOnAlarmActive(getAlarmSnapshot(this.props.realtimeState, this.props.socketConnected));
+        const startWarning = heaterSafetyAlarmActive
+            ? 'Brauvorgang kann wegen eines aktiven Heizungs-Sicherheitsalarms nicht gestartet werden.'
+            : !sensorReady ? `Brauvorgang kann nicht gestartet werden: ${getTemperatureSensorMessage(this.props.realtimeState?.temperatureSensor)}.` : undefined;
+        return <ProcessList displayMode="current" selectedBeer={selectedBeer} currentStepIndex={brewingStatus?.currentStep?.index ?? 0} currentStep={brewingStatus?.currentStep} brewingStatus={brewingStatus} remainingSeconds={this.state.displayedRemainingSeconds} confirmationPending={this.props.isConfirmPending} confirmationError={this.props.confirmError} onConfirmWaiting={this.confirmCurrentWaitingState} hopReminderName={this.state.showHopsDialog ? this.state.hopName : undefined} onCompleteHopReminder={this.confirmHopDialog} onStartBrewing={this.startBrewing} isStartBrewingDisabled={this.isStartButtonDisabled()} startBrewingWarning={startWarning} />;
     }
 
 
     render() {
         const {showFinishDialog} = this.state;
-        const equipmentAlarmActive = isEquipmentAlarmActive(getAlarmSnapshot(this.props.realtimeState, this.props.socketConnected));
+        const alarms = getAlarmSnapshot(this.props.realtimeState, this.props.socketConnected);
+        const heaterSafetyAlarmActive = isHeaterStuckOnAlarmActive(alarms);
+        const equipmentAlarmActive = isEquipmentAlarmActive(alarms);
+        const activeAlarmDisplay = heaterSafetyAlarmActive ? heaterStuckOnAlarmDisplay : equipmentAlarmDisplay;
         return (
             <div className="containerProduction ">
                 {this.props.isBrewingStatusStale && <div role="alert" className="production-stale-status">Controller nicht erreichbar – angezeigter Braustatus ist veraltet.</div>}
@@ -959,9 +970,9 @@ export class Production extends React.Component<ProductionProps, ProductionState
                     onConfirmFinish={this.confirmFinishDialog}
                     isSavingFinishedBrew={this.props.isAddingFinishedBrew}
                     finishedBrewSaveError={this.props.addFinishedBrewError}
-                    showEquipmentAlarmDialog={equipmentAlarmActive && !this.state.equipmentAlarmDismissed}
-                    equipmentAlarmTitle={equipmentAlarmDisplay.title}
-                    equipmentAlarmMessage={equipmentAlarmDisplay.message}
+                    showEquipmentAlarmDialog={(heaterSafetyAlarmActive || equipmentAlarmActive) && !this.state.equipmentAlarmDismissed}
+                    equipmentAlarmTitle={activeAlarmDisplay.title}
+                    equipmentAlarmMessage={activeAlarmDisplay.message}
                     onDismissEquipmentAlarm={() => this.setState({equipmentAlarmDismissed: true})}
                 />
 

--- a/src/containers/Settings/SettingsPage.connect.ts
+++ b/src/containers/Settings/SettingsPage.connect.ts
@@ -7,6 +7,8 @@ const mapStateToProps = (state: any) => ({
     theme: state.applicationReducer.theme as ThemeName,
     debug: state.applicationReducer.debug as boolean,
     agitatorDefaultsSnapshot: state.productionReducer.agitatorDefaults,
+    temperatureSensor: state.productionReducer.realtimeState.temperatureSensor,
+    socketConnected: state.productionReducer.socketConnection.connected,
 });
 
 const mapDispatchToProps = (dispatch: any) => ({

--- a/src/containers/Settings/SettingsPage.css
+++ b/src/containers/Settings/SettingsPage.css
@@ -125,3 +125,20 @@
 }
 .settings-warning .settings-secondary { display: block; margin-top: var(--spacing-sm); }
 @media (max-width: 600px) { .agitator-default-fields { grid-template-columns: minmax(0, 1fr); } }
+
+.operational-fields { display: grid; gap: var(--spacing-md); padding-top: var(--spacing-md); border-top: 1px solid var(--color-border-soft); }
+.operational-field { display: grid; gap: 4px; }
+.operational-input-row { display: flex; align-items: center; gap: var(--spacing-sm); }
+.operational-input-row input { box-sizing: border-box; width: 9rem; min-height: var(--control-height-compact); padding: var(--spacing-xs) var(--spacing-sm); color: var(--color-text); background: var(--color-surface-strong); border: 1px solid var(--color-border); border-radius: var(--border-radius-medium); font: inherit; }
+.operational-input-row input:focus { outline: 2px solid var(--color-primary); outline-offset: 1px; }
+.operational-input-row input:disabled { color: var(--color-disabled-text); background: var(--color-disabled-bg); }
+.safety-card { border-color: var(--color-warning); }
+.advanced-card { background: var(--color-panel-contrast); }
+.advanced-card h3 { margin: var(--spacing-md) 0 var(--spacing-sm); color: var(--color-text-secondary); }
+.heater-safety-status { display: flex; flex-wrap: wrap; align-items: center; gap: var(--spacing-md); margin-top: var(--spacing-md); padding: var(--spacing-sm); background: var(--color-panel-contrast); border-radius: var(--border-radius-medium); }
+.heater-safety-status.critical { color: var(--color-error); background: var(--color-error-subtle); border: 1px solid var(--color-error); }
+.diagnosis-list { display: grid; gap: var(--spacing-sm); margin: var(--spacing-md) 0 0; }
+.diagnosis-list div { display: grid; grid-template-columns: minmax(7rem, .4fr) 1fr; gap: var(--spacing-md); padding-top: var(--spacing-sm); border-top: 1px solid var(--color-border-soft); }
+.diagnosis-list dt { color: var(--color-text-secondary); }
+.diagnosis-list dd { margin: 0; font-weight: 600; overflow-wrap: anywhere; }
+@media (max-width: 600px) { .operational-input-row input { width: min(100%, 12rem); } .diagnosis-list div { grid-template-columns: 1fr; gap: 2px; } }

--- a/src/containers/Settings/SettingsPage.test.tsx
+++ b/src/containers/Settings/SettingsPage.test.tsx
@@ -5,9 +5,13 @@ import { AudioRepository } from '../../repositorys/AudioRepository';
 import { SoundType } from '../../enums/eSoundType';
 import {AgitatorSettingsRepository} from '../../repositorys/AgitatorSettingsRepository';
 import {PushService} from '../../utils/pushService';
+import {OperationalSettingsRepository} from '../../repositorys/OperationalSettingsRepository';
+import {HeaterSafetyRepository} from '../../repositorys/HeaterSafetyRepository';
 
 jest.mock('../../repositorys/AudioRepository');
 jest.mock('../../repositorys/AgitatorSettingsRepository');
+jest.mock('../../repositorys/OperationalSettingsRepository');
+jest.mock('../../repositorys/HeaterSafetyRepository');
 jest.mock('../../utils/pushService', () => ({
     isPushSupported: jest.fn(() => true),
     getPermissionState: jest.fn(() => 'granted'),
@@ -23,6 +27,21 @@ const mockedTestSound = AudioRepository.testSound as jest.MockedFunction<typeof 
 const mockedGetAgitatorSettings = AgitatorSettingsRepository.get as jest.MockedFunction<typeof AgitatorSettingsRepository.get>;
 const mockedUpdateAgitatorSettings = AgitatorSettingsRepository.update as jest.MockedFunction<typeof AgitatorSettingsRepository.update>;
 const mockedPushService = PushService as jest.Mocked<typeof PushService>;
+const mockedOperational = OperationalSettingsRepository as jest.Mocked<typeof OperationalSettingsRepository>;
+const mockedHeaterSafety = HeaterSafetyRepository as jest.Mocked<typeof HeaterSafetyRepository>;
+const operationalSettings = {
+    waterFilling: {pulsesPerLiter: 411, sensorStartDelaySeconds: 0.7},
+    audio: {enabled: true, confirmationRepeatSeconds: 12, alarmRepeatSeconds: 4},
+    processSafety: {heatingTimeoutMinutes: 55, confirmationTimeoutMinutes: 0},
+    heaterSafety: {offGracePeriodSeconds: 121, maxOffTemperatureRise: 2.2, riseObservationWindowSeconds: 31},
+};
+
+beforeEach(() => {
+    mockedOperational.get.mockResolvedValue(operationalSettings);
+    mockedOperational.updateSection.mockImplementation(async (_section, settings) => settings as any);
+    mockedHeaterSafety.get.mockResolvedValue({state: 'MONITORING', latched: false});
+    mockedHeaterSafety.reset.mockResolvedValue({state: 'DISARMED', latched: false});
+});
 
 const deferred = <T,>() => {
     let resolve!: (value: T) => void;
@@ -232,5 +251,79 @@ describe('Settings async lifecycle', () => {
         const request = deferred<void>();
         mockedTestSound.mockReturnValue(request.promise);
         await expectNoPostUnmountState(() => page!.handleSoundTest(SoundType.ALARM), () => request.resolve());
+    });
+});
+
+describe('Operational settings', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockedOperational.get.mockResolvedValue(operationalSettings);
+        mockedOperational.updateSection.mockImplementation(async (_section, settings) => settings as any);
+        mockedHeaterSafety.get.mockResolvedValue({state: 'MONITORING', latched: false});
+        mockedGetAgitatorSettings.mockResolvedValue({speed: 32, intervalOnMinutes: 2.5, intervalOffMinutes: 7});
+        mockedPushService.getSubscription.mockResolvedValue(null);
+        mockedTestSound.mockResolvedValue();
+    });
+
+    it('loads one complete backend snapshot and displays all sections without frontend defaults', async () => {
+        renderSettings(false);
+        expect(mockedOperational.get).toHaveBeenCalledTimes(1);
+        expect(await screen.findByDisplayValue('411')).toBeInTheDocument();
+        ['0.7', '12', '4', '55', '121', '2.2', '31'].forEach((value) => expect(screen.getByDisplayValue(value)).toBeInTheDocument());
+        expect(screen.getByLabelText('Lautsprecher')).toBeChecked();
+    });
+
+    it('sends a complete water section and adopts the confirmed response only', async () => {
+        mockedOperational.updateSection.mockResolvedValueOnce({pulsesPerLiter: 500, sensorStartDelaySeconds: 1.25});
+        renderSettings(false);
+        fireEvent.change(await screen.findByLabelText('Impulse pro Liter'), {target: {value: '480'}});
+        fireEvent.change(screen.getByLabelText('Startverzögerung Impulszählung'), {target: {value: '1'}});
+        fireEvent.click(screen.getAllByRole('button', {name: 'Speichern'})[1]);
+        await waitFor(() => expect(mockedOperational.updateSection).toHaveBeenCalledWith('waterFilling', {pulsesPerLiter: 480, sensorStartDelaySeconds: 1}));
+        expect(await screen.findByDisplayValue('500')).toBeInTheDocument();
+        expect(screen.getByDisplayValue('1.25')).toBeInTheDocument();
+        expect(screen.getByDisplayValue('12')).toBeInTheDocument();
+    });
+
+    it('sends complete audio, heater-safety, and process-safety sections independently', async () => {
+        renderSettings(false);
+        await screen.findByDisplayValue('411');
+        fireEvent.click(screen.getByLabelText('Lautsprecher'));
+        fireEvent.click(screen.getAllByRole('button', {name: 'Speichern'})[2]);
+        await waitFor(() => expect(mockedOperational.updateSection).toHaveBeenCalledWith('audio', {enabled: false, confirmationRepeatSeconds: 12, alarmRepeatSeconds: 4}));
+
+        fireEvent.change(screen.getByLabelText('Erlaubter Temperaturanstieg'), {target: {value: '2.8'}});
+        fireEvent.click(screen.getAllByRole('button', {name: 'Speichern'})[3]);
+        await waitFor(() => expect(mockedOperational.updateSection).toHaveBeenCalledWith('heaterSafety', {offGracePeriodSeconds: 121, maxOffTemperatureRise: 2.8, riseObservationWindowSeconds: 31}));
+
+        fireEvent.change(screen.getByLabelText('Maximale Aufheizzeit'), {target: {value: '60'}});
+        fireEvent.click(screen.getAllByRole('button', {name: 'Speichern'})[4]);
+        await waitFor(() => expect(mockedOperational.updateSection).toHaveBeenCalledWith('processSafety', {heatingTimeoutMinutes: 60, confirmationTimeoutMinutes: 0}));
+    });
+
+    it('keeps other sections usable after a backend validation error', async () => {
+        mockedOperational.updateSection.mockRejectedValueOnce({response: {data: {error: {message: 'Backend-Validierung'}}}});
+        renderSettings(false);
+        await screen.findByDisplayValue('411');
+        fireEvent.click(screen.getAllByRole('button', {name: 'Speichern'})[1]);
+        expect(await screen.findByText('Backend-Validierung')).toBeInTheDocument();
+        expect(screen.getByLabelText('Lautsprecher')).toBeEnabled();
+    });
+
+    it('renders the automatically managed sensor id read-only', async () => {
+        render(<SettingsPage theme="default" setTheme={jest.fn()} debug={false} setDebug={jest.fn()} socketConnected temperatureSensor={{current: 20, health: 'OK', sensorId: '28-abcdef'}}/>);
+        expect(await screen.findByText('28-abcdef')).toBeInTheDocument();
+        expect(screen.queryByDisplayValue('28-abcdef')).not.toBeInTheDocument();
+    });
+
+    it('offers reset only while latched and keeps the alarm after a failed reset', async () => {
+        mockedHeaterSafety.get.mockResolvedValueOnce({state: 'HEATER_STUCK_ON', latched: true});
+        mockedHeaterSafety.reset.mockRejectedValueOnce(new Error('offline'));
+        renderSettings(false);
+        const reset = await screen.findByRole('button', {name: 'Sicherheitsalarm zurücksetzen'});
+        fireEvent.click(reset);
+        expect(await screen.findByText('Sicherheitsalarm konnte nicht zurückgesetzt werden.')).toBeInTheDocument();
+        expect(screen.getByText(/HEATER_STUCK_ON/)).toBeInTheDocument();
+        expect(reset).toBeEnabled();
     });
 });

--- a/src/containers/Settings/SettingsPage.tsx
+++ b/src/containers/Settings/SettingsPage.tsx
@@ -10,9 +10,19 @@ import PaletteOutlinedIcon from '@mui/icons-material/PaletteOutlined';
 import PrecisionManufacturingOutlinedIcon from '@mui/icons-material/PrecisionManufacturingOutlined';
 import NotificationsNoneOutlinedIcon from '@mui/icons-material/NotificationsNoneOutlined';
 import TuneOutlinedIcon from '@mui/icons-material/TuneOutlined';
+import WaterDropOutlinedIcon from '@mui/icons-material/WaterDropOutlined';
+import VolumeUpOutlinedIcon from '@mui/icons-material/VolumeUpOutlined';
+import HealthAndSafetyOutlinedIcon from '@mui/icons-material/HealthAndSafetyOutlined';
+import SensorsOutlinedIcon from '@mui/icons-material/SensorsOutlined';
 import {AgitatorSettings} from '../../model/AgitatorSettings';
 import {AgitatorSettingsRepository} from '../../repositorys/AgitatorSettingsRepository';
 import '../../components/Controlls/QuantityPicker/QuantityPicker.css';
+import {OperationalSettings, OperationalSettingsSection} from '../../model/OperationalSettings';
+import {HeaterSafetyState} from '../../model/HeaterSafetyState';
+import {OperationalSettingsRepository} from '../../repositorys/OperationalSettingsRepository';
+import {HeaterSafetyRepository} from '../../repositorys/HeaterSafetyRepository';
+import {TemperatureSensorRealtimeState} from '../../model/RealtimeControllerState';
+import {getTemperatureSensorMessage} from '../../utils/temperatureSensor';
 
 interface SettingsPageProps {
     theme: ThemeName;
@@ -20,6 +30,8 @@ interface SettingsPageProps {
     debug: boolean;
     setDebug: (debug: boolean) => void;
     agitatorDefaultsSnapshot?: AgitatorSettings;
+    temperatureSensor?: TemperatureSensorRealtimeState;
+    socketConnected?: boolean;
 }
 
 interface SettingsPageState {
@@ -40,6 +52,16 @@ interface SettingsPageState {
     agitatorLoading: boolean;
     agitatorSaving: boolean;
     agitatorError: string | null;
+    operationalSettings?: OperationalSettings;
+    operationalDrafts?: Record<OperationalSettingsSection, Record<string, string | boolean>>;
+    operationalLoading: boolean;
+    sectionSaving: OperationalSettingsSection | null;
+    operationalError: string | null;
+    sectionErrors: Partial<Record<OperationalSettingsSection, string>>;
+    heaterSafety?: HeaterSafetyState;
+    heaterSafetyLoading: boolean;
+    heaterSafetyResetting: boolean;
+    heaterSafetyError: string | null;
 }
 
 export class SettingsPage extends React.Component<SettingsPageProps, SettingsPageState> {
@@ -64,6 +86,16 @@ export class SettingsPage extends React.Component<SettingsPageProps, SettingsPag
             agitatorLoading: true,
             agitatorSaving: false,
             agitatorError: null,
+            operationalSettings: undefined,
+            operationalDrafts: undefined,
+            operationalLoading: true,
+            sectionSaving: null,
+            operationalError: null,
+            sectionErrors: {},
+            heaterSafety: undefined,
+            heaterSafetyLoading: true,
+            heaterSafetyResetting: false,
+            heaterSafetyError: null,
         };
     }
 
@@ -80,6 +112,8 @@ export class SettingsPage extends React.Component<SettingsPageProps, SettingsPag
         this.isMountedComponent = true;
         this.refreshPushState();
         void this.loadAgitatorSettings();
+        void this.loadOperationalSettings();
+        void this.loadHeaterSafety();
     }
 
     componentWillUnmount() {
@@ -196,6 +230,100 @@ export class SettingsPage extends React.Component<SettingsPageProps, SettingsPag
         if (!Number.isFinite(current)) return;
         const next = Math.min(max, Math.max(min, current + delta));
         this.changeAgitatorDraft(field, String(next));
+    };
+
+    private operationalDraftsFor = (settings: OperationalSettings): SettingsPageState['operationalDrafts'] => ({
+        waterFilling: {
+            pulsesPerLiter: String(settings.waterFilling.pulsesPerLiter),
+            sensorStartDelaySeconds: String(settings.waterFilling.sensorStartDelaySeconds),
+        },
+        audio: {
+            enabled: settings.audio.enabled,
+            confirmationRepeatSeconds: String(settings.audio.confirmationRepeatSeconds),
+            alarmRepeatSeconds: String(settings.audio.alarmRepeatSeconds),
+        },
+        processSafety: {
+            heatingTimeoutMinutes: String(settings.processSafety.heatingTimeoutMinutes),
+            confirmationTimeoutMinutes: String(settings.processSafety.confirmationTimeoutMinutes),
+        },
+        heaterSafety: {
+            offGracePeriodSeconds: String(settings.heaterSafety.offGracePeriodSeconds),
+            maxOffTemperatureRise: String(settings.heaterSafety.maxOffTemperatureRise),
+            riseObservationWindowSeconds: String(settings.heaterSafety.riseObservationWindowSeconds),
+        },
+    });
+
+    loadOperationalSettings = async () => {
+        this.setState({operationalLoading: true, operationalError: null});
+        try {
+            const settings = await OperationalSettingsRepository.get();
+            if (this.isMountedComponent) this.setState({operationalSettings: settings, operationalDrafts: this.operationalDraftsFor(settings), operationalLoading: false});
+        } catch {
+            if (this.isMountedComponent) this.setState({operationalSettings: undefined, operationalDrafts: undefined, operationalLoading: false, operationalError: 'Betriebseinstellungen konnten nicht geladen werden.'});
+        }
+    };
+
+    loadHeaterSafety = async () => {
+        this.setState({heaterSafetyLoading: true, heaterSafetyError: null});
+        try {
+            const heaterSafety = await HeaterSafetyRepository.get();
+            if (this.isMountedComponent) this.setState({heaterSafety, heaterSafetyLoading: false});
+        } catch {
+            if (this.isMountedComponent) this.setState({heaterSafetyLoading: false, heaterSafetyError: 'Heater-Safety-Status konnte nicht geladen werden.'});
+        }
+    };
+
+    private formatApiError = (error: any, fallback: string): string => {
+        const data = error?.response?.data;
+        const message = data?.error?.message ?? data?.error ?? data?.message ?? data?.detail;
+        return typeof message === 'string' && message.trim() ? message : fallback;
+    };
+
+    changeOperationalDraft = (section: OperationalSettingsSection, field: string, value: string | boolean) => {
+        this.setState((state) => state.operationalDrafts ? ({
+            operationalDrafts: {...state.operationalDrafts, [section]: {...state.operationalDrafts[section], [field]: value}},
+            sectionErrors: {...state.sectionErrors, [section]: undefined},
+        }) : null);
+    };
+
+    private sectionPayload = (section: OperationalSettingsSection): OperationalSettings[OperationalSettingsSection] | null => {
+        const draft = this.state.operationalDrafts?.[section];
+        if (!draft) return null;
+        const payload: Record<string, number | boolean> = {};
+        for (const [field, value] of Object.entries(draft)) {
+            if (typeof value === 'boolean') payload[field] = value;
+            else if (!value.trim() || !Number.isFinite(Number(value))) return null;
+            else payload[field] = Number(value);
+        }
+        return payload as unknown as OperationalSettings[OperationalSettingsSection];
+    };
+
+    saveOperationalSection = async (section: OperationalSettingsSection) => {
+        const payload = this.sectionPayload(section);
+        if (!payload || this.state.sectionSaving) return;
+        this.setState({sectionSaving: section, sectionErrors: {...this.state.sectionErrors, [section]: undefined}});
+        try {
+            const confirmed = await OperationalSettingsRepository.updateSection(section, payload as any);
+            if (this.isMountedComponent) this.setState((state) => state.operationalSettings && state.operationalDrafts ? ({
+                operationalSettings: {...state.operationalSettings, [section]: confirmed},
+                operationalDrafts: {...state.operationalDrafts, [section]: this.operationalDraftsFor({...state.operationalSettings, [section]: confirmed} as OperationalSettings)![section]},
+                sectionSaving: null,
+                statusMessage: 'Betriebseinstellungen gespeichert.',
+            }) : ({sectionSaving: null}));
+        } catch (error) {
+            if (this.isMountedComponent) this.setState({sectionSaving: null, sectionErrors: {...this.state.sectionErrors, [section]: this.formatApiError(error, 'Einstellungen konnten nicht gespeichert werden.')}});
+        }
+    };
+
+    resetHeaterSafety = async () => {
+        if (!this.state.heaterSafety?.latched || this.state.heaterSafetyResetting) return;
+        this.setState({heaterSafetyResetting: true, heaterSafetyError: null});
+        try {
+            const heaterSafety = await HeaterSafetyRepository.reset();
+            if (this.isMountedComponent) this.setState({heaterSafety, heaterSafetyResetting: false, statusMessage: 'Heater-Sicherheitsalarm wurde zurückgesetzt.'});
+        } catch (error) {
+            if (this.isMountedComponent) this.setState({heaterSafetyResetting: false, heaterSafetyError: this.formatApiError(error, 'Sicherheitsalarm konnte nicht zurückgesetzt werden.')});
+        }
     };
 
     refreshPushState = async () => {
@@ -324,8 +452,25 @@ export class SettingsPage extends React.Component<SettingsPageProps, SettingsPag
         this.setState({ temperatureUnit: event.target.value as 'celsius' | 'fahrenheit' });
     };
 
+    private renderOperationalNumber = (section: OperationalSettingsSection, field: string, label: string, unit: string, description: string) => {
+        const value = this.state.operationalDrafts?.[section]?.[field];
+        return <label className="operational-field">
+            <span className="setting-label">{label}</span>
+            <span className="operational-input-row">
+                <input aria-label={label} type="number" step="any" value={typeof value === 'string' ? value : ''} disabled={this.state.sectionSaving === section} onChange={(event) => this.changeOperationalDraft(section, field, event.target.value)} />
+                {unit && <span>{unit}</span>}
+            </span>
+            <span className="setting-description">{description}</span>
+        </label>;
+    };
+
+    private renderSectionAction = (section: OperationalSettingsSection) => <>
+        {this.state.sectionErrors[section] && <p className="settings-error" role="alert">{this.state.sectionErrors[section]}</p>}
+        <div className="settings-actions"><button className="settings-primary" type="button" disabled={!this.sectionPayload(section) || this.state.sectionSaving !== null} onClick={() => this.saveOperationalSection(section)}>{this.state.sectionSaving === section ? 'Wird gespeichert…' : 'Speichern'}</button></div>
+    </>;
+
     render() {
-        const { theme, debug } = this.props;
+        const { theme, debug, temperatureSensor, socketConnected } = this.props;
         const { autoConnect, notificationsEnabled, temperatureUnit, statusMessage, pushSupported, pushSubscribed, pushLoading, pushError, pushPermission, soundPlaying, soundError, agitatorSettings, agitatorDraft, pendingAgitatorSnapshot, agitatorLoading, agitatorSaving, agitatorError } = this.state;
 
         return (
@@ -402,6 +547,63 @@ export class SettingsPage extends React.Component<SettingsPageProps, SettingsPag
                             {agitatorError && <p className="settings-error" role="alert">{agitatorError}</p>}
                         </div>}
                     </section>
+
+                    {this.state.operationalLoading && <section className="settings-card operational-loading" aria-live="polite"><p>Betriebseinstellungen werden geladen…</p></section>}
+                    {!this.state.operationalLoading && !this.state.operationalSettings && <section className="settings-card"><p className="settings-error" role="alert">{this.state.operationalError}</p><div className="settings-actions"><button className="settings-secondary" type="button" onClick={this.loadOperationalSettings}>Erneut versuchen</button></div></section>}
+                    {this.state.operationalSettings && this.state.operationalDrafts && <>
+                        <section className="settings-card">
+                            <div className="settings-card-header"><WaterDropOutlinedIcon aria-hidden="true"/><div><h2>Wasser</h2><p>Kalibrierung der automatischen Wasserfüllung.</p></div></div>
+                            <div className="operational-fields">
+                                {this.renderOperationalNumber('waterFilling', 'pulsesPerLiter', 'Impulse pro Liter', 'Impulse/L', 'Kalibrierwert des Durchflusssensors. Gibt an, wie viele Sensorimpulse einem Liter Wasser entsprechen.')}
+                            </div>
+                            {this.renderSectionAction('waterFilling')}
+                        </section>
+
+                        <section className="settings-card">
+                            <div className="settings-card-header"><VolumeUpOutlinedIcon aria-hidden="true"/><div><h2>Audio</h2><p>Persistente Signaltöne der Brausteuerung.</p></div></div>
+                            <div className="setting-row"><div className="setting-label-group"><label htmlFor="audio-enabled">Lautsprecher</label><span className="setting-description">Akustische Hinweise zentral ein- oder ausschalten.</span></div><label className="settings-toggle"><input id="audio-enabled" type="checkbox" checked={Boolean(this.state.operationalDrafts.audio.enabled)} disabled={this.state.sectionSaving === 'audio'} onChange={(event) => this.changeOperationalDraft('audio', 'enabled', event.target.checked)}/><span aria-hidden="true"/></label></div>
+                            <div className="operational-fields">
+                                {this.renderOperationalNumber('audio', 'confirmationRepeatSeconds', 'Bestätigung wiederholen alle', 's', 'Intervall für notwendige Benutzerbestätigungen.')}
+                                {this.renderOperationalNumber('audio', 'alarmRepeatSeconds', 'Alarm wiederholen alle', 's', 'Intervall für wiederholte Alarmtöne.')}
+                            </div>
+                            <div className="settings-actions"><button className="settings-secondary" type="button" disabled={soundPlaying !== null} onClick={() => this.handleSoundTest(SoundType.CONFIRMATION)}>{soundPlaying === SoundType.CONFIRMATION ? 'Wird abgespielt…' : 'Testton abspielen'}</button></div>
+                            {soundError && <p className="settings-error" role="alert">{soundError}</p>}
+                            {this.renderSectionAction('audio')}
+                        </section>
+
+                        <section className="settings-card safety-card">
+                            <div className="settings-card-header"><HealthAndSafetyOutlinedIcon aria-hidden="true"/><div><h2>Heizung / Sicherheit</h2><p>Safety-Erkennung nach dem Abschalten der Heizung – keine Temperaturregelung.</p></div></div>
+                            <div className="operational-fields">
+                                {this.renderOperationalNumber('heaterSafety', 'offGracePeriodSeconds', 'Nachlaufzeit nach Heizung AUS', 's', 'Zeitraum nach dem Abschalten, in dem ein weiterer Temperaturanstieg durch gespeicherte Wärme noch als normal gilt.')}
+                                {this.renderOperationalNumber('heaterSafety', 'maxOffTemperatureRise', 'Erlaubter Temperaturanstieg', '°C', 'Maximal erlaubter Temperaturanstieg gegenüber der Temperatur beim Abschalten der Heizung.')}
+                                {this.renderOperationalNumber('heaterSafety', 'riseObservationWindowSeconds', 'Beobachtungszeit', 's', 'Zeitraum, über den ein weiterer Temperaturanstieg bestätigt werden muss, bevor ein Safety-Alarm ausgelöst wird.')}
+                            </div>
+                            {this.renderSectionAction('heaterSafety')}
+                            <div className={`heater-safety-status ${this.state.heaterSafety?.latched ? 'critical' : ''}`}>
+                                <strong>Safety-Status:</strong> {this.state.heaterSafetyLoading ? 'Wird geladen…' : this.state.heaterSafety?.state ?? 'Nicht verfügbar'}
+                                {this.state.heaterSafety?.latched && <button className="settings-primary" type="button" disabled={this.state.heaterSafetyResetting} onClick={this.resetHeaterSafety}>{this.state.heaterSafetyResetting ? 'Wird zurückgesetzt…' : 'Sicherheitsalarm zurücksetzen'}</button>}
+                            </div>
+                            {this.state.heaterSafetyError && <p className="settings-error" role="alert">{this.state.heaterSafetyError}</p>}
+                        </section>
+
+                        <section className="settings-card advanced-card">
+                            <div className="settings-card-header"><TuneOutlinedIcon aria-hidden="true"/><div><h2>Erweitert</h2><p>Hardware- und Prozess-Safety-Werte für Service und Betrieb.</p></div></div>
+                            <h3>Wasserfüllung</h3><div className="operational-fields">
+                                {this.renderOperationalNumber('waterFilling', 'sensorStartDelaySeconds', 'Startverzögerung Impulszählung', 's', 'Verzögerung nach dem Öffnen des Wasserventils, bevor die Impulszählung beginnt. Dadurch werden Schaltimpulse des Ventils nicht als Wassermenge gezählt.')}
+                            </div>
+                            <h3>Prozess-Safety</h3><div className="operational-fields">
+                                {this.renderOperationalNumber('processSafety', 'heatingTimeoutMinutes', 'Maximale Aufheizzeit', 'min', 'Maximale Zeit, in der eine Zieltemperatur erreicht werden muss. 0 deaktiviert das Timeout.')}
+                                {this.renderOperationalNumber('processSafety', 'confirmationTimeoutMinutes', 'Maximale Wartezeit auf Bestätigung', 'min', 'Maximale Zeit für notwendige Benutzerbestätigungen während des Brauprozesses. 0 bedeutet keine Zeitbegrenzung.')}
+                            </div>
+                            {this.renderSectionAction('processSafety')}
+                            <p className="settings-warning">Die Startverzögerung gehört zur Wasser-Section und wird gemeinsam mit „Impulse pro Liter“ gespeichert.</p>
+                        </section>
+
+                        <section className="settings-card diagnosis-card">
+                            <div className="settings-card-header"><SensorsOutlinedIcon aria-hidden="true"/><div><h2>Diagnose</h2><p>Automatisch erkannter Temperatursensor (nur lesbar).</p></div></div>
+                            <dl className="diagnosis-list"><div><dt>Status</dt><dd>{socketConnected ? getTemperatureSensorMessage(temperatureSensor) : 'Controllerverbindung nicht aktiv'}</dd></div><div><dt>Sensor-ID</dt><dd>{temperatureSensor?.sensorId ?? 'Nicht verfügbar'}</dd></div></dl>
+                        </section>
+                    </>}
 
                     <section className="settings-card">
                         <div className="settings-card-header">
@@ -538,10 +740,6 @@ export class SettingsPage extends React.Component<SettingsPageProps, SettingsPag
                     </section>
                 </div>
 
-                <footer className="settings-footer">
-                    <button className="settings-primary" type="button" onClick={this.handleSave}>Einstellungen speichern</button>
-                    <p>Alle Änderungen lassen sich jederzeit anpassen.</p>
-                </footer>
             </main>
         );
     }

--- a/src/model/HeaterSafetyState.ts
+++ b/src/model/HeaterSafetyState.ts
@@ -1,0 +1,12 @@
+export type HeaterSafetyStatus =
+    | 'DISARMED'
+    | 'HEATING'
+    | 'OVERSHOOT_GRACE'
+    | 'MONITORING'
+    | 'SUSPENDED'
+    | 'HEATER_STUCK_ON';
+
+export interface HeaterSafetyState {
+    state: HeaterSafetyStatus;
+    latched: boolean;
+}

--- a/src/model/OperationalSettings.ts
+++ b/src/model/OperationalSettings.ts
@@ -1,0 +1,30 @@
+export interface WaterFillingSettings {
+    pulsesPerLiter: number;
+    sensorStartDelaySeconds: number;
+}
+
+export interface AudioSettings {
+    enabled: boolean;
+    confirmationRepeatSeconds: number;
+    alarmRepeatSeconds: number;
+}
+
+export interface ProcessSafetySettings {
+    heatingTimeoutMinutes: number;
+    confirmationTimeoutMinutes: number;
+}
+
+export interface HeaterSafetySettings {
+    offGracePeriodSeconds: number;
+    maxOffTemperatureRise: number;
+    riseObservationWindowSeconds: number;
+}
+
+export interface OperationalSettings {
+    waterFilling: WaterFillingSettings;
+    audio: AudioSettings;
+    processSafety: ProcessSafetySettings;
+    heaterSafety: HeaterSafetySettings;
+}
+
+export type OperationalSettingsSection = keyof OperationalSettings;

--- a/src/model/brewingStatus.types.ts
+++ b/src/model/brewingStatus.types.ts
@@ -42,7 +42,8 @@ export enum WaitingFor {
 export type WaitingState = WaitingFor | string;
 
 export enum AlarmType {
-    EQUIPMENT_ALARM = "EQUIPMENT_ALARM"
+    EQUIPMENT_ALARM = "EQUIPMENT_ALARM",
+    HEATER_STUCK_ON = "HEATER_STUCK_ON"
 }
 
 export type AlarmTypeValue = AlarmType | string;

--- a/src/repositorys/HeaterSafetyRepository.test.ts
+++ b/src/repositorys/HeaterSafetyRepository.test.ts
@@ -1,0 +1,32 @@
+import axios from 'axios';
+import {HeaterSafetyRepository} from './HeaterSafetyRepository';
+
+jest.mock('axios');
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+describe('HeaterSafetyRepository', () => {
+    beforeEach(() => jest.clearAllMocks());
+
+    it('loads the confirmed heater safety snapshot', async () => {
+        const snapshot = {state: 'MONITORING' as const, latched: false};
+        mockedAxios.get.mockResolvedValueOnce({data: snapshot});
+
+        await expect(HeaterSafetyRepository.get()).resolves.toEqual(snapshot);
+        expect(mockedAxios.get).toHaveBeenCalledWith('/api/controller/Safety/Heater');
+    });
+
+    it('posts reset and returns the confirmed backend snapshot', async () => {
+        const snapshot = {state: 'DISARMED' as const, latched: false};
+        mockedAxios.post.mockResolvedValueOnce({data: snapshot});
+
+        await expect(HeaterSafetyRepository.reset()).resolves.toEqual(snapshot);
+        expect(mockedAxios.post).toHaveBeenCalledWith('/api/controller/Safety/Heater/Reset');
+    });
+
+    it('propagates reset errors without manufacturing a local state', async () => {
+        const error = new Error('reset rejected');
+        mockedAxios.post.mockRejectedValueOnce(error);
+
+        await expect(HeaterSafetyRepository.reset()).rejects.toBe(error);
+    });
+});

--- a/src/repositorys/HeaterSafetyRepository.ts
+++ b/src/repositorys/HeaterSafetyRepository.ts
@@ -1,0 +1,17 @@
+import axios from 'axios';
+import {BaseURL} from '../global';
+import {HeaterSafetyState} from '../model/HeaterSafetyState';
+
+const HEATER_SAFETY_URL = `${BaseURL}/Safety/Heater`;
+
+export class HeaterSafetyRepository {
+    static async get(): Promise<HeaterSafetyState> {
+        const response = await axios.get<HeaterSafetyState>(HEATER_SAFETY_URL);
+        return response.data;
+    }
+
+    static async reset(): Promise<HeaterSafetyState> {
+        const response = await axios.post<HeaterSafetyState>(`${HEATER_SAFETY_URL}/Reset`);
+        return response.data;
+    }
+}

--- a/src/repositorys/OperationalSettingsRepository.test.ts
+++ b/src/repositorys/OperationalSettingsRepository.test.ts
@@ -1,0 +1,51 @@
+import axios from 'axios';
+import {OperationalSettings} from '../model/OperationalSettings';
+import {OperationalSettingsRepository} from './OperationalSettingsRepository';
+
+jest.mock('axios');
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+describe('OperationalSettingsRepository', () => {
+    const settings: OperationalSettings = {
+        waterFilling: {pulsesPerLiter: 411, sensorStartDelaySeconds: 0.4},
+        audio: {enabled: true, confirmationRepeatSeconds: 9, alarmRepeatSeconds: 2},
+        processSafety: {heatingTimeoutMinutes: 55, confirmationTimeoutMinutes: 4},
+        heaterSafety: {offGracePeriodSeconds: 100, maxOffTemperatureRise: 1.8, riseObservationWindowSeconds: 25},
+    };
+
+    beforeEach(() => jest.clearAllMocks());
+
+    it('loads the complete settings snapshot in one request', async () => {
+        mockedAxios.get.mockResolvedValueOnce({data: settings});
+
+        await expect(OperationalSettingsRepository.get()).resolves.toEqual(settings);
+        expect(mockedAxios.get).toHaveBeenCalledWith('/api/controller/Settings');
+    });
+
+    it('loads an individual typed section', async () => {
+        mockedAxios.get.mockResolvedValueOnce({data: settings.audio});
+
+        await expect(OperationalSettingsRepository.getSection('audio')).resolves.toEqual(settings.audio);
+        expect(mockedAxios.get).toHaveBeenCalledWith('/api/controller/Settings/audio');
+    });
+
+    it.each([
+        ['waterFilling', settings.waterFilling],
+        ['audio', settings.audio],
+        ['processSafety', settings.processSafety],
+        ['heaterSafety', settings.heaterSafety],
+    ] as const)('puts the complete %s section and returns the confirmed response', async (section, payload) => {
+        const confirmed = {...payload};
+        mockedAxios.put.mockResolvedValueOnce({data: confirmed});
+
+        await expect(OperationalSettingsRepository.updateSection(section, payload)).resolves.toEqual(confirmed);
+        expect(mockedAxios.put).toHaveBeenCalledWith(`/api/controller/Settings/${section}`, payload);
+    });
+
+    it('propagates backend validation and network errors', async () => {
+        const error = new Error('validation failed');
+        mockedAxios.put.mockRejectedValueOnce(error);
+
+        await expect(OperationalSettingsRepository.updateSection('audio', settings.audio)).rejects.toBe(error);
+    });
+});

--- a/src/repositorys/OperationalSettingsRepository.ts
+++ b/src/repositorys/OperationalSettingsRepository.ts
@@ -1,0 +1,27 @@
+import axios from 'axios';
+import {BaseURL} from '../global';
+import {OperationalSettings, OperationalSettingsSection} from '../model/OperationalSettings';
+
+const SETTINGS_URL = `${BaseURL}/Settings`;
+
+export class OperationalSettingsRepository {
+    static async get(): Promise<OperationalSettings> {
+        const response = await axios.get<OperationalSettings>(SETTINGS_URL);
+        return response.data;
+    }
+
+    static async getSection<Section extends OperationalSettingsSection>(
+        section: Section,
+    ): Promise<OperationalSettings[Section]> {
+        const response = await axios.get<OperationalSettings[Section]>(`${SETTINGS_URL}/${section}`);
+        return response.data;
+    }
+
+    static async updateSection<Section extends OperationalSettingsSection>(
+        section: Section,
+        settings: OperationalSettings[Section],
+    ): Promise<OperationalSettings[Section]> {
+        const response = await axios.put<OperationalSettings[Section]>(`${SETTINGS_URL}/${section}`, settings);
+        return response.data;
+    }
+}

--- a/src/utils/brewingStatus/alarmDisplay.ts
+++ b/src/utils/brewingStatus/alarmDisplay.ts
@@ -6,7 +6,18 @@ export const equipmentAlarmDisplay = {
     headerText: 'ANLAGENALARM – Anlage prüfen'
 };
 
+export const heaterStuckOnAlarmDisplay = {
+    title: 'Heizungs-Sicherheitsalarm',
+    message: 'Die Heizung scheint nach dem Abschalten weiter Wärme zu erzeugen.\nBitte Anlage prüfen und den Sicherheitsalarm erst nach Beseitigung der Ursache zurücksetzen.',
+    headerText: 'HEIZUNGSALARM – Anlage prüfen'
+};
+
 export const isEquipmentAlarmActive = (alarms?: Alarm[]): boolean =>
     alarms?.some((aAlarm) =>
         aAlarm.type === AlarmType.EQUIPMENT_ALARM && aAlarm.active === true
+    ) === true;
+
+export const isHeaterStuckOnAlarmActive = (alarms?: Alarm[]): boolean =>
+    alarms?.some((alarm) =>
+        alarm.type === AlarmType.HEATER_STUCK_ON && alarm.active === true
     ) === true;

--- a/src/utils/brewingStatus/selectors.test.ts
+++ b/src/utils/brewingStatus/selectors.test.ts
@@ -1,7 +1,7 @@
 import {getBrewingStatusLabel, getConfirmButtonLabel, getConfirmationRequestViewModel, getConfirmationType, getCountdownValue, isBrewingProcessActive, shouldShowConfirmButton, shouldShowCountdown, shouldShowWaitingDialog} from './selectors';
 import {AlarmType, BrewingStatus, ProcessMode, ProcessPhase, ProcessState, WaitingFor} from '../../model/brewingStatus.types';
 import {ConfirmStates} from '../../enums/eConfirmStates';
-import {isEquipmentAlarmActive} from './alarmDisplay';
+import {isEquipmentAlarmActive, isHeaterStuckOnAlarmActive} from './alarmDisplay';
 
 const makeStatus = (aPart: Partial<BrewingStatus>): BrewingStatus => ({
   elapsedTime: 0,
@@ -17,6 +17,11 @@ describe('brewing selectors', () => {
     expect(isEquipmentAlarmActive([{type: 'FUTURE_ALARM', active: true}])).toBe(false);
     expect(isEquipmentAlarmActive([{type: AlarmType.EQUIPMENT_ALARM, active: false}])).toBe(false);
     expect(isEquipmentAlarmActive([{type: AlarmType.EQUIPMENT_ALARM, active: true}])).toBe(true);
+  });
+  it('recognizes HEATER_STUCK_ON independently from the equipment alarm', () => {
+    expect(isHeaterStuckOnAlarmActive([{type: AlarmType.EQUIPMENT_ALARM, active: true}])).toBe(false);
+    expect(isHeaterStuckOnAlarmActive([{type: AlarmType.HEATER_STUCK_ON, active: false}])).toBe(false);
+    expect(isHeaterStuckOnAlarmActive([{type: AlarmType.HEATER_STUCK_ON, active: true}])).toBe(true);
   });
   it('derives an active brewing process from process.state ACTIVE only', () => {
     expect(isBrewingProcessActive(undefined)).toBe(false);

--- a/src/utils/serviceWorker.test.ts
+++ b/src/utils/serviceWorker.test.ts
@@ -62,11 +62,43 @@ describe('service-worker push handling', () => {
             data: expect.objectContaining({
                 url: '/production?step=6',
                 waitingFor: 'MASHING_OUT_CONFIRMATION',
-                serviceWorkerVersion: 'brauhaus-push-v2',
+                serviceWorkerVersion: 'brauhaus-push-v3',
             }),
         }));
         expect(waitUntil).toHaveBeenCalledTimes(1);
         await expect(waitUntil.mock.calls[0][0]).resolves.toBeUndefined();
+    });
+
+    it.each([
+        ['INFO', {}],
+        ['WARNING', { vibrate: [200, 100, 200] }],
+        ['ALARM', { requireInteraction: true, vibrate: [300, 100, 300, 100, 600] }],
+    ])('uses the backend-provided %s severity without deriving it', (severity, expectedOptions) => {
+        const { listeners, showNotification } = loadServiceWorker();
+
+        listeners.push({
+            data: { json: () => ({ title: 'Meldung', severity }) },
+            waitUntil: jest.fn(),
+        });
+
+        expect(showNotification).toHaveBeenCalledWith('Meldung', expect.objectContaining({
+            ...expectedOptions,
+            data: expect.objectContaining({ severity }),
+        }));
+    });
+
+    it('keeps legacy payloads without severity compatible', () => {
+        const { listeners, showNotification } = loadServiceWorker();
+
+        listeners.push({
+            data: { json: () => ({ title: 'Legacy-Meldung' }) },
+            waitUntil: jest.fn(),
+        });
+
+        const options = showNotification.mock.calls[0][1];
+        expect(options.data.severity).toBeUndefined();
+        expect(options.requireInteraction).toBeUndefined();
+        expect(options.vibrate).toBeUndefined();
     });
 
     it('shows a fallback notification for invalid payloads', () => {


### PR DESCRIPTION
### Motivation

- Introduce controller-managed operational settings and a dedicated heater-safety contract so the UI consumes authoritative backend snapshots and does not synthesize safety state or defaults.
- Surface a new realtime heater-safety alarm (`HEATER_STUCK_ON`) as a high-priority, distinct condition that blocks brew start and is reset via a dedicated endpoint.
- Improve push handling to honor backend-provided `severity` and adjust notification presentation without breaking legacy payloads.

### Description

- Added new models `OperationalSettings` and `HeaterSafetyState` in `src/model` and repositories `OperationalSettingsRepository` and `HeaterSafetyRepository` to call `GET /Settings`, `GET /Settings/{section}`, `PUT /Settings/{section}`, `GET /Safety/Heater`, and `POST /Safety/Heater/Reset`.
- Extended realtime/alarms and alarm helpers by adding `AlarmType.HEATER_STUCK_ON`, new displays `heaterStuckOnAlarmDisplay`, and helper `isHeaterStuckOnAlarmActive`; updated UI to prioritize heater-safety messages in `Header` and `Production`, block brew start when active, and show distinct dialogs/messages.
- Implemented a comprehensive settings UI for operational sections in `SettingsPage` including drafts, per-section save via `updateSection`, heater-safety status display and reset action, validation and API error handling, and layout/styles in `SettingsPage.css`.
- Updated the service worker to `SERVICE_WORKER_VERSION = 'brauhaus-push-v3'`, parse backend `severity` (`INFO`/`WARNING`/`ALARM`), and apply corresponding notification options (`vibrate`, `requireInteraction`) while preserving legacy behavior when `severity` is absent.
- Added integration/utility tests and repository tests for the new APIs and behaviors, plus small test updates to reflect the new alarm and service worker changes.
- Documentation updated in `docs/codex/*` to describe the operational settings, heater-safety contract, and push severity behavior.

### Testing

- Unit tests covering repositories and new behavior were added: `OperationalSettingsRepository.test.ts`, `HeaterSafetyRepository.test.ts`, and service worker tests in `serviceWorker.test.ts`, and component tests updated/extended for `SettingsPage`, `Header`, and `Production`; these tests were executed and passed.
- Component tests asserting UI flows for operational settings loading/saving, heater-safety reset and blocking brew start, and push severity presentation were run as part of the test suite and succeeded.
- No runtime/manual verification steps are included here; docs note some controller/hardware behaviors still marked `Needs verification` for end-to-end hardware interactions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a9663051344832f99fad589d3e02fa4)