### PR TITLE
Refactor Settings page: unify layout with MUI Accordions and add diagnostics header

### DIFF
--- a/src/containers/Settings/SettingsAccordion.tsx
+++ b/src/containers/Settings/SettingsAccordion.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import Accordion from '@mui/material/Accordion';
+import AccordionDetails from '@mui/material/AccordionDetails';
+import AccordionSummary from '@mui/material/AccordionSummary';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+
+interface SettingsAccordionProps {
+    icon: React.ReactNode;
+    title: string;
+    description: string;
+    status?: React.ReactNode;
+    className?: string;
+    children: React.ReactNode;
+}
+
+export const SettingsAccordion = ({icon, title, description, status, className = '', children}: SettingsAccordionProps) => (
+    <Accordion component="section" disableGutters elevation={0} className={`settings-accordion ${className}`.trim()}>
+        <AccordionSummary className="settings-accordion-summary" expandIcon={<ExpandMoreIcon aria-hidden="true" />}>
+            <span className="settings-accordion-icon" aria-hidden="true">{icon}</span>
+            <span className="settings-accordion-heading">
+                <span className="settings-accordion-title">{title}</span>
+                <span className="settings-accordion-description">{description}</span>
+            </span>
+            {status && <span className="settings-accordion-status">{status}</span>}
+        </AccordionSummary>
+        <AccordionDetails className="settings-accordion-details">{children}</AccordionDetails>
+    </Accordion>
+);

--- a/src/containers/Settings/SettingsPage.css
+++ b/src/containers/Settings/SettingsPage.css
@@ -26,11 +26,59 @@
 }
 
 .settings-grid {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  align-items: start;
-  gap: var(--spacing-lg);
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-sm);
 }
+
+.settings-diagnostics {
+  min-width: 0;
+  margin-bottom: var(--spacing-lg);
+  padding: var(--spacing-md) var(--spacing-lg);
+  background: var(--color-panel-bg);
+  border: 1px solid var(--color-border);
+  border-radius: var(--border-radius-large);
+  box-shadow: 0 2px 6px var(--shadow-card-light);
+}
+.settings-diagnostics-heading { display: flex; align-items: flex-start; gap: var(--spacing-md); }
+.settings-diagnostics-heading > svg { flex: 0 0 auto; color: var(--color-primary); font-size: 1.5rem; }
+.settings-diagnostics h2, .settings-diagnostics p { margin: 0; }
+.settings-diagnostics h2 { font-size: var(--font-size-section-title); }
+.settings-diagnostics-heading p { margin-top: 2px; color: var(--color-text-secondary); font-size: var(--font-size-small); }
+.settings-diagnostics .diagnosis-list { grid-template-columns: repeat(4, minmax(0, 1fr)); gap: var(--spacing-sm); }
+.settings-diagnostics .diagnosis-list div { display: block; padding: var(--spacing-sm); background: var(--color-panel-contrast); border: 0; border-radius: var(--border-radius-medium); }
+.settings-diagnostics .diagnosis-list dd { margin-top: 2px; }
+
+.settings-accordion.MuiAccordion-root {
+  min-width: 0;
+  color: var(--color-text);
+  background: var(--color-panel-bg);
+  border: 1px solid var(--color-primary);
+  border-left-width: 3px;
+  border-radius: var(--border-radius-large) !important;
+  box-shadow: 0 2px 6px var(--shadow-card-light);
+  overflow: hidden;
+}
+.settings-accordion.MuiAccordion-root::before { display: none; }
+.settings-accordion.MuiAccordion-root.Mui-expanded { margin: 0; }
+.settings-accordion-summary.MuiAccordionSummary-root {
+  min-height: 68px;
+  padding: 0 var(--spacing-lg);
+  transition: background .15s;
+}
+.settings-accordion-summary.MuiAccordionSummary-root:hover { background: var(--color-panel-highlight); }
+.settings-accordion-summary.Mui-focusVisible { background: var(--color-panel-highlight) !important; outline: 2px solid var(--color-primary); outline-offset: -2px; }
+.settings-accordion-summary .MuiAccordionSummary-content { min-width: 0; align-items: center; gap: var(--spacing-md); margin: var(--spacing-sm) 0; }
+.settings-accordion-summary .MuiAccordionSummary-expandIconWrapper { color: var(--color-text-secondary); }
+.settings-accordion-icon { display: flex; flex: 0 0 auto; color: var(--color-primary); }
+.settings-accordion-icon svg { font-size: 1.5rem; }
+.settings-accordion-heading { display: flex; min-width: 0; flex: 1 1 auto; flex-direction: column; }
+.settings-accordion-title { font-size: var(--font-size-section-title); font-weight: 700; line-height: 1.25; }
+.settings-accordion-description { margin-top: 2px; color: var(--color-text-secondary); font-size: var(--font-size-small); line-height: var(--line-height-normal); }
+.settings-accordion-status { flex: 0 0 auto; margin-left: auto; }
+.settings-status-chip { display: inline-flex; padding: 3px var(--spacing-sm); color: var(--color-text-secondary); background: var(--color-panel-contrast); border: 1px solid var(--color-border); border-radius: var(--border-radius-pill); font-size: .75rem; font-weight: 700; white-space: nowrap; }
+.settings-status-chip.critical { color: var(--color-error); background: var(--color-error-subtle); border-color: var(--color-error); }
+.settings-accordion-details.MuiAccordionDetails-root { padding: var(--spacing-md) var(--spacing-lg) var(--spacing-lg); border-top: 1px solid var(--color-border-soft); }
 
 .settings-card {
   min-width: 0;
@@ -107,7 +155,7 @@
 .settings-footer { display: flex; align-items: center; gap: var(--spacing-md); margin-top: var(--spacing-lg); padding-top: var(--spacing-md); border-top: 1px solid var(--color-border-soft); }
 .settings-footer p { margin: 0; color: var(--color-text-secondary); font-size: var(--font-size-small); }
 
-@media (max-width: 900px) { .settings-grid { grid-template-columns: minmax(0, 1fr); } }
+@media (max-width: 900px) { .settings-diagnostics .diagnosis-list { grid-template-columns: repeat(2, minmax(0, 1fr)); } }
 @media (max-width: 600px) {
   .settings-page { padding: var(--spacing-lg) var(--spacing-lg) calc(var(--spacing-xl) + env(safe-area-inset-bottom)); }
   .setting-row { align-items: flex-start; }
@@ -116,6 +164,13 @@
   .push-status-list, .sound-list { grid-template-columns: minmax(0, 1fr); }
   .settings-actions, .settings-footer { align-items: stretch; flex-direction: column; }
   .settings-actions button, .settings-footer button { width: 100%; }
+  .settings-accordion-summary.MuiAccordionSummary-root { min-height: 76px; padding-inline: var(--spacing-md); }
+  .settings-accordion-summary .MuiAccordionSummary-content { align-items: flex-start; flex-wrap: wrap; gap: var(--spacing-sm); }
+  .settings-accordion-heading { flex-basis: calc(100% - 2rem - var(--spacing-sm)); }
+  .settings-accordion-status { margin-left: calc(1.5rem + var(--spacing-sm)); }
+  .settings-accordion-details.MuiAccordionDetails-root { padding: var(--spacing-md); }
+  .settings-diagnostics { padding: var(--spacing-md); }
+  .settings-diagnostics .diagnosis-list { grid-template-columns: minmax(0, 1fr); }
 }
 
 .mobile-content > .settings-page { flex: 1 1 auto; min-height: 0; }
@@ -141,11 +196,7 @@
 .settings-number-field .quantity-picker-native-input { box-sizing: border-box; text-align: center; background: var(--color-surface-strong); font-size: var(--font-size-normal); font-weight: 700; }
 .settings-number-field .quantity-picker-content-disabled .quantity-picker-native-input { background: var(--color-disabled-bg); }
 .settings-number-field > .setting-description { margin-top: 2px; }
-.safety-card { border-color: var(--color-warning); }
-.advanced-card { background: var(--color-panel-contrast); }
-.advanced-card h3 { margin: var(--spacing-md) 0 var(--spacing-sm); color: var(--color-text-secondary); }
-.heater-safety-status { display: flex; flex-wrap: wrap; align-items: center; gap: var(--spacing-md); margin-top: var(--spacing-md); padding: var(--spacing-sm); background: var(--color-panel-contrast); border-radius: var(--border-radius-medium); }
-.heater-safety-status.critical { color: var(--color-error); background: var(--color-error-subtle); border: 1px solid var(--color-error); }
+.advanced-accordion h3 { margin: var(--spacing-md) 0 var(--spacing-sm); color: var(--color-text-secondary); }
 .diagnosis-list { display: grid; gap: var(--spacing-sm); margin: var(--spacing-md) 0 0; }
 .diagnosis-list div { display: grid; grid-template-columns: minmax(7rem, .4fr) 1fr; gap: var(--spacing-md); padding-top: var(--spacing-sm); border-top: 1px solid var(--color-border-soft); }
 .diagnosis-list dt { color: var(--color-text-secondary); }

--- a/src/containers/Settings/SettingsPage.test.tsx
+++ b/src/containers/Settings/SettingsPage.test.tsx
@@ -273,6 +273,21 @@ describe('Operational settings', () => {
         expect(screen.getByLabelText('Lautsprecher')).toBeChecked();
     });
 
+    it('separates read-only diagnostics from independently expandable settings', async () => {
+        render(<SettingsPage theme="default" setTheme={jest.fn()} debug={false} setDebug={jest.fn()} socketConnected temperatureSensor={{current: 20, health: 'OK', sensorId: '28-abcdef'}}/>);
+
+        expect(screen.getByRole('heading', {name: 'System- und Diagnosestatus'})).toBeInTheDocument();
+        expect(screen.getByText('28-abcdef')).toBeInTheDocument();
+        expect(screen.queryByRole('button', {name: /System- und Diagnosestatus/})).not.toBeInTheDocument();
+        expect(screen.getByRole('button', {name: /Rührwerk/})).toHaveAttribute('aria-expanded', 'false');
+        expect(await screen.findByRole('button', {name: /Heizung \/ Sicherheit/})).toHaveAttribute('aria-expanded', 'false');
+
+        fireEvent.click(screen.getByRole('button', {name: /Rührwerk/}));
+        fireEvent.click(screen.getByRole('button', {name: /Heizung \/ Sicherheit/}));
+        expect(screen.getByRole('button', {name: /Rührwerk/})).toHaveAttribute('aria-expanded', 'true');
+        expect(screen.getByRole('button', {name: /Heizung \/ Sicherheit/})).toHaveAttribute('aria-expanded', 'true');
+    });
+
     it('sends a complete water section and adopts the confirmed response only', async () => {
         mockedOperational.updateSection.mockResolvedValueOnce({pulsesPerLiter: 500, sensorStartDelaySeconds: 1.25});
         renderSettings(false);
@@ -333,7 +348,7 @@ describe('Operational settings', () => {
         const reset = await screen.findByRole('button', {name: 'Sicherheitsalarm zurücksetzen'});
         fireEvent.click(reset);
         expect(await screen.findByText('Sicherheitsalarm konnte nicht zurückgesetzt werden.')).toBeInTheDocument();
-        expect(screen.getByText(/HEATER_STUCK_ON/)).toBeInTheDocument();
+        expect(screen.getAllByText(/HEATER_STUCK_ON/)).not.toHaveLength(0);
         expect(reset).toBeEnabled();
     });
 });

--- a/src/containers/Settings/SettingsPage.tsx
+++ b/src/containers/Settings/SettingsPage.tsx
@@ -23,6 +23,7 @@ import {HeaterSafetyRepository} from '../../repositorys/HeaterSafetyRepository';
 import {TemperatureSensorRealtimeState} from '../../model/RealtimeControllerState';
 import {getTemperatureSensorMessage} from '../../utils/temperatureSensor';
 import {SettingsNumberField} from './SettingsNumberField';
+import {SettingsAccordion} from './SettingsAccordion';
 
 interface SettingsPageProps {
     theme: ThemeName;
@@ -470,15 +471,18 @@ export class SettingsPage extends React.Component<SettingsPageProps, SettingsPag
                     </div>
                 )}
 
+                <section className="settings-diagnostics" aria-labelledby="settings-diagnostics-title">
+                    <div className="settings-diagnostics-heading"><SensorsOutlinedIcon aria-hidden="true"/><div><h2 id="settings-diagnostics-title">System- und Diagnosestatus</h2><p>Live-Informationen der Brausteuerung (nur lesbar).</p></div></div>
+                    <dl className="diagnosis-list">
+                        <div><dt>Verbindung</dt><dd>{socketConnected ? 'Verbunden' : 'Nicht aktiv'}</dd></div>
+                        <div><dt>Temperatursensor</dt><dd>{socketConnected ? getTemperatureSensorMessage(temperatureSensor) : 'Controllerverbindung nicht aktiv'}</dd></div>
+                        <div><dt>Sensor-ID</dt><dd>{temperatureSensor?.sensorId ?? 'Nicht verfügbar'}</dd></div>
+                        <div><dt>Safety</dt><dd>{this.state.heaterSafetyLoading ? 'Wird geladen…' : this.state.heaterSafety?.state ?? 'Nicht verfügbar'}</dd></div>
+                    </dl>
+                </section>
+
                 <div className="settings-grid">
-                    <section className="settings-card agitator-defaults-card">
-                        <div className="settings-card-header">
-                            <TuneOutlinedIcon aria-hidden="true" />
-                            <div>
-                                <h2>Rührwerk</h2>
-                                <p>Persistente Standardwerte der Brausteuerung.</p>
-                            </div>
-                        </div>
+                    <SettingsAccordion className="agitator-defaults-card" icon={<TuneOutlinedIcon />} title="Rührwerk" description="Persistente Standardwerte der Brausteuerung.">
 
                         {agitatorLoading && <p className="agitator-settings-state" role="status">Rührwerk-Standardwerte werden geladen…</p>}
                         {!agitatorLoading && !agitatorSettings && <div className="agitator-settings-state">
@@ -500,21 +504,19 @@ export class SettingsPage extends React.Component<SettingsPageProps, SettingsPag
                             </div>
                             {agitatorError && <p className="settings-error" role="alert">{agitatorError}</p>}
                         </div>}
-                    </section>
+                    </SettingsAccordion>
 
                     {this.state.operationalLoading && <section className="settings-card operational-loading" aria-live="polite"><p>Betriebseinstellungen werden geladen…</p></section>}
                     {!this.state.operationalLoading && !this.state.operationalSettings && <section className="settings-card"><p className="settings-error" role="alert">{this.state.operationalError}</p><div className="settings-actions"><button className="settings-secondary" type="button" onClick={this.loadOperationalSettingsSnapshot}>Erneut versuchen</button></div></section>}
                     {this.state.operationalSettings && this.state.operationalDrafts && <>
-                        <section className="settings-card">
-                            <div className="settings-card-header"><WaterDropOutlinedIcon aria-hidden="true"/><div><h2>Wasser</h2><p>Kalibrierung der automatischen Wasserfüllung.</p></div></div>
+                        <SettingsAccordion icon={<WaterDropOutlinedIcon />} title="Wasser" description="Kalibrierung der automatischen Wasserfüllung.">
                             <div className="operational-fields">
                                 {this.renderOperationalNumber('waterFilling', 'pulsesPerLiter', 'Impulse pro Liter', 'Impulse/L', 'Kalibrierwert des Durchflusssensors. Gibt an, wie viele Sensorimpulse einem Liter Wasser entsprechen.', 1)}
                             </div>
                             {this.renderSectionAction('waterFilling')}
-                        </section>
+                        </SettingsAccordion>
 
-                        <section className="settings-card">
-                            <div className="settings-card-header"><VolumeUpOutlinedIcon aria-hidden="true"/><div><h2>Audio</h2><p>Persistente Signaltöne der Brausteuerung.</p></div></div>
+                        <SettingsAccordion icon={<VolumeUpOutlinedIcon />} title="Audio" description="Persistente Signaltöne der Brausteuerung.">
                             <div className="setting-row"><div className="setting-label-group"><label htmlFor="audio-enabled">Lautsprecher</label><span className="setting-description">Akustische Hinweise zentral ein- oder ausschalten.</span></div><label className="settings-toggle"><input id="audio-enabled" type="checkbox" checked={Boolean(this.state.operationalDrafts.audio.enabled)} disabled={this.state.sectionSaving === 'audio'} onChange={(event) => this.updateOperationalDraft('audio', 'enabled', event.target.checked)}/><span aria-hidden="true"/></label></div>
                             <div className="operational-fields">
                                 {this.renderOperationalNumber('audio', 'confirmationRepeatSeconds', 'Bestätigung wiederholen alle', 's', 'Intervall für notwendige Benutzerbestätigungen.', 1)}
@@ -523,25 +525,20 @@ export class SettingsPage extends React.Component<SettingsPageProps, SettingsPag
                             <div className="settings-actions"><button className="settings-secondary" type="button" disabled={soundPlaying !== null} onClick={() => this.handleSoundTest(SoundType.CONFIRMATION)}>{soundPlaying === SoundType.CONFIRMATION ? 'Wird abgespielt…' : 'Testton abspielen'}</button></div>
                             {soundError && <p className="settings-error" role="alert">{soundError}</p>}
                             {this.renderSectionAction('audio')}
-                        </section>
+                        </SettingsAccordion>
 
-                        <section className="settings-card safety-card">
-                            <div className="settings-card-header"><HealthAndSafetyOutlinedIcon aria-hidden="true"/><div><h2>Heizung / Sicherheit</h2><p>Safety-Erkennung nach dem Abschalten der Heizung – keine Temperaturregelung.</p></div></div>
+                        <SettingsAccordion className="safety-accordion" icon={<HealthAndSafetyOutlinedIcon />} title="Heizung / Sicherheit" description="Safety-Erkennung nach dem Abschalten der Heizung – keine Temperaturregelung." status={<span className={`settings-status-chip ${this.state.heaterSafety?.latched ? 'critical' : ''}`}>{this.state.heaterSafetyLoading ? 'Wird geladen…' : this.state.heaterSafety?.state ?? 'Nicht verfügbar'}</span>}>
                             <div className="operational-fields">
                                 {this.renderOperationalNumber('heaterSafety', 'offGracePeriodSeconds', 'Nachlaufzeit nach Heizung AUS', 's', 'Zeitraum nach dem Abschalten, in dem ein weiterer Temperaturanstieg durch gespeicherte Wärme noch als normal gilt.', 1)}
                                 {this.renderOperationalNumber('heaterSafety', 'maxOffTemperatureRise', 'Erlaubter Temperaturanstieg', '°C', 'Maximal erlaubter Temperaturanstieg gegenüber der Temperatur beim Abschalten der Heizung.', 0.1)}
                                 {this.renderOperationalNumber('heaterSafety', 'riseObservationWindowSeconds', 'Beobachtungszeit', 's', 'Zeitraum, über den ein weiterer Temperaturanstieg bestätigt werden muss, bevor ein Safety-Alarm ausgelöst wird.', 1)}
                             </div>
                             {this.renderSectionAction('heaterSafety')}
-                            <div className={`heater-safety-status ${this.state.heaterSafety?.latched ? 'critical' : ''}`}>
-                                <strong>Safety-Status:</strong> {this.state.heaterSafetyLoading ? 'Wird geladen…' : this.state.heaterSafety?.state ?? 'Nicht verfügbar'}
-                                {this.state.heaterSafety?.latched && <button className="settings-primary" type="button" disabled={this.state.heaterSafetyResetting} onClick={this.resetLatchedHeaterSafety}>{this.state.heaterSafetyResetting ? 'Wird zurückgesetzt…' : 'Sicherheitsalarm zurücksetzen'}</button>}
-                            </div>
+                            {this.state.heaterSafety?.latched && <div className="settings-actions"><button className="settings-primary" type="button" disabled={this.state.heaterSafetyResetting} onClick={this.resetLatchedHeaterSafety}>{this.state.heaterSafetyResetting ? 'Wird zurückgesetzt…' : 'Sicherheitsalarm zurücksetzen'}</button></div>}
                             {this.state.heaterSafetyError && <p className="settings-error" role="alert">{this.state.heaterSafetyError}</p>}
-                        </section>
+                        </SettingsAccordion>
 
-                        <section className="settings-card advanced-card">
-                            <div className="settings-card-header"><TuneOutlinedIcon aria-hidden="true"/><div><h2>Erweitert</h2><p>Hardware- und Prozess-Safety-Werte für Service und Betrieb.</p></div></div>
+                        <SettingsAccordion className="advanced-accordion" icon={<TuneOutlinedIcon />} title="Erweitert" description="Hardware- und Prozess-Safety-Werte für Service und Betrieb.">
                             <h3>Wasserfüllung</h3><div className="operational-fields">
                                 {this.renderOperationalNumber('waterFilling', 'sensorStartDelaySeconds', 'Startverzögerung Impulszählung', 's', 'Verzögerung nach dem Öffnen des Wasserventils, bevor die Impulszählung beginnt. Dadurch werden Schaltimpulse des Ventils nicht als Wassermenge gezählt.', 0.1)}
                             </div>
@@ -551,22 +548,10 @@ export class SettingsPage extends React.Component<SettingsPageProps, SettingsPag
                             </div>
                             {this.renderSectionAction('processSafety')}
                             <p className="settings-warning">Die Startverzögerung gehört zur Wasser-Section und wird gemeinsam mit „Impulse pro Liter“ gespeichert.</p>
-                        </section>
-
-                        <section className="settings-card diagnosis-card">
-                            <div className="settings-card-header"><SensorsOutlinedIcon aria-hidden="true"/><div><h2>Diagnose</h2><p>Automatisch erkannter Temperatursensor (nur lesbar).</p></div></div>
-                            <dl className="diagnosis-list"><div><dt>Status</dt><dd>{socketConnected ? getTemperatureSensorMessage(temperatureSensor) : 'Controllerverbindung nicht aktiv'}</dd></div><div><dt>Sensor-ID</dt><dd>{temperatureSensor?.sensorId ?? 'Nicht verfügbar'}</dd></div></dl>
-                        </section>
+                        </SettingsAccordion>
                     </>}
 
-                    <section className="settings-card">
-                        <div className="settings-card-header">
-                            <PaletteOutlinedIcon aria-hidden="true" />
-                            <div>
-                                <h2>Oberfläche</h2>
-                                <p>Darstellung und Funktionsumfang dieses Browsers.</p>
-                            </div>
-                        </div>
+                    <SettingsAccordion icon={<PaletteOutlinedIcon />} title="Oberfläche" description="Darstellung und Funktionsumfang dieses Browsers.">
 
                         <div className="setting-block">
                             <div className="setting-label-group">
@@ -589,16 +574,9 @@ export class SettingsPage extends React.Component<SettingsPageProps, SettingsPag
                                 <button className={theme === 'dark-alt' ? 'active' : ''} type="button" aria-pressed={theme === 'dark-alt'} onClick={() => this.handleThemeChange('dark-alt')}>Dunkles Theme</button>
                             </div>
                         </div>
-                    </section>
+                    </SettingsAccordion>
 
-                    <section className="settings-card">
-                        <div className="settings-card-header">
-                            <PrecisionManufacturingOutlinedIcon aria-hidden="true" />
-                            <div>
-                                <h2>Brausteuerung</h2>
-                                <p>Verbindung, Messwerte und Werkzeuge für den Brauprozess.</p>
-                            </div>
-                        </div>
+                    <SettingsAccordion icon={<PrecisionManufacturingOutlinedIcon />} title="Brausteuerung" description="Verbindung, Messwerte und Werkzeuge für den Brauprozess.">
 
                         <div className="setting-row">
                             <div className="setting-label-group">
@@ -648,16 +626,9 @@ export class SettingsPage extends React.Component<SettingsPageProps, SettingsPag
                                 ))}
                             </div>
                         </div>}
-                    </section>
+                    </SettingsAccordion>
 
-                    <section className="settings-card">
-                        <div className="settings-card-header">
-                            <NotificationsNoneOutlinedIcon aria-hidden="true" />
-                            <div>
-                                <h2>Benachrichtigungen</h2>
-                                <p>Systemmeldungen und Hinweise aus der Brausteuerung.</p>
-                            </div>
-                        </div>
+                    <SettingsAccordion icon={<NotificationsNoneOutlinedIcon />} title="Benachrichtigungen" description="Systemmeldungen und Hinweise aus der Brausteuerung.">
                         <div className="setting-row">
                             <div className="setting-label-group">
                                 <label htmlFor="notifications">Systemmeldungen</label>
@@ -691,7 +662,7 @@ export class SettingsPage extends React.Component<SettingsPageProps, SettingsPag
                                 <button className="settings-secondary" type="button" onClick={this.handlePushTest} disabled={!pushSubscribed || pushLoading}>Testnachricht senden</button>
                             </div>
                         </div>
-                    </section>
+                    </SettingsAccordion>
                 </div>
 
             </main>


### PR DESCRIPTION
### Motivation

- Reduce visual noise from the old two-column card grid by using a single-column, consistent accordion layout for editable settings.
- Keep all current functionality, requests, sockets and persistence unchanged while making status information immediately visible.
- Separate readonly diagnostic/status data from editable sections so system state is never hidden inside an accordion.

### Description

- Added a small reusable `SettingsAccordion` component wrapping MUI `Accordion`/`AccordionSummary`/`AccordionDetails` to standardize icon, title, description, optional status chip and chevron behavior (new file `src/containers/Settings/SettingsAccordion.tsx`).
- Replaced the two-column Card grid on the Settings page with a single-column sequence of `SettingsAccordion` instances for Rührwerk, Wasser, Audio, Heizung/Sicherheit, Erweitert, Oberfläche, Brausteuerung and Benachrichtigungen while preserving all existing inputs/actions and saving logic (`src/containers/Settings/SettingsPage.tsx`).
- Moved readonly diagnostic information into a fixed, non-collapsible diagnostics section above the accordions and removed the large inline Safety status block, exposing the Heater-Safety state as a compact status chip in the `Heizung / Sicherheit` accordion header while keeping the reset action in the content area (`src/containers/Settings/SettingsPage.tsx`).
- Implemented consistent, theme-aware visual accents and touch-friendly accordion headers (thin left accent, compact summary height, hover/focus states, responsive wrapping) via CSS updates (`src/containers/Settings/SettingsPage.css`).
- Added a unit/interaction test that verifies the diagnostics are fixed above the accordions and that multiple accordions can be opened independently, and adjusted one Safety-related expectation to match the new layout (`src/containers/Settings/SettingsPage.test.tsx`).
- No backend API, DTOs, request/socket logic, validation rules, units or persistence were changed.
- Committed as: "Refine settings page with accordions" (HEAD commit id shown in repo). 

### Testing

- Ran `git diff --check` which passed and created a commit for the changes. 
- Attempted component tests with `npm test` / `react-scripts test` but a local `react-scripts` install and registry access are unavailable in this environment, so the Jest run could not be completed (environment/network limitation). 
- Attempted TypeScript check with `npx tsc --noEmit` but a full project typecheck cannot complete here due to missing project dependencies and type declarations in the sandbox; the typecheck failures are unrelated to the changed Settings files. 
- Added/updated a focused Settings test that asserts the diagnostics section is non-collapsible and that accordions open independently; this test was committed, but full CI/Jest should be executed in the project environment to confirm.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a967dfcc7a4832fb31d6a6ef5b9a5b6)