### PR TITLE
AppAccordion: Vereinheitlichung des MUI-Accordion‑Stils

### DIFF
--- a/src/components/AppAccordion/AppAccordion.css
+++ b/src/components/AppAccordion/AppAccordion.css
@@ -1,0 +1,62 @@
+.app-accordion.MuiAccordion-root {
+    min-width: 0;
+    color: var(--color-text);
+    background: var(--color-panel-bg);
+    border: 1px solid var(--color-primary);
+    border-left-width: 3px;
+    border-radius: var(--border-radius-large) !important;
+    box-shadow: 0 2px 6px var(--shadow-card-light);
+    overflow: hidden;
+}
+
+.app-accordion.MuiAccordion-root::before { display: none; }
+.app-accordion.MuiAccordion-root.Mui-expanded { margin: 0; }
+
+.app-accordion-group {
+    display: flex;
+    min-width: 0;
+    flex-direction: column;
+    gap: var(--spacing-sm);
+}
+
+.app-accordion-summary.MuiAccordionSummary-root {
+    min-height: 68px;
+    padding: 0 var(--spacing-lg);
+    transition: background .15s;
+}
+
+.app-accordion-summary.MuiAccordionSummary-root:hover { background: var(--color-panel-highlight); }
+.app-accordion-summary.Mui-focusVisible {
+    background: var(--color-panel-highlight) !important;
+    outline: 2px solid var(--color-primary);
+    outline-offset: -2px;
+}
+
+.app-accordion-summary .MuiAccordionSummary-content {
+    min-width: 0;
+    align-items: center;
+    gap: var(--spacing-md);
+    margin: var(--spacing-sm) 0;
+}
+
+.app-accordion-summary .MuiAccordionSummary-expandIconWrapper { color: var(--color-text-secondary); }
+.app-accordion-icon { display: flex; flex: 0 0 auto; color: var(--color-primary); }
+.app-accordion-icon svg { font-size: 1.5rem; }
+.app-accordion-heading { display: flex; min-width: 0; flex: 1 1 auto; flex-direction: column; }
+.app-accordion-title { font-size: var(--font-size-section-title); font-weight: 700; line-height: 1.25; }
+.app-accordion-description { margin-top: 2px; color: var(--color-text-secondary); font-size: var(--font-size-small); line-height: var(--line-height-normal); }
+.app-accordion-status { flex: 0 0 auto; margin-left: auto; }
+.app-accordion-details.MuiAccordionDetails-root {
+    min-width: 0;
+    padding: var(--spacing-md) var(--spacing-lg) var(--spacing-lg);
+    background: var(--color-panel-bg);
+    border-top: 1px solid var(--color-border-soft);
+}
+
+@media (max-width: 600px) {
+    .app-accordion-summary.MuiAccordionSummary-root { min-height: 76px; padding-inline: var(--spacing-md); }
+    .app-accordion-summary .MuiAccordionSummary-content { align-items: flex-start; flex-wrap: wrap; gap: var(--spacing-sm); }
+    .app-accordion-heading { flex-basis: calc(100% - 2rem - var(--spacing-sm)); }
+    .app-accordion-status { margin-left: calc(1.5rem + var(--spacing-sm)); }
+    .app-accordion-details.MuiAccordionDetails-root { padding: var(--spacing-md); }
+}

--- a/src/components/AppAccordion/AppAccordion.tsx
+++ b/src/components/AppAccordion/AppAccordion.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import Accordion, {AccordionProps} from '@mui/material/Accordion';
+import AccordionDetails, {AccordionDetailsProps} from '@mui/material/AccordionDetails';
+import AccordionSummary, {AccordionSummaryProps} from '@mui/material/AccordionSummary';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import './AppAccordion.css';
+
+interface AppAccordionProps extends Omit<AccordionProps, 'children'> {
+    summary: React.ReactNode;
+    children: React.ReactNode;
+    summaryProps?: Omit<AccordionSummaryProps, 'children' | 'expandIcon'>;
+    detailsProps?: Omit<AccordionDetailsProps, 'children'>;
+    expandIcon?: React.ReactNode;
+}
+
+const joinClassNames = (...classNames: Array<string | undefined>) => classNames.filter(Boolean).join(' ');
+
+/** Shared visual shell for application accordions. State and event props are passed to MUI unchanged. */
+export const AppAccordion = ({
+    summary,
+    children,
+    summaryProps,
+    detailsProps,
+    expandIcon = <ExpandMoreIcon aria-hidden="true" />,
+    className,
+    disableGutters = true,
+    elevation = 0,
+    ...accordionProps
+}: AppAccordionProps) => (
+    <Accordion
+        {...accordionProps}
+        disableGutters={disableGutters}
+        elevation={elevation}
+        className={joinClassNames('app-accordion', className)}
+    >
+        <AccordionSummary
+            {...summaryProps}
+            className={joinClassNames('app-accordion-summary', summaryProps?.className)}
+            expandIcon={expandIcon}
+        >
+            {summary}
+        </AccordionSummary>
+        <AccordionDetails
+            {...detailsProps}
+            className={joinClassNames('app-accordion-details', detailsProps?.className)}
+        >
+            {children}
+        </AccordionDetails>
+    </Accordion>
+);
+
+interface AppAccordionHeaderProps {
+    icon?: React.ReactNode;
+    title: React.ReactNode;
+    description?: React.ReactNode;
+    status?: React.ReactNode;
+}
+
+/** Flexible standard header; callers can pass arbitrary `summary` content when controls require it. */
+export const AppAccordionHeader = ({icon, title, description, status}: AppAccordionHeaderProps) => (
+    <>
+        {icon && <span className="app-accordion-icon" aria-hidden="true">{icon}</span>}
+        <span className="app-accordion-heading">
+            <span className="app-accordion-title">{title}</span>
+            {description && <span className="app-accordion-description">{description}</span>}
+        </span>
+        {status && <span className="app-accordion-status">{status}</span>}
+    </>
+);

--- a/src/containers/DatabaseOverview/IngredientsFormPage.css
+++ b/src/containers/DatabaseOverview/IngredientsFormPage.css
@@ -5,23 +5,7 @@
     overflow: visible !important;
 }
 
-.containerIngredientsForm .ingredients-accordion {
-    background-color: var(--color-brew-bg) !important;
-    box-shadow: none !important;
-    margin-bottom: 8px;
-}
-
-.containerIngredientsForm .ingredients-accordion::before {
-    display: none;
-}
-
-.containerIngredientsForm .ingredients-accordion-summary {
-    background-color: var(--color-accent) !important;
-    min-height: 48px !important;
-}
-
 .containerIngredientsForm .ingredients-accordion-details {
-    background-color: var(--color-brew-bg) !important;
     overflow: visible !important;
 }
 

--- a/src/containers/DatabaseOverview/IngredientsFormPage.tsx
+++ b/src/containers/DatabaseOverview/IngredientsFormPage.tsx
@@ -1,8 +1,5 @@
 import React from 'react';
 import {
-    Accordion,
-    AccordionDetails,
-    AccordionSummary,
     Typography,
     Table,
     TableBody,
@@ -11,7 +8,6 @@ import {
     TableHead,
     TableRow
 } from "@mui/material";
-import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import AddIcon from "@mui/icons-material/Add";
 import SaveIcon from "@mui/icons-material/Save";
 import CloseIcon from "@mui/icons-material/Close";
@@ -26,6 +22,7 @@ import './IngredientsFormPage.css';
 
 import { AdditionalIngredient } from "../../model/AdditionalIngredient";
 import EditIcon from "@mui/icons-material/Edit";
+import {AppAccordion, AppAccordionHeader} from "../../components/AppAccordion/AppAccordion";
 import {IngredientEditDialog, IngredientEditValue, IngredientKind} from "./IngredientEditDialog";
 
 
@@ -80,18 +77,15 @@ export class IngredientsFormPage extends React.Component<any, any> {
         const { expandedAccordion } = this.state;
 
         return (
-            <Accordion
+            <AppAccordion
                 expanded={expandedAccordion === aAccordionKey}
                 onChange={this.handleAccordionChange(aAccordionKey)}
                 className="ingredients-accordion"
+                summary={<AppAccordionHeader title={aTitle} />}
+                detailsProps={{className: 'ingredients-accordion-details'}}
             >
-                <AccordionSummary expandIcon={<ExpandMoreIcon />} className="ingredients-accordion-summary">
-                    <Typography>{aTitle}</Typography>
-                </AccordionSummary>
-                <AccordionDetails className="ingredients-accordion-details">
-                    {aContent}
-                </AccordionDetails>
-            </Accordion>
+                {aContent}
+            </AppAccordion>
         );
     };
 
@@ -391,7 +385,7 @@ export class IngredientsFormPage extends React.Component<any, any> {
                 style={{ height: "calc(100vh - 0px)" }}
                 autoHide={false}
             >
-                <div className='containerIngredientsForm'>
+                <div className='containerIngredientsForm app-accordion-group'>
                     {this.renderIngredientAccordion("malz", "Malz", this.renderMaltContent())}
                     {this.renderIngredientAccordion("hopfen", "Hopfen", this.renderHopContent())}
                     {this.renderIngredientAccordion("hefe", "Hefe", this.renderYeastContent())}

--- a/src/containers/MainView/Details/Details.tsx
+++ b/src/containers/MainView/Details/Details.tsx
@@ -3,7 +3,6 @@ import './Details.css';
 import { Beer } from "../../../model/Beer";
 
 import {
-    Accordion, AccordionDetails, AccordionSummary,
     Paper,
     Table,
     TableBody,
@@ -13,9 +12,9 @@ import {
     TableRow,
     Typography
 } from "@mui/material";
-import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import {BeerRecipeScaler, scalingValues} from "../../../utils/BeerScaler/ScalingBeerRecipe";
-import {COLOR_ACCENT, COLOR_BREW_BG} from "../../../colors";
+import {COLOR_BREW_BG} from "../../../colors";
+import {AppAccordion, AppAccordionHeader} from "../../../components/AppAccordion/AppAccordion";
 
 interface DetailsProps {
     selectedBeer?: Beer;
@@ -145,22 +144,9 @@ export class Details extends React.Component<DetailsProps, DetailsState> {
     // -------------------------------------------------------------
     renderAccordionGeneralData() {
         return (
-            <Accordion defaultExpanded>
-                <AccordionSummary
-                    sx={{
-                        backgroundColor: COLOR_ACCENT,
-                        color: 'white',
-                        '& .MuiTypography-root': { color: 'white' }
-                    }}
-                    expandIcon={<ExpandMoreIcon sx={{ color: 'white' }} />}
-                >
-                    <Typography>Allgemeine Daten</Typography>
-                </AccordionSummary>
-
-                <AccordionDetails sx={{ backgroundColor: COLOR_BREW_BG }}>
-                    {this.renderGeneralData()}
-                </AccordionDetails>
-            </Accordion>
+            <AppAccordion defaultExpanded summary={<AppAccordionHeader title="Allgemeine Daten" />}>
+                {this.renderGeneralData()}
+            </AppAccordion>
         );
     }
 
@@ -188,22 +174,9 @@ export class Details extends React.Component<DetailsProps, DetailsState> {
     // -------------------------------------------------------------
     renderAccordionFermentation() {
         return (
-            <Accordion>
-                <AccordionSummary
-                    sx={{
-                        backgroundColor: COLOR_ACCENT,
-                        color: 'white',
-                        '& .MuiTypography-root': { color: 'white' }
-                    }}
-                    expandIcon={<ExpandMoreIcon sx={{ color: 'white' }} />}
-                >
-                    <Typography>Maischplan</Typography>
-                </AccordionSummary>
-
-                <AccordionDetails sx={{ backgroundColor: COLOR_BREW_BG }}>
-                    {this.renderFermentation()}
-                </AccordionDetails>
-            </Accordion>
+            <AppAccordion summary={<AppAccordionHeader title="Maischplan" />}>
+                {this.renderFermentation()}
+            </AppAccordion>
         );
     }
 
@@ -240,22 +213,9 @@ export class Details extends React.Component<DetailsProps, DetailsState> {
     // -------------------------------------------------------------
     renderAccordionFilling() {
         return (
-            <Accordion>
-                <AccordionSummary
-                    sx={{
-                        backgroundColor: COLOR_ACCENT,
-                        color: 'white',
-                        '& .MuiTypography-root': { color: 'white' }
-                    }}
-                    expandIcon={<ExpandMoreIcon sx={{ color: 'white' }} />}
-                >
-                    <Typography>Schüttung</Typography>
-                </AccordionSummary>
-
-                <AccordionDetails sx={{ backgroundColor: COLOR_BREW_BG }}>
-                    {this.renderFilling()}
-                </AccordionDetails>
-            </Accordion>
+            <AppAccordion summary={<AppAccordionHeader title="Schüttung" />}>
+                {this.renderFilling()}
+            </AppAccordion>
         );
     }
 
@@ -290,22 +250,9 @@ export class Details extends React.Component<DetailsProps, DetailsState> {
     // -------------------------------------------------------------
     renderAccordionWortBoiling() {
         return (
-            <Accordion>
-                <AccordionSummary
-                    sx={{
-                        backgroundColor: COLOR_ACCENT,
-                        color: 'white',
-                        '& .MuiTypography-root': { color: 'white' }
-                    }}
-                    expandIcon={<ExpandMoreIcon sx={{ color: 'white' }} />}
-                >
-                    <Typography>Würzekochen</Typography>
-                </AccordionSummary>
-
-                <AccordionDetails sx={{ backgroundColor: COLOR_BREW_BG }}>
-                    {this.renderWortBoiling()}
-                </AccordionDetails>
-            </Accordion>
+            <AppAccordion summary={<AppAccordionHeader title="Würzekochen" />}>
+                {this.renderWortBoiling()}
+            </AppAccordion>
         );
     }
 
@@ -349,22 +296,9 @@ export class Details extends React.Component<DetailsProps, DetailsState> {
     // -------------------------------------------------------------
     renderAccordionFermentationMaturation() {
         return (
-            <Accordion>
-                <AccordionSummary
-                    sx={{
-                        backgroundColor: COLOR_ACCENT,
-                        color: 'white',
-                        '& .MuiTypography-root': { color: 'white' }
-                    }}
-                    expandIcon={<ExpandMoreIcon sx={{ color: 'white' }} />}
-                >
-                    <Typography>Gärung und Reifung</Typography>
-                </AccordionSummary>
-
-                <AccordionDetails sx={{ backgroundColor: COLOR_BREW_BG }}>
-                    {this.renderFermentationMaturation()}
-                </AccordionDetails>
-            </Accordion>
+            <AppAccordion summary={<AppAccordionHeader title="Gärung und Reifung" />}>
+                {this.renderFermentationMaturation()}
+            </AppAccordion>
         );
     }
 
@@ -410,22 +344,9 @@ export class Details extends React.Component<DetailsProps, DetailsState> {
     // -------------------------------------------------------------
     renderAccordionWater() {
         return (
-            <Accordion>
-                <AccordionSummary
-                    sx={{
-                        backgroundColor: COLOR_ACCENT,
-                        color: 'white',
-                        '& .MuiTypography-root': { color: 'white' }
-                    }}
-                    expandIcon={<ExpandMoreIcon sx={{ color: 'white' }} />}
-                >
-                    <Typography>Wasser</Typography>
-                </AccordionSummary>
-
-                <AccordionDetails sx={{ backgroundColor: COLOR_BREW_BG }}>
-                    {this.renderBrewingWater()}
-                </AccordionDetails>
-            </Accordion>
+            <AppAccordion summary={<AppAccordionHeader title="Wasser" />}>
+                {this.renderBrewingWater()}
+            </AppAccordion>
         );
     }
 
@@ -466,12 +387,14 @@ export class Details extends React.Component<DetailsProps, DetailsState> {
 
                 {/* ONLY THIS PART SCROLLS */}
 
-                    {this.renderAccordionGeneralData()}
-                    {this.renderAccordionFermentation()}
-                    {this.renderAccordionFilling()}
-                    {this.renderAccordionWortBoiling()}
-                    {this.renderAccordionFermentationMaturation()}
-                    {this.renderAccordionWater()}
+                    <div className="app-accordion-group">
+                        {this.renderAccordionGeneralData()}
+                        {this.renderAccordionFermentation()}
+                        {this.renderAccordionFilling()}
+                        {this.renderAccordionWortBoiling()}
+                        {this.renderAccordionFermentationMaturation()}
+                        {this.renderAccordionWater()}
+                    </div>
 
 
             </div>

--- a/src/containers/Settings/SettingsAccordion.tsx
+++ b/src/containers/Settings/SettingsAccordion.tsx
@@ -1,8 +1,5 @@
 import React from 'react';
-import Accordion from '@mui/material/Accordion';
-import AccordionDetails from '@mui/material/AccordionDetails';
-import AccordionSummary from '@mui/material/AccordionSummary';
-import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import {AppAccordion, AppAccordionHeader} from '../../components/AppAccordion/AppAccordion';
 
 interface SettingsAccordionProps {
     icon: React.ReactNode;
@@ -14,15 +11,11 @@ interface SettingsAccordionProps {
 }
 
 export const SettingsAccordion = ({icon, title, description, status, className = '', children}: SettingsAccordionProps) => (
-    <Accordion component="section" disableGutters elevation={0} className={`settings-accordion ${className}`.trim()}>
-        <AccordionSummary className="settings-accordion-summary" expandIcon={<ExpandMoreIcon aria-hidden="true" />}>
-            <span className="settings-accordion-icon" aria-hidden="true">{icon}</span>
-            <span className="settings-accordion-heading">
-                <span className="settings-accordion-title">{title}</span>
-                <span className="settings-accordion-description">{description}</span>
-            </span>
-            {status && <span className="settings-accordion-status">{status}</span>}
-        </AccordionSummary>
-        <AccordionDetails className="settings-accordion-details">{children}</AccordionDetails>
-    </Accordion>
+    <AppAccordion
+        component="section"
+        className={className}
+        summary={<AppAccordionHeader icon={icon} title={title} description={description} status={status} />}
+    >
+        {children}
+    </AppAccordion>
 );

--- a/src/containers/Settings/SettingsPage.css
+++ b/src/containers/Settings/SettingsPage.css
@@ -27,8 +27,6 @@
 
 .settings-grid {
   display: flex;
-  flex-direction: column;
-  gap: var(--spacing-sm);
 }
 
 .settings-diagnostics {
@@ -49,36 +47,8 @@
 .settings-diagnostics .diagnosis-list div { display: block; padding: var(--spacing-sm); background: var(--color-panel-contrast); border: 0; border-radius: var(--border-radius-medium); }
 .settings-diagnostics .diagnosis-list dd { margin-top: 2px; }
 
-.settings-accordion.MuiAccordion-root {
-  min-width: 0;
-  color: var(--color-text);
-  background: var(--color-panel-bg);
-  border: 1px solid var(--color-primary);
-  border-left-width: 3px;
-  border-radius: var(--border-radius-large) !important;
-  box-shadow: 0 2px 6px var(--shadow-card-light);
-  overflow: hidden;
-}
-.settings-accordion.MuiAccordion-root::before { display: none; }
-.settings-accordion.MuiAccordion-root.Mui-expanded { margin: 0; }
-.settings-accordion-summary.MuiAccordionSummary-root {
-  min-height: 68px;
-  padding: 0 var(--spacing-lg);
-  transition: background .15s;
-}
-.settings-accordion-summary.MuiAccordionSummary-root:hover { background: var(--color-panel-highlight); }
-.settings-accordion-summary.Mui-focusVisible { background: var(--color-panel-highlight) !important; outline: 2px solid var(--color-primary); outline-offset: -2px; }
-.settings-accordion-summary .MuiAccordionSummary-content { min-width: 0; align-items: center; gap: var(--spacing-md); margin: var(--spacing-sm) 0; }
-.settings-accordion-summary .MuiAccordionSummary-expandIconWrapper { color: var(--color-text-secondary); }
-.settings-accordion-icon { display: flex; flex: 0 0 auto; color: var(--color-primary); }
-.settings-accordion-icon svg { font-size: 1.5rem; }
-.settings-accordion-heading { display: flex; min-width: 0; flex: 1 1 auto; flex-direction: column; }
-.settings-accordion-title { font-size: var(--font-size-section-title); font-weight: 700; line-height: 1.25; }
-.settings-accordion-description { margin-top: 2px; color: var(--color-text-secondary); font-size: var(--font-size-small); line-height: var(--line-height-normal); }
-.settings-accordion-status { flex: 0 0 auto; margin-left: auto; }
 .settings-status-chip { display: inline-flex; padding: 3px var(--spacing-sm); color: var(--color-text-secondary); background: var(--color-panel-contrast); border: 1px solid var(--color-border); border-radius: var(--border-radius-pill); font-size: .75rem; font-weight: 700; white-space: nowrap; }
 .settings-status-chip.critical { color: var(--color-error); background: var(--color-error-subtle); border-color: var(--color-error); }
-.settings-accordion-details.MuiAccordionDetails-root { padding: var(--spacing-md) var(--spacing-lg) var(--spacing-lg); border-top: 1px solid var(--color-border-soft); }
 
 .settings-card {
   min-width: 0;
@@ -164,11 +134,6 @@
   .push-status-list, .sound-list { grid-template-columns: minmax(0, 1fr); }
   .settings-actions, .settings-footer { align-items: stretch; flex-direction: column; }
   .settings-actions button, .settings-footer button { width: 100%; }
-  .settings-accordion-summary.MuiAccordionSummary-root { min-height: 76px; padding-inline: var(--spacing-md); }
-  .settings-accordion-summary .MuiAccordionSummary-content { align-items: flex-start; flex-wrap: wrap; gap: var(--spacing-sm); }
-  .settings-accordion-heading { flex-basis: calc(100% - 2rem - var(--spacing-sm)); }
-  .settings-accordion-status { margin-left: calc(1.5rem + var(--spacing-sm)); }
-  .settings-accordion-details.MuiAccordionDetails-root { padding: var(--spacing-md); }
   .settings-diagnostics { padding: var(--spacing-md); }
   .settings-diagnostics .diagnosis-list { grid-template-columns: minmax(0, 1fr); }
 }

--- a/src/containers/Settings/SettingsPage.tsx
+++ b/src/containers/Settings/SettingsPage.tsx
@@ -481,7 +481,7 @@ export class SettingsPage extends React.Component<SettingsPageProps, SettingsPag
                     </dl>
                 </section>
 
-                <div className="settings-grid">
+                <div className="settings-grid app-accordion-group">
                     <SettingsAccordion className="agitator-defaults-card" icon={<TuneOutlinedIcon />} title="Rührwerk" description="Persistente Standardwerte der Brausteuerung.">
 
                         {agitatorLoading && <p className="agitator-settings-state" role="status">Rührwerk-Standardwerte werden geladen…</p>}


### PR DESCRIPTION
### Motivation

- Den neuen visuellen Accordion‑Stil, der auf der Settings‑Seite implementiert wurde, als App‑weiter Standard wiederverwenden und Duplikate vermeiden.
- Eine kleine gemeinsame Basis bereitstellen, die das visuelle Grundgerüst kapselt, ohne bestehende fachliche Accordion‑Logik zu verändern.

### Description

- Neue wiederverwendbare Basis `AppAccordion` mit optionalem `AppAccordionHeader` hinzugefügt unter `src/components/AppAccordion/` inklusive `AppAccordion.tsx` und `AppAccordion.css`, die das Settings‑Design (Border, orange Akzent, Radius, Summary‑Höhe, Hover/Focus, Details‑Padding, mobile Regeln) zentral bereitstellt.
- `SettingsAccordion` auf `AppAccordion` umgestellt, dabei Icon/Title/Description/Status‑Semantik erhalten und weiterverwendet (keine visuelle Regression der Settings‑Referenz). 
- Accordions in `src/containers/MainView/Details/Details.tsx` und `src/containers/DatabaseOverview/IngredientsFormPage.tsx` auf `AppAccordion` migriert und dabei bestehende Props/Control‑Logik (`expanded`, `onChange`, `defaultExpanded`, `aria-*`, IDs, refs, Eventhandler) unverändert gelassen.
- Lokale duplizierte Styles in `SettingsPage.css` und `IngredientsFormPage.css` bereinigt und ein zentrales Gruppierungs‑Klassenmuster `app-accordion-group` für konsistente Abstände eingeführt.
- Selbst implementierte, nicht‑MUI Akkordeons (z.B. im `BeerForm`) nicht verändert, da sie eigene ARIA/Keyboard-/Fehler‑Logik besitzen.
- Es wurden keine Requests, Socket‑Events, API‑Formate, Validierungen oder Business‑Logik geändert.

### Testing

- `git diff --check` und repository‑Suchprüfungen (`rg`) liefen erfolgreich und bestätigen, dass MUI‑Accordion‑Imports nun zentral über die neue Komponente konsistent verwendet werden.
- `npx tsc --noEmit` wurde ausgeführt, schlug jedoch fehl wegen projektweiter TypeScript/tsconfig‑Deprecation‑Hinweise (Umgebung/tsc‑Version) und ist daher nicht aussagekräftig für die Änderungen hier.
- `npm ci` schlug in der Laufzeitumgebung fehl (Registry HTTP 403), wodurch `npm test` und `npm run build` in dieser Umgebung nicht ausgeführt werden konnten; deshalb konnten Unit‑Tests/Build nicht abgeschlossen werden.
- Da die App in dieser Umgebung nicht gestartet werden konnte, wurden visuelle Verifikation und Screenshot nicht automatisiert ausgeführt.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a968649f850832fb60c49776a50f820)