### PR TITLE
Introduce AppAccordion component, migrate existing accordions, and add themed scrollbars

### DIFF
--- a/src/components/AppAccordion/AppAccordion.css
+++ b/src/components/AppAccordion/AppAccordion.css
@@ -1,0 +1,62 @@
+.app-accordion.MuiAccordion-root {
+    min-width: 0;
+    color: var(--color-text);
+    background: var(--color-panel-bg);
+    border: 1px solid var(--color-primary);
+    border-left-width: 3px;
+    border-radius: var(--border-radius-large) !important;
+    box-shadow: 0 2px 6px var(--shadow-card-light);
+    overflow: hidden;
+}
+
+.app-accordion.MuiAccordion-root::before { display: none; }
+.app-accordion.MuiAccordion-root.Mui-expanded { margin: 0; }
+
+.app-accordion-group {
+    display: flex;
+    min-width: 0;
+    flex-direction: column;
+    gap: var(--spacing-sm);
+}
+
+.app-accordion-summary.MuiAccordionSummary-root {
+    min-height: 68px;
+    padding: 0 var(--spacing-lg);
+    transition: background .15s;
+}
+
+.app-accordion-summary.MuiAccordionSummary-root:hover { background: var(--color-panel-highlight); }
+.app-accordion-summary.Mui-focusVisible {
+    background: var(--color-panel-highlight) !important;
+    outline: 2px solid var(--color-primary);
+    outline-offset: -2px;
+}
+
+.app-accordion-summary .MuiAccordionSummary-content {
+    min-width: 0;
+    align-items: center;
+    gap: var(--spacing-md);
+    margin: var(--spacing-sm) 0;
+}
+
+.app-accordion-summary .MuiAccordionSummary-expandIconWrapper { color: var(--color-text-secondary); }
+.app-accordion-icon { display: flex; flex: 0 0 auto; color: var(--color-primary); }
+.app-accordion-icon svg { font-size: 1.5rem; }
+.app-accordion-heading { display: flex; min-width: 0; flex: 1 1 auto; flex-direction: column; }
+.app-accordion-title { font-size: var(--font-size-section-title); font-weight: 700; line-height: 1.25; }
+.app-accordion-description { margin-top: 2px; color: var(--color-text-secondary); font-size: var(--font-size-small); line-height: var(--line-height-normal); }
+.app-accordion-status { flex: 0 0 auto; margin-left: auto; }
+.app-accordion-details.MuiAccordionDetails-root {
+    min-width: 0;
+    padding: var(--spacing-md) var(--spacing-lg) var(--spacing-lg);
+    background: var(--color-panel-bg);
+    border-top: 1px solid var(--color-border-soft);
+}
+
+@media (max-width: 600px) {
+    .app-accordion-summary.MuiAccordionSummary-root { min-height: 76px; padding-inline: var(--spacing-md); }
+    .app-accordion-summary .MuiAccordionSummary-content { align-items: flex-start; flex-wrap: wrap; gap: var(--spacing-sm); }
+    .app-accordion-heading { flex-basis: calc(100% - 2rem - var(--spacing-sm)); }
+    .app-accordion-status { margin-left: calc(1.5rem + var(--spacing-sm)); }
+    .app-accordion-details.MuiAccordionDetails-root { padding: var(--spacing-md); }
+}

--- a/src/components/AppAccordion/AppAccordion.tsx
+++ b/src/components/AppAccordion/AppAccordion.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import Accordion, {AccordionProps} from '@mui/material/Accordion';
+import AccordionDetails, {AccordionDetailsProps} from '@mui/material/AccordionDetails';
+import AccordionSummary, {AccordionSummaryProps} from '@mui/material/AccordionSummary';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import './AppAccordion.css';
+
+interface AppAccordionProps extends Omit<AccordionProps, 'children'> {
+    /** Allows callers to retain MUI's polymorphic root semantics (for example, a settings section). */
+    component?: React.ElementType;
+    summary: React.ReactNode;
+    children: React.ReactNode;
+    summaryProps?: Omit<AccordionSummaryProps, 'children' | 'expandIcon'>;
+    detailsProps?: Omit<AccordionDetailsProps, 'children'>;
+    expandIcon?: React.ReactNode;
+}
+
+const joinClassNames = (...classNames: Array<string | undefined>) => classNames.filter(Boolean).join(' ');
+
+/** Shared visual shell for application accordions. State and event props are passed to MUI unchanged. */
+export const AppAccordion = ({
+    summary,
+    children,
+    summaryProps,
+    detailsProps,
+    expandIcon = <ExpandMoreIcon aria-hidden="true" />,
+    className,
+    disableGutters = true,
+    elevation = 0,
+    ...accordionProps
+}: AppAccordionProps) => (
+    <Accordion
+        {...accordionProps}
+        disableGutters={disableGutters}
+        elevation={elevation}
+        className={joinClassNames('app-accordion', className)}
+    >
+        <AccordionSummary
+            {...summaryProps}
+            className={joinClassNames('app-accordion-summary', summaryProps?.className)}
+            expandIcon={expandIcon}
+        >
+            {summary}
+        </AccordionSummary>
+        <AccordionDetails
+            {...detailsProps}
+            className={joinClassNames('app-accordion-details', detailsProps?.className)}
+        >
+            {children}
+        </AccordionDetails>
+    </Accordion>
+);
+
+interface AppAccordionHeaderProps {
+    icon?: React.ReactNode;
+    title: React.ReactNode;
+    description?: React.ReactNode;
+    status?: React.ReactNode;
+}
+
+/** Flexible standard header; callers can pass arbitrary `summary` content when controls require it. */
+export const AppAccordionHeader = ({icon, title, description, status}: AppAccordionHeaderProps) => (
+    <>
+        {icon && <span className="app-accordion-icon" aria-hidden="true">{icon}</span>}
+        <span className="app-accordion-heading">
+            <span className="app-accordion-title">{title}</span>
+            {description && <span className="app-accordion-description">{description}</span>}
+        </span>
+        {status && <span className="app-accordion-status">{status}</span>}
+    </>
+);

--- a/src/containers/Dashboard/DashboardPage.css
+++ b/src/containers/Dashboard/DashboardPage.css
@@ -16,7 +16,7 @@
 .dashboard-section-header { display: flex; align-items: center; gap: var(--spacing-sm); margin-bottom: var(--spacing-sm); flex: none; }
 .dashboard-section-header h2 { font-size: var(--font-size-section-title); }
 .dashboard-section-header svg { color: var(--color-primary); font-size: 1.25rem; }
-.dashboard-scroll-list { min-height: 0; overflow-y: auto; scrollbar-color: var(--color-primary) var(--color-panel-contrast); padding-right: var(--spacing-xs); }
+.dashboard-scroll-list { min-height: 0; overflow-y: auto; padding-right: var(--spacing-xs); }
 .dashboard-active-row { display: grid; grid-template-columns: auto minmax(0, 1fr) auto auto; align-items: center; gap: var(--spacing-sm); padding: var(--spacing-md) var(--spacing-xs); border-bottom: 1px solid var(--color-border-soft); }
 .dashboard-active-row:last-child { border-bottom: 0; }
 .dashboard-active-row h3 { font-size: var(--font-size-normal); }

--- a/src/containers/DatabaseOverview/IngredientsFormPage.css
+++ b/src/containers/DatabaseOverview/IngredientsFormPage.css
@@ -1,27 +1,23 @@
-.containerIngredientsForm {
-    margin: 10px;
+.ingredients-page-scroll {
     width: 100%;
+    max-width: 100%;
+}
+
+.ingredients-page-scroll .simplebar-content {
+    min-width: 0;
+}
+
+.containerIngredientsForm {
+    box-sizing: border-box;
+    margin: 10px;
+    width: auto;
+    max-width: calc(100% - 20px);
+    min-width: 0;
     height: auto !important;
     overflow: visible !important;
 }
 
-.containerIngredientsForm .ingredients-accordion {
-    background-color: var(--color-brew-bg) !important;
-    box-shadow: none !important;
-    margin-bottom: 8px;
-}
-
-.containerIngredientsForm .ingredients-accordion::before {
-    display: none;
-}
-
-.containerIngredientsForm .ingredients-accordion-summary {
-    background-color: var(--color-accent) !important;
-    min-height: 48px !important;
-}
-
 .containerIngredientsForm .ingredients-accordion-details {
-    background-color: var(--color-brew-bg) !important;
     overflow: visible !important;
 }
 
@@ -40,6 +36,7 @@
 }
 
 .containerIngredientsForm .MuiTableContainer-root {
+    max-width: 100%;
     background-color: var(--color-brew-bg) !important;
     box-shadow: none !important;
     padding: 0 !important;

--- a/src/containers/DatabaseOverview/IngredientsFormPage.tsx
+++ b/src/containers/DatabaseOverview/IngredientsFormPage.tsx
@@ -1,8 +1,5 @@
 import React from 'react';
 import {
-    Accordion,
-    AccordionDetails,
-    AccordionSummary,
     Typography,
     Table,
     TableBody,
@@ -11,7 +8,6 @@ import {
     TableHead,
     TableRow
 } from "@mui/material";
-import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import AddIcon from "@mui/icons-material/Add";
 import SaveIcon from "@mui/icons-material/Save";
 import CloseIcon from "@mui/icons-material/Close";
@@ -26,6 +22,7 @@ import './IngredientsFormPage.css';
 
 import { AdditionalIngredient } from "../../model/AdditionalIngredient";
 import EditIcon from "@mui/icons-material/Edit";
+import {AppAccordion, AppAccordionHeader} from "../../components/AppAccordion/AppAccordion";
 import {IngredientEditDialog, IngredientEditValue, IngredientKind} from "./IngredientEditDialog";
 
 
@@ -80,18 +77,15 @@ export class IngredientsFormPage extends React.Component<any, any> {
         const { expandedAccordion } = this.state;
 
         return (
-            <Accordion
+            <AppAccordion
                 expanded={expandedAccordion === aAccordionKey}
                 onChange={this.handleAccordionChange(aAccordionKey)}
                 className="ingredients-accordion"
+                summary={<AppAccordionHeader title={aTitle} />}
+                detailsProps={{className: 'ingredients-accordion-details'}}
             >
-                <AccordionSummary expandIcon={<ExpandMoreIcon />} className="ingredients-accordion-summary">
-                    <Typography>{aTitle}</Typography>
-                </AccordionSummary>
-                <AccordionDetails className="ingredients-accordion-details">
-                    {aContent}
-                </AccordionDetails>
-            </Accordion>
+                {aContent}
+            </AppAccordion>
         );
     };
 
@@ -387,11 +381,12 @@ export class IngredientsFormPage extends React.Component<any, any> {
     render() {
         return (
             <SimpleBar
+                className="ingredients-page-scroll"
                 ref={(ref) => { this.simpleBarRef = ref }}
                 style={{ height: "calc(100vh - 0px)" }}
                 autoHide={false}
             >
-                <div className='containerIngredientsForm'>
+                <div className='containerIngredientsForm app-accordion-group'>
                     {this.renderIngredientAccordion("malz", "Malz", this.renderMaltContent())}
                     {this.renderIngredientAccordion("hopfen", "Hopfen", this.renderHopContent())}
                     {this.renderIngredientAccordion("hefe", "Hefe", this.renderYeastContent())}

--- a/src/containers/MainView/Details/Details.tsx
+++ b/src/containers/MainView/Details/Details.tsx
@@ -3,7 +3,6 @@ import './Details.css';
 import { Beer } from "../../../model/Beer";
 
 import {
-    Accordion, AccordionDetails, AccordionSummary,
     Paper,
     Table,
     TableBody,
@@ -13,9 +12,9 @@ import {
     TableRow,
     Typography
 } from "@mui/material";
-import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import {BeerRecipeScaler, scalingValues} from "../../../utils/BeerScaler/ScalingBeerRecipe";
-import {COLOR_ACCENT, COLOR_BREW_BG} from "../../../colors";
+import {COLOR_BREW_BG} from "../../../colors";
+import {AppAccordion, AppAccordionHeader} from "../../../components/AppAccordion/AppAccordion";
 
 interface DetailsProps {
     selectedBeer?: Beer;
@@ -145,22 +144,9 @@ export class Details extends React.Component<DetailsProps, DetailsState> {
     // -------------------------------------------------------------
     renderAccordionGeneralData() {
         return (
-            <Accordion defaultExpanded>
-                <AccordionSummary
-                    sx={{
-                        backgroundColor: COLOR_ACCENT,
-                        color: 'white',
-                        '& .MuiTypography-root': { color: 'white' }
-                    }}
-                    expandIcon={<ExpandMoreIcon sx={{ color: 'white' }} />}
-                >
-                    <Typography>Allgemeine Daten</Typography>
-                </AccordionSummary>
-
-                <AccordionDetails sx={{ backgroundColor: COLOR_BREW_BG }}>
-                    {this.renderGeneralData()}
-                </AccordionDetails>
-            </Accordion>
+            <AppAccordion defaultExpanded summary={<AppAccordionHeader title="Allgemeine Daten" />}>
+                {this.renderGeneralData()}
+            </AppAccordion>
         );
     }
 
@@ -188,22 +174,9 @@ export class Details extends React.Component<DetailsProps, DetailsState> {
     // -------------------------------------------------------------
     renderAccordionFermentation() {
         return (
-            <Accordion>
-                <AccordionSummary
-                    sx={{
-                        backgroundColor: COLOR_ACCENT,
-                        color: 'white',
-                        '& .MuiTypography-root': { color: 'white' }
-                    }}
-                    expandIcon={<ExpandMoreIcon sx={{ color: 'white' }} />}
-                >
-                    <Typography>Maischplan</Typography>
-                </AccordionSummary>
-
-                <AccordionDetails sx={{ backgroundColor: COLOR_BREW_BG }}>
-                    {this.renderFermentation()}
-                </AccordionDetails>
-            </Accordion>
+            <AppAccordion summary={<AppAccordionHeader title="Maischplan" />}>
+                {this.renderFermentation()}
+            </AppAccordion>
         );
     }
 
@@ -240,22 +213,9 @@ export class Details extends React.Component<DetailsProps, DetailsState> {
     // -------------------------------------------------------------
     renderAccordionFilling() {
         return (
-            <Accordion>
-                <AccordionSummary
-                    sx={{
-                        backgroundColor: COLOR_ACCENT,
-                        color: 'white',
-                        '& .MuiTypography-root': { color: 'white' }
-                    }}
-                    expandIcon={<ExpandMoreIcon sx={{ color: 'white' }} />}
-                >
-                    <Typography>Schüttung</Typography>
-                </AccordionSummary>
-
-                <AccordionDetails sx={{ backgroundColor: COLOR_BREW_BG }}>
-                    {this.renderFilling()}
-                </AccordionDetails>
-            </Accordion>
+            <AppAccordion summary={<AppAccordionHeader title="Schüttung" />}>
+                {this.renderFilling()}
+            </AppAccordion>
         );
     }
 
@@ -290,22 +250,9 @@ export class Details extends React.Component<DetailsProps, DetailsState> {
     // -------------------------------------------------------------
     renderAccordionWortBoiling() {
         return (
-            <Accordion>
-                <AccordionSummary
-                    sx={{
-                        backgroundColor: COLOR_ACCENT,
-                        color: 'white',
-                        '& .MuiTypography-root': { color: 'white' }
-                    }}
-                    expandIcon={<ExpandMoreIcon sx={{ color: 'white' }} />}
-                >
-                    <Typography>Würzekochen</Typography>
-                </AccordionSummary>
-
-                <AccordionDetails sx={{ backgroundColor: COLOR_BREW_BG }}>
-                    {this.renderWortBoiling()}
-                </AccordionDetails>
-            </Accordion>
+            <AppAccordion summary={<AppAccordionHeader title="Würzekochen" />}>
+                {this.renderWortBoiling()}
+            </AppAccordion>
         );
     }
 
@@ -349,22 +296,9 @@ export class Details extends React.Component<DetailsProps, DetailsState> {
     // -------------------------------------------------------------
     renderAccordionFermentationMaturation() {
         return (
-            <Accordion>
-                <AccordionSummary
-                    sx={{
-                        backgroundColor: COLOR_ACCENT,
-                        color: 'white',
-                        '& .MuiTypography-root': { color: 'white' }
-                    }}
-                    expandIcon={<ExpandMoreIcon sx={{ color: 'white' }} />}
-                >
-                    <Typography>Gärung und Reifung</Typography>
-                </AccordionSummary>
-
-                <AccordionDetails sx={{ backgroundColor: COLOR_BREW_BG }}>
-                    {this.renderFermentationMaturation()}
-                </AccordionDetails>
-            </Accordion>
+            <AppAccordion summary={<AppAccordionHeader title="Gärung und Reifung" />}>
+                {this.renderFermentationMaturation()}
+            </AppAccordion>
         );
     }
 
@@ -410,22 +344,9 @@ export class Details extends React.Component<DetailsProps, DetailsState> {
     // -------------------------------------------------------------
     renderAccordionWater() {
         return (
-            <Accordion>
-                <AccordionSummary
-                    sx={{
-                        backgroundColor: COLOR_ACCENT,
-                        color: 'white',
-                        '& .MuiTypography-root': { color: 'white' }
-                    }}
-                    expandIcon={<ExpandMoreIcon sx={{ color: 'white' }} />}
-                >
-                    <Typography>Wasser</Typography>
-                </AccordionSummary>
-
-                <AccordionDetails sx={{ backgroundColor: COLOR_BREW_BG }}>
-                    {this.renderBrewingWater()}
-                </AccordionDetails>
-            </Accordion>
+            <AppAccordion summary={<AppAccordionHeader title="Wasser" />}>
+                {this.renderBrewingWater()}
+            </AppAccordion>
         );
     }
 
@@ -466,12 +387,14 @@ export class Details extends React.Component<DetailsProps, DetailsState> {
 
                 {/* ONLY THIS PART SCROLLS */}
 
-                    {this.renderAccordionGeneralData()}
-                    {this.renderAccordionFermentation()}
-                    {this.renderAccordionFilling()}
-                    {this.renderAccordionWortBoiling()}
-                    {this.renderAccordionFermentationMaturation()}
-                    {this.renderAccordionWater()}
+                    <div className="app-accordion-group">
+                        {this.renderAccordionGeneralData()}
+                        {this.renderAccordionFermentation()}
+                        {this.renderAccordionFilling()}
+                        {this.renderAccordionWortBoiling()}
+                        {this.renderAccordionFermentationMaturation()}
+                        {this.renderAccordionWater()}
+                    </div>
 
 
             </div>

--- a/src/containers/Production/ProcessList/ProcessList.css
+++ b/src/containers/Production/ProcessList/ProcessList.css
@@ -242,25 +242,6 @@
     overflow-y: auto;
     overflow-x: hidden;
     padding-right: 0.25rem;
-    scrollbar-width: thin;
-    scrollbar-color: rgba(255, 255, 255, 0.35) transparent;
-}
-
-.upcoming-process-scroll::-webkit-scrollbar {
-    width: 0.35rem;
-}
-
-.upcoming-process-scroll::-webkit-scrollbar-track {
-    background: transparent;
-}
-
-.upcoming-process-scroll::-webkit-scrollbar-thumb {
-    background: rgba(255, 255, 255, 0.22);
-    border-radius: 999px;
-}
-
-.upcoming-process-scroll:hover::-webkit-scrollbar-thumb {
-    background: rgba(255, 255, 255, 0.36);
 }
 
 .upcoming-process-scroll ul {

--- a/src/containers/Settings/SettingsAccordion.tsx
+++ b/src/containers/Settings/SettingsAccordion.tsx
@@ -1,8 +1,5 @@
 import React from 'react';
-import Accordion from '@mui/material/Accordion';
-import AccordionDetails from '@mui/material/AccordionDetails';
-import AccordionSummary from '@mui/material/AccordionSummary';
-import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import {AppAccordion, AppAccordionHeader} from '../../components/AppAccordion/AppAccordion';
 
 interface SettingsAccordionProps {
     icon: React.ReactNode;
@@ -14,15 +11,11 @@ interface SettingsAccordionProps {
 }
 
 export const SettingsAccordion = ({icon, title, description, status, className = '', children}: SettingsAccordionProps) => (
-    <Accordion component="section" disableGutters elevation={0} className={`settings-accordion ${className}`.trim()}>
-        <AccordionSummary className="settings-accordion-summary" expandIcon={<ExpandMoreIcon aria-hidden="true" />}>
-            <span className="settings-accordion-icon" aria-hidden="true">{icon}</span>
-            <span className="settings-accordion-heading">
-                <span className="settings-accordion-title">{title}</span>
-                <span className="settings-accordion-description">{description}</span>
-            </span>
-            {status && <span className="settings-accordion-status">{status}</span>}
-        </AccordionSummary>
-        <AccordionDetails className="settings-accordion-details">{children}</AccordionDetails>
-    </Accordion>
+    <AppAccordion
+        component="section"
+        className={className}
+        summary={<AppAccordionHeader icon={icon} title={title} description={description} status={status} />}
+    >
+        {children}
+    </AppAccordion>
 );

--- a/src/containers/Settings/SettingsPage.css
+++ b/src/containers/Settings/SettingsPage.css
@@ -49,36 +49,8 @@
 .settings-diagnostics .diagnosis-list div { display: block; padding: var(--spacing-sm); background: var(--color-panel-contrast); border: 0; border-radius: var(--border-radius-medium); }
 .settings-diagnostics .diagnosis-list dd { margin-top: 2px; }
 
-.settings-accordion.MuiAccordion-root {
-  min-width: 0;
-  color: var(--color-text);
-  background: var(--color-panel-bg);
-  border: 1px solid var(--color-primary);
-  border-left-width: 3px;
-  border-radius: var(--border-radius-large) !important;
-  box-shadow: 0 2px 6px var(--shadow-card-light);
-  overflow: hidden;
-}
-.settings-accordion.MuiAccordion-root::before { display: none; }
-.settings-accordion.MuiAccordion-root.Mui-expanded { margin: 0; }
-.settings-accordion-summary.MuiAccordionSummary-root {
-  min-height: 68px;
-  padding: 0 var(--spacing-lg);
-  transition: background .15s;
-}
-.settings-accordion-summary.MuiAccordionSummary-root:hover { background: var(--color-panel-highlight); }
-.settings-accordion-summary.Mui-focusVisible { background: var(--color-panel-highlight) !important; outline: 2px solid var(--color-primary); outline-offset: -2px; }
-.settings-accordion-summary .MuiAccordionSummary-content { min-width: 0; align-items: center; gap: var(--spacing-md); margin: var(--spacing-sm) 0; }
-.settings-accordion-summary .MuiAccordionSummary-expandIconWrapper { color: var(--color-text-secondary); }
-.settings-accordion-icon { display: flex; flex: 0 0 auto; color: var(--color-primary); }
-.settings-accordion-icon svg { font-size: 1.5rem; }
-.settings-accordion-heading { display: flex; min-width: 0; flex: 1 1 auto; flex-direction: column; }
-.settings-accordion-title { font-size: var(--font-size-section-title); font-weight: 700; line-height: 1.25; }
-.settings-accordion-description { margin-top: 2px; color: var(--color-text-secondary); font-size: var(--font-size-small); line-height: var(--line-height-normal); }
-.settings-accordion-status { flex: 0 0 auto; margin-left: auto; }
 .settings-status-chip { display: inline-flex; padding: 3px var(--spacing-sm); color: var(--color-text-secondary); background: var(--color-panel-contrast); border: 1px solid var(--color-border); border-radius: var(--border-radius-pill); font-size: .75rem; font-weight: 700; white-space: nowrap; }
 .settings-status-chip.critical { color: var(--color-error); background: var(--color-error-subtle); border-color: var(--color-error); }
-.settings-accordion-details.MuiAccordionDetails-root { padding: var(--spacing-md) var(--spacing-lg) var(--spacing-lg); border-top: 1px solid var(--color-border-soft); }
 
 .settings-card {
   min-width: 0;
@@ -164,11 +136,6 @@
   .push-status-list, .sound-list { grid-template-columns: minmax(0, 1fr); }
   .settings-actions, .settings-footer { align-items: stretch; flex-direction: column; }
   .settings-actions button, .settings-footer button { width: 100%; }
-  .settings-accordion-summary.MuiAccordionSummary-root { min-height: 76px; padding-inline: var(--spacing-md); }
-  .settings-accordion-summary .MuiAccordionSummary-content { align-items: flex-start; flex-wrap: wrap; gap: var(--spacing-sm); }
-  .settings-accordion-heading { flex-basis: calc(100% - 2rem - var(--spacing-sm)); }
-  .settings-accordion-status { margin-left: calc(1.5rem + var(--spacing-sm)); }
-  .settings-accordion-details.MuiAccordionDetails-root { padding: var(--spacing-md); }
   .settings-diagnostics { padding: var(--spacing-md); }
   .settings-diagnostics .diagnosis-list { grid-template-columns: minmax(0, 1fr); }
 }

--- a/src/index.css
+++ b/src/index.css
@@ -13,6 +13,52 @@ body {
     font-family: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", "Noto Sans", "Liberation Sans", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
 }
 
+/* Theme-aware native scrollbars for tables and all other overflow regions. */
+* {
+    scrollbar-color: var(--color-primary) var(--color-panel-contrast);
+    scrollbar-width: thin;
+}
+
+*::-webkit-scrollbar {
+    width: 10px;
+    height: 10px;
+}
+
+*::-webkit-scrollbar-track {
+    background: var(--color-panel-contrast);
+}
+
+*::-webkit-scrollbar-thumb {
+    background: var(--color-primary);
+    border: 2px solid var(--color-panel-contrast);
+    border-radius: var(--border-radius-pill);
+}
+
+*::-webkit-scrollbar-thumb:hover {
+    background: var(--color-primary-hover);
+}
+
+*::-webkit-scrollbar-corner {
+    background: var(--color-panel-contrast);
+}
+
+/* SimpleBar renders its own track and thumb instead of the browser scrollbar. */
+.simplebar-track {
+    background: var(--color-panel-contrast);
+}
+
+.simplebar-scrollbar::before {
+    background: var(--color-primary);
+    border-radius: var(--border-radius-pill);
+    opacity: .8;
+}
+
+.simplebar-scrollbar.simplebar-visible::before,
+.simplebar-track:hover .simplebar-scrollbar::before {
+    background: var(--color-primary-hover);
+    opacity: 1;
+}
+
 .MainContainer {
     width: 100%;
     height: 100%;


### PR DESCRIPTION
### Motivation
- Provide a shared, themeable accordion shell and header to standardize look/feel and accessibility across the app.
- Replace ad-hoc MUI `Accordion` usages with a reusable component to centralize styling and behavior.
- Improve native and SimpleBar scrollbar styling to match the theme.

### Description
- Add `AppAccordion` and `AppAccordionHeader` (`src/components/AppAccordion/AppAccordion.tsx`) and styles (`src/components/AppAccordion/AppAccordion.css`) to encapsulate MUI accordion markup and classes.
- Migrate usages of raw MUI `Accordion`/`AccordionSummary`/`AccordionDetails` to `AppAccordion` in `IngredientsFormPage`, `Details`, `SettingsAccordion`, and other places, and wrap accordion lists with the new `.app-accordion-group` layout class.
- Refactor styles: introduce theme-aware global scrollbar styles in `src/index.css`, add SimpleBar track/thumb rules, and adjust several container CSS files (`DashboardPage.css`, `IngredientsFormPage.css`, `SettingsPage.css`, `ProcessList.css`) to remove duplicated scrollbar rules and adapt to the new accordion classes.
- Update markup in `IngredientsFormPage.tsx`, `Details.tsx`, `SettingsAccordion.tsx` to use `AppAccordionHeader` for summary content and pass `detailsProps`/`summary` where needed.

### Testing
- Built the app with `yarn build` and the production build completed successfully.
- Ran the test suite with `yarn test` and all tests passed.
- Type-checked the TypeScript code with `tsc --noEmit` and there were no type errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a968649f850832fb60c49776a50f820)