### PR TITLE
Add global warning state to controller UI

### DIFF
--- a/src/actions/warningActions.ts
+++ b/src/actions/warningActions.ts
@@ -1,0 +1,19 @@
+import {WarningRealtimeState} from '../model/Warning';
+
+export namespace WarningActions {
+    export enum ActionTypes {
+        WARNING_STATE_CHANGED = 'WarningActions.WARNING_STATE_CHANGED',
+    }
+
+    export interface WarningStateChanged {
+        readonly type: ActionTypes.WARNING_STATE_CHANGED;
+        payload: WarningRealtimeState;
+    }
+
+    export type AllWarningActions = WarningStateChanged;
+
+    export const warningStateChanged = (payload: WarningRealtimeState): WarningStateChanged => ({
+        type: ActionTypes.WARNING_STATE_CHANGED,
+        payload,
+    });
+}

--- a/src/containers/MainView/Header/Header.connect.ts
+++ b/src/containers/MainView/Header/Header.connect.ts
@@ -3,14 +3,17 @@ import {Views} from "../../../enums/eViews";
 import {ApplicationActions} from "../../../actions/actions";
 import setViewState = ApplicationActions.setViewState;
 import {Header} from './Header';
+import type {RootState} from '../../../reducers/rootReducer';
 
-const mapStateToProps = (state: any) => ({
+const mapStateToProps = (state: RootState) => ({
     currentView: state.applicationReducer.view,
     messages: state.applicationReducer.message,
     backendStatus: state.productionReducer.isBackenAvailable,
     brewingStatus: state.productionReducer.brewingStatus,
     realtimeState: state.productionReducer.realtimeState,
     socketConnected: state.productionReducer.socketConnection.connected,
+    warnings: state.warningReducer.warnings,
+    warningsReceived: state.warningReducer.warningsReceived,
 });
 
 const mapDispatchToProps = (dispatch: any) => ({

--- a/src/containers/MainView/Header/Header.test.tsx
+++ b/src/containers/MainView/Header/Header.test.tsx
@@ -81,10 +81,48 @@ describe('Header navigation', () => {
         expect(screen.queryByText('Bereit')).not.toBeInTheDocument();
     });
 
-    it('shows translated sensor failures globally and removes the warning after recovery', () => {
+    it('shows backend warnings globally with warning severity', () => {
+        render(
+            <Header
+                setViewState={jest.fn()}
+                currentView={Views.SETTINGS}
+                removeAllMessages={jest.fn()}
+                backendStatus={true}
+                messages={['Bereit']}
+                socketConnected={true}
+                realtimeState={healthyRealtime}
+                warningsReceived={true}
+                warnings={[{type: 'TEMPERATURE_SENSOR', active: true, details: {health: 'MISSING'}}]}
+            />
+        );
+
+        expect(screen.getByRole('status')).toHaveTextContent('Temperatursensor nicht verfügbar');
+        expect(screen.queryByText('Bereit')).not.toBeInTheDocument();
+    });
+
+    it('keeps alarms above warnings when both are active', () => {
+        render(
+            <Header
+                setViewState={jest.fn()}
+                currentView={Views.PRODUCTION}
+                removeAllMessages={jest.fn()}
+                backendStatus={true}
+                messages={[]}
+                socketConnected={true}
+                realtimeState={{alarms: [{type: AlarmType.EQUIPMENT_ALARM, active: true}], alarmsReceived: true}}
+                warningsReceived={true}
+                warnings={[{type: 'TEMPERATURE_SENSOR', active: true, details: {health: 'MISSING'}}]}
+            />
+        );
+
+        expect(screen.getByRole('alert')).toHaveTextContent('ANLAGENALARM – Anlage prüfen');
+        expect(screen.queryByText('Temperatursensor nicht verfügbar')).not.toBeInTheDocument();
+    });
+
+    it('shows translated sensor failures globally as compatibility fallback and removes the warning after recovery', () => {
         const props = {setViewState: jest.fn(), currentView: Views.SETTINGS, removeAllMessages: jest.fn(), backendStatus: true, messages: []};
         const {rerender} = render(<Header {...props} socketConnected={true} realtimeState={{...healthyRealtime, temperatureSensor: {current: null, health: 'MULTIPLE_SENSORS_FOUND', sensorId: null}}} />);
-        expect(screen.getByRole('alert')).toHaveTextContent('Mehrere Temperatursensoren erkannt');
+        expect(screen.getByRole('status')).toHaveTextContent('Mehrere Temperatursensoren erkannt');
         rerender(<Header {...props} socketConnected={true} realtimeState={healthyRealtime} />);
         expect(screen.queryByText(/Temperatursensor:/)).not.toBeInTheDocument();
     });

--- a/src/containers/MainView/Header/Header.tsx
+++ b/src/containers/MainView/Header/Header.tsx
@@ -15,6 +15,8 @@ import {SystemRepository} from '../../../repositorys/SystemRepository';
 import {RealtimeControllerState} from '../../../model/RealtimeControllerState';
 import {getAlarmSnapshot} from '../../Production/utils/productionStatus';
 import {getTemperatureSensorMessage} from '../../../utils/temperatureSensor';
+import {Warning} from '../../../model/Warning';
+import {getWarningHeaderText} from '../../../utils/warningDisplay';
 
 
 
@@ -27,6 +29,8 @@ interface HeaderProps {
     brewingStatus?: BrewingStatus;
     realtimeState?: RealtimeControllerState;
     socketConnected?: boolean;
+    warnings?: Warning[];
+    warningsReceived?: boolean;
 }
 
 interface HeaderState {
@@ -116,10 +120,17 @@ export class Header extends React.Component<HeaderProps, HeaderState> {
        const alarmText = isHeaterStuckOnAlarmActive(alarms)
            ? heaterStuckOnAlarmDisplay.headerText
            : isEquipmentAlarmActive(alarms) ? equipmentAlarmDisplay.headerText : undefined;
+       const warningText = this.props.socketConnected && this.props.warningsReceived
+           ? getWarningHeaderText(this.props.warnings)
+           : undefined;
        const temperatureSensor = this.props.realtimeState?.temperatureSensor;
-       const sensorWarning = !this.props.socketConnected || temperatureSensor?.health !== 'OK'
+       // Keep the technical sensor state as a compatibility fallback until all
+       // controller versions provide warning-state-changed snapshots.
+       const sensorWarning = !warningText && (!this.props.socketConnected || temperatureSensor?.health !== 'OK')
            ? `⚠ Temperatursensor: ${getTemperatureSensorMessage(temperatureSensor)}`
            : undefined;
+       const priorityMessage = alarmText ?? warningText ?? sensorWarning;
+       const prioritySeverity = alarmText ? 'alarm' : priorityMessage ? 'warning' : undefined;
        const uiMode = getUiMode();
        const navigationViews = getNavigationViews(uiMode);
        const isVisible = (view: Views) => navigationViews.includes(view);
@@ -209,7 +220,14 @@ export class Header extends React.Component<HeaderProps, HeaderState> {
                 </div>
                 <div className="header-status">
                   <div className="status-display-wrapper">
-                    <StatusDisplay backendStatus={backendStatus} messages={messages} priorityMessage={alarmText ?? sensorWarning} disableScrollAnimation={true} removeAllMessages={removeAllMessages}/>
+                    <StatusDisplay
+                      backendStatus={backendStatus}
+                      messages={messages}
+                      priorityMessage={priorityMessage}
+                      prioritySeverity={prioritySeverity}
+                      disableScrollAnimation={true}
+                      removeAllMessages={removeAllMessages}
+                    />
                   </div>
                   <div className="time">
                     <span>{this.state.currentDate}</span>

--- a/src/containers/MainView/Header/StatusDisplay.css
+++ b/src/containers/MainView/Header/StatusDisplay.css
@@ -109,3 +109,8 @@
   color: var(--color-error);
   font-weight: bold;
 }
+
+.warning-message .message {
+  color: var(--color-warning);
+  font-weight: bold;
+}

--- a/src/containers/MainView/Header/StatusDisplay.test.tsx
+++ b/src/containers/MainView/Header/StatusDisplay.test.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import {render, screen} from '@testing-library/react';
+import StatusDisplay from './StatusDisplay';
+
+describe('StatusDisplay priority severity', () => {
+    it('renders alarms as assertive red priority messages', () => {
+        render(
+            <StatusDisplay
+                backendStatus={true}
+                priorityMessage="Alarm"
+                prioritySeverity="alarm"
+                removeAllMessages={jest.fn()}
+            />
+        );
+
+        expect(screen.getByRole('alert')).toHaveTextContent('Alarm');
+        expect(screen.getByRole('alert')).toHaveClass('alarm-message');
+    });
+
+    it('renders warnings as non-alarm warning priority messages', () => {
+        render(
+            <StatusDisplay
+                backendStatus={true}
+                priorityMessage="Warnung"
+                prioritySeverity="warning"
+                removeAllMessages={jest.fn()}
+            />
+        );
+
+        expect(screen.getByRole('status')).toHaveTextContent('Warnung');
+        expect(screen.getByRole('status')).toHaveClass('warning-message');
+        expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    });
+});

--- a/src/containers/MainView/Header/StatusDisplay.tsx
+++ b/src/containers/MainView/Header/StatusDisplay.tsx
@@ -7,6 +7,7 @@ interface StatusDisplayProps {
   disableScrollAnimation?: boolean;
   removeAllMessages: () => void;
   priorityMessage?: string;
+  prioritySeverity?: 'alarm' | 'warning';
 }
 
 interface StatusDisplayState {}
@@ -62,9 +63,14 @@ class StatusDisplay extends React.Component<StatusDisplayProps, StatusDisplaySta
   };
 
   render() {
-    const { backendStatus, messages, removeAllMessages, priorityMessage } = this.props;
+    const { backendStatus, messages, removeAllMessages, priorityMessage, prioritySeverity } = this.props;
 
     const backendClass = backendStatus ? 'Online' : 'Offline';
+    const priorityClass = prioritySeverity === 'alarm'
+      ? 'alarm-message'
+      : prioritySeverity === 'warning' ? 'warning-message' : '';
+    const priorityRole = prioritySeverity === 'alarm' ? 'alert' : 'status';
+
     return (
       <div className="status-display">
         <div className="backend-status-row">
@@ -74,7 +80,7 @@ class StatusDisplay extends React.Component<StatusDisplayProps, StatusDisplaySta
           </span>
         </div>
         {priorityMessage ? (
-          <div className="messages alarm-message" role="alert">
+          <div className={`messages ${priorityClass}`} role={priorityRole}>
             <div className="message-row">
               <span className="message">{priorityMessage}</span>
             </div>

--- a/src/containers/Mobile/MobileStatusView/MobileProductionView.connect.ts
+++ b/src/containers/Mobile/MobileStatusView/MobileProductionView.connect.ts
@@ -2,15 +2,18 @@ import { connect } from 'react-redux';
 import { ProductionActions } from '../../../actions/actions';
 import {MobileProductionView} from './MobileProductionView';
 import {ConfirmStates} from '../../../enums/eConfirmStates';
+import type {RootState} from '../../../reducers/rootReducer';
 
-const mapStateToProps = (state: any) => ({
+const mapStateToProps = (state: RootState) => ({
     temperature: state.productionReducer.temperature,
     brewingStatus: state.productionReducer.brewingStatus,
     isConfirmPending: state.productionReducer.isConfirmPending,
     confirmError: state.productionReducer.confirmError,
-    isBrewingStatusStale: state.productionReducer.isBrewingStatusStale
-    ,realtimeState: state.productionReducer.realtimeState
-    ,socketConnected: state.productionReducer.socketConnection.connected
+    isBrewingStatusStale: state.productionReducer.isBrewingStatusStale,
+    realtimeState: state.productionReducer.realtimeState,
+    socketConnected: state.productionReducer.socketConnection.connected,
+    warnings: state.warningReducer.warnings,
+    warningsReceived: state.warningReducer.warningsReceived,
 });
 
 const mapDispatchToProps = (dispatch: any) => ({

--- a/src/containers/Mobile/MobileStatusView/MobileProductionView.css
+++ b/src/containers/Mobile/MobileStatusView/MobileProductionView.css
@@ -15,6 +15,20 @@
   overflow: hidden;
 }
 
+.mobile-global-warning {
+  width: 100%;
+  box-sizing: border-box;
+  margin: 0 0 8px;
+  padding: 10px 12px;
+  color: var(--color-warning);
+  background: var(--color-warning-subtle);
+  border: 1px solid var(--color-warning);
+  border-radius: 8px;
+  font-weight: 700;
+  line-height: 1.3;
+  flex: 0 0 auto;
+}
+
 .mobile-content {
   flex: 1 1 auto;
   width: 100%;

--- a/src/containers/Mobile/MobileStatusView/MobileProductionView.tsx
+++ b/src/containers/Mobile/MobileStatusView/MobileProductionView.tsx
@@ -9,7 +9,9 @@ import {ConfirmStates} from '../../../enums/eConfirmStates';
 import {ControlConfirmationNotice} from '../../Production/components/InlineProcessNotice';
 import {getAgitatorActive, getHeatingActive} from '../../Production/utils/productionStatus';
 import {RealtimeControllerState} from '../../../model/RealtimeControllerState';
-import {formatTemperature} from '../../../utils/temperatureSensor';
+import {formatTemperature, getTemperatureSensorMessage} from '../../../utils/temperatureSensor';
+import {Warning} from '../../../model/Warning';
+import {getWarningHeaderText} from '../../../utils/warningDisplay';
 
 interface MobileProductionViewProps {
     temperature: number;
@@ -20,6 +22,8 @@ interface MobileProductionViewProps {
     isBrewingStatusStale: boolean;
     realtimeState?: RealtimeControllerState;
     socketConnected?: boolean;
+    warnings?: Warning[];
+    warningsReceived?: boolean;
 }
 
 interface MobileProductionViewState {
@@ -88,6 +92,15 @@ export class MobileProductionView extends React.Component<MobileProductionViewPr
         const { activeTab } = this.state;
         const statusText = this.props.isBrewingStatusStale ? 'Status veraltet – Controller nicht erreichbar' : getBrewingStatusLabel(brewingStatus);
         const confirmationRequest = getConfirmationRequestViewModel(brewingStatus);
+        const warningText = this.props.socketConnected && this.props.warningsReceived
+            ? getWarningHeaderText(this.props.warnings)
+            : undefined;
+        const temperatureSensor = this.props.realtimeState?.temperatureSensor;
+        const sensorWarning = !warningText && this.props.socketConnected && temperatureSensor?.health !== 'OK'
+            ? `⚠ ${getTemperatureSensorMessage(temperatureSensor)}`
+            : undefined;
+        const globalWarningText = warningText ?? sensorWarning;
+
         return (
             <div
                 className="mobile-production-container"
@@ -95,6 +108,11 @@ export class MobileProductionView extends React.Component<MobileProductionViewPr
                 onTouchMove={this.handleTouchMove}
                 onTouchEnd={this.handleTouchEnd}
             >
+                {globalWarningText && (
+                    <div className="mobile-global-warning" role="status">
+                        {globalWarningText}
+                    </div>
+                )}
                 <div className="mobile-tabs">
                     <button className={activeTab === 'status' ? 'active' : ''} onClick={() => this.handleTabChange('status')}>Status</button>
                     <button className={activeTab === 'finishedBrew' ? 'active' : ''} onClick={() => this.handleTabChange('finishedBrew')}>Aktiver Sud</button>

--- a/src/epics/productionEpics.ts
+++ b/src/epics/productionEpics.ts
@@ -2,6 +2,7 @@ import { ofType } from 'redux-observable';
 import {from, of, interval, EMPTY, filter, takeWhile, startWith, Observable} from 'rxjs';
 import { catchError, exhaustMap, map, mergeMap, switchMap, takeUntil } from 'rxjs/operators';
 import { ApplicationActions, BeerActions, ProductionActions } from '../actions/actions';
+import {WarningActions} from '../actions/warningActions';
 import { ProductionRepository } from '../repositorys/ProductionRepository';
 import { dataCollector } from '../utils/DataCollector/dataCollector';
 import { WebSocketController } from '../utils/WebSocketController';
@@ -17,6 +18,7 @@ import {Beer} from "../model/Beer";
 import type {RootState} from "../reducers/rootReducer";
 import {AgitatorRealtimeState, AlarmRealtimeState, HeatingRunningState, TemperatureSensorRealtimeState} from '../model/RealtimeControllerState';
 import {AgitatorSettings} from '../model/AgitatorSettings';
+import {WarningRealtimeState} from '../model/Warning';
 
 const BREWING_STATUS_POLL_INTERVAL = 1000;
 export const BREWING_STATUS_REQUEST_TIMEOUT = 8000;
@@ -37,6 +39,7 @@ export const mapControlSocketEvent = (event: {event: string; data?: unknown}) =>
     case 'heating-running-changed': return ProductionActions.heatingRunningChanged(event.data as HeatingRunningState);
     case 'agitator-state-changed': return ProductionActions.agitatorStateChanged(event.data as AgitatorRealtimeState);
     case 'alarm-state-changed': return ProductionActions.alarmStateChanged(event.data as AlarmRealtimeState);
+    case 'warning-state-changed': return WarningActions.warningStateChanged(event.data as WarningRealtimeState);
     case 'temperature-sensor-state-changed': return ProductionActions.temperatureSensorStateChanged(event.data as TemperatureSensorRealtimeState);
     case 'agitator-defaults-changed': return ProductionActions.agitatorDefaultsChanged(event.data as AgitatorSettings);
     default:

--- a/src/epics/warningSocketMapping.test.ts
+++ b/src/epics/warningSocketMapping.test.ts
@@ -1,0 +1,19 @@
+import {WarningActions} from '../actions/warningActions';
+import {mapControlSocketEvent} from './productionEpics';
+
+describe('warning socket mapping', () => {
+    it('maps warning-state-changed without changing the replacement snapshot', () => {
+        const snapshot = {
+            warnings: [
+                {
+                    type: 'TEMPERATURE_SENSOR',
+                    active: true,
+                    details: {health: 'MISSING'},
+                },
+            ],
+        };
+
+        expect(mapControlSocketEvent({event: 'warning-state-changed', data: snapshot}))
+            .toEqual(WarningActions.warningStateChanged(snapshot));
+    });
+});

--- a/src/model/Warning.ts
+++ b/src/model/Warning.ts
@@ -1,0 +1,13 @@
+export type WarningType = 'TEMPERATURE_SENSOR' | string;
+
+export type WarningDetailValue = string | number | boolean | null;
+
+export interface Warning {
+    type: WarningType;
+    active: boolean;
+    details?: Record<string, WarningDetailValue>;
+}
+
+export interface WarningRealtimeState {
+    warnings: Warning[];
+}

--- a/src/reducers/rootReducer.ts
+++ b/src/reducers/rootReducer.ts
@@ -6,11 +6,13 @@ import { hopsReducer, HopsReducerState, initialHopsState } from './hopsReducer';
 import {maltsReducer, MaltsReducerState, initialMaltsState} from './maltsReducer';
 import {yeastReducer, YeastReducerState, initialYeastState} from './yeastReducer';
 import {additionalIngredientsReducer, AdditionalIngredientsReducerState, initialAdditionalIngredientsState} from './additionalIngredientsReducer';
+import {initialWarningState, warningReducer, WarningReducerState} from './warningReducer';
 
 export const rootReducer = combineReducers({
     applicationReducer: applicationReducer,
     beerDataReducer: beerDataReducer,
     productionReducer: productionReducer,
+    warningReducer: warningReducer,
     hopsReducer: hopsReducer,
     maltsReducer: maltsReducer,
     yeastReducer: yeastReducer,
@@ -22,10 +24,11 @@ export interface RootState {
     applicationReducer: ApplicationReducerState;
     beerDataReducer: BeerDataReducerState;
     productionReducer: ProductionReducerState;
+    warningReducer: WarningReducerState;
     hopsReducer: HopsReducerState;
     maltsReducer: MaltsReducerState;
     yeastReducer: YeastReducerState;
     additionalIngredientsReducer: AdditionalIngredientsReducerState;
 }
-export type { ApplicationReducerState, BeerDataReducerState, ProductionReducerState, HopsReducerState, MaltsReducerState, YeastReducerState, AdditionalIngredientsReducerState };
-export { initialApplicationState, initialBeerState, initialProductionState ,initialHopsState, initialMaltsState, initialYeastState, initialAdditionalIngredientsState};
+export type { ApplicationReducerState, BeerDataReducerState, ProductionReducerState, WarningReducerState, HopsReducerState, MaltsReducerState, YeastReducerState, AdditionalIngredientsReducerState };
+export { initialApplicationState, initialBeerState, initialProductionState, initialWarningState, initialHopsState, initialMaltsState, initialYeastState, initialAdditionalIngredientsState};

--- a/src/reducers/warningReducer.test.ts
+++ b/src/reducers/warningReducer.test.ts
@@ -1,0 +1,88 @@
+import {ProductionActions} from '../actions/actions';
+import {WarningActions} from '../actions/warningActions';
+import {initialWarningState, warningReducer} from './warningReducer';
+
+const temperatureWarning = (health: string) => ({
+    type: 'TEMPERATURE_SENSOR',
+    active: true,
+    details: {health},
+});
+
+describe('warningReducer', () => {
+    it('stores replacement warning snapshots and marks them as received', () => {
+        const state = warningReducer(
+            initialWarningState,
+            WarningActions.warningStateChanged({warnings: [temperatureWarning('MISSING')]}),
+        );
+
+        expect(state).toEqual({
+            warnings: [temperatureWarning('MISSING')],
+            warningsReceived: true,
+        });
+    });
+
+    it('returns the same state for an identical semantic snapshot', () => {
+        const active = warningReducer(
+            initialWarningState,
+            WarningActions.warningStateChanged({warnings: [temperatureWarning('STALE')]}),
+        );
+
+        const repeated = warningReducer(
+            active,
+            WarningActions.warningStateChanged({warnings: [temperatureWarning('STALE')]}),
+        );
+
+        expect(repeated).toBe(active);
+    });
+
+    it('updates details when a warning changes without changing its type', () => {
+        const missing = warningReducer(
+            initialWarningState,
+            WarningActions.warningStateChanged({warnings: [temperatureWarning('MISSING')]}),
+        );
+
+        const stale = warningReducer(
+            missing,
+            WarningActions.warningStateChanged({warnings: [temperatureWarning('STALE')]}),
+        );
+
+        expect(stale).not.toBe(missing);
+        expect(stale.warnings[0].details?.health).toBe('STALE');
+    });
+
+    it('copies the socket snapshot so later payload mutation cannot change Redux state', () => {
+        const warning = temperatureWarning('MISSING');
+        const payload = {warnings: [warning]};
+        const state = warningReducer(initialWarningState, WarningActions.warningStateChanged(payload));
+
+        warning.details.health = 'OK';
+        payload.warnings.length = 0;
+
+        expect(state.warnings).toEqual([temperatureWarning('MISSING')]);
+    });
+
+    it('accepts multiple simultaneous warnings and clears them with an empty replacement snapshot', () => {
+        const active = warningReducer(initialWarningState, WarningActions.warningStateChanged({
+            warnings: [
+                temperatureWarning('MISSING'),
+                {type: 'WATER_SUPPLY', active: true, details: {reason: 'NO_FLOW'}},
+            ],
+        }));
+
+        expect(active.warnings).toHaveLength(2);
+
+        const cleared = warningReducer(active, WarningActions.warningStateChanged({warnings: []}));
+        expect(cleared).toEqual({warnings: [], warningsReceived: true});
+    });
+
+    it('drops non-latched warning snapshots when the socket disconnects', () => {
+        const active = warningReducer(
+            initialWarningState,
+            WarningActions.warningStateChanged({warnings: [temperatureWarning('MISSING')]}),
+        );
+
+        const disconnected = warningReducer(active, ProductionActions.socketConnectionChanged(false));
+
+        expect(disconnected).toEqual(initialWarningState);
+    });
+});

--- a/src/reducers/warningReducer.ts
+++ b/src/reducers/warningReducer.ts
@@ -1,3 +1,4 @@
+import {ProductionActions} from '../actions/actions';
 import {WarningActions} from '../actions/warningActions';
 import {Warning} from '../model/Warning';
 
@@ -28,9 +29,20 @@ const warningSnapshotsEqual = (left: Warning[], right: Warning[]): boolean =>
             && detailsEqual(warning.details, candidate.details);
     }));
 
+const copyWarnings = (warnings: Warning[]): Warning[] =>
+    warnings.map((warning) => ({
+        ...warning,
+        details: warning.details ? {...warning.details} : undefined,
+    }));
+
+type WarningReducerAction =
+    WarningActions.AllWarningActions
+    | ProductionActions.SocketConnectionChanged
+    | ProductionActions.WebSocketDisconnect;
+
 export const warningReducer = (
     state: WarningReducerState = initialWarningState,
-    action: WarningActions.AllWarningActions,
+    action: WarningReducerAction,
 ): WarningReducerState => {
     switch (action.type) {
         case WarningActions.ActionTypes.WARNING_STATE_CHANGED:
@@ -38,9 +50,13 @@ export const warningReducer = (
                 return state;
             }
             return {
-                warnings: action.payload.warnings,
+                warnings: copyWarnings(action.payload.warnings),
                 warningsReceived: true,
             };
+        case ProductionActions.ActionTypes.SOCKET_CONNECTION_CHANGED:
+            return action.payload.connected ? state : initialWarningState;
+        case ProductionActions.ActionTypes.WEBSOCKET_DISCONNECT:
+            return initialWarningState;
         default:
             return state;
     }

--- a/src/reducers/warningReducer.ts
+++ b/src/reducers/warningReducer.ts
@@ -1,0 +1,47 @@
+import {WarningActions} from '../actions/warningActions';
+import {Warning} from '../model/Warning';
+
+export interface WarningReducerState {
+    warnings: Warning[];
+    warningsReceived: boolean;
+}
+
+export const initialWarningState: WarningReducerState = {
+    warnings: [],
+    warningsReceived: false,
+};
+
+const detailsEqual = (left?: Warning['details'], right?: Warning['details']): boolean => {
+    if (left === right) return true;
+    if (!left || !right) return !left && !right;
+    const leftKeys = Object.keys(left);
+    const rightKeys = Object.keys(right);
+    return leftKeys.length === rightKeys.length
+        && leftKeys.every((key) => Object.prototype.hasOwnProperty.call(right, key) && left[key] === right[key]);
+};
+
+const warningSnapshotsEqual = (left: Warning[], right: Warning[]): boolean =>
+    left === right || (left.length === right.length && left.every((warning, index) => {
+        const candidate = right[index];
+        return warning.type === candidate.type
+            && warning.active === candidate.active
+            && detailsEqual(warning.details, candidate.details);
+    }));
+
+export const warningReducer = (
+    state: WarningReducerState = initialWarningState,
+    action: WarningActions.AllWarningActions,
+): WarningReducerState => {
+    switch (action.type) {
+        case WarningActions.ActionTypes.WARNING_STATE_CHANGED:
+            if (state.warningsReceived && warningSnapshotsEqual(state.warnings, action.payload.warnings)) {
+                return state;
+            }
+            return {
+                warnings: action.payload.warnings,
+                warningsReceived: true,
+            };
+        default:
+            return state;
+    }
+};

--- a/src/utils/WebSocketController.test.ts
+++ b/src/utils/WebSocketController.test.ts
@@ -52,6 +52,7 @@ describe('WebSocketController', () => {
     expect(socket.on).toHaveBeenCalledWith('heating-running-changed', expect.any(Function));
     expect(socket.on).toHaveBeenCalledWith('agitator-state-changed', expect.any(Function));
     expect(socket.on).toHaveBeenCalledWith('alarm-state-changed', expect.any(Function));
+    expect(socket.on).toHaveBeenCalledWith('warning-state-changed', expect.any(Function));
     expect(socket.on).toHaveBeenCalledWith('temperature-sensor-state-changed', expect.any(Function));
     expect(socket.on).toHaveBeenCalledWith('agitator-defaults-changed', expect.any(Function));
   });
@@ -76,6 +77,18 @@ describe('WebSocketController', () => {
     listeners['brew-session-running']();
 
     expect(handler).toHaveBeenCalledWith({event: 'brew-session-running', data: undefined});
+  });
+
+  it('forwards complete warning snapshots on the shared connection', () => {
+    const handler = jest.fn();
+    const controller = new WebSocketController('ws://controller');
+    controller.onMessage(handler);
+    controller.connect();
+    const snapshot = {warnings: [{type: 'TEMPERATURE_SENSOR', active: true, details: {health: 'MISSING'}}]};
+
+    listeners['warning-state-changed'](snapshot);
+
+    expect(handler).toHaveBeenCalledWith({event: 'warning-state-changed', data: snapshot});
   });
 
   it('forwards complete temperature snapshots on the shared connection', () => {

--- a/src/utils/WebSocketController.ts
+++ b/src/utils/WebSocketController.ts
@@ -6,7 +6,7 @@ export interface SocketConnectionStatus {
 }
 
 export type MessageHandler = (event: { event: string; data?: any }) => void;
-const realtimeEvents = ['heating-running-changed', 'agitator-state-changed', 'alarm-state-changed', 'temperature-sensor-state-changed', 'agitator-defaults-changed'] as const;
+const realtimeEvents = ['heating-running-changed', 'agitator-state-changed', 'alarm-state-changed', 'warning-state-changed', 'temperature-sensor-state-changed', 'agitator-defaults-changed'] as const;
 
 export class WebSocketController {
   private socket: Socket | null = null;

--- a/src/utils/temperatureSensor.ts
+++ b/src/utils/temperatureSensor.ts
@@ -9,8 +9,11 @@ const healthMessages: Record<TemperatureSensorHealth, string> = {
     NOT_CONFIGURED: 'Temperatursensor nicht konfiguriert',
 };
 
+export const getTemperatureSensorHealthMessage = (health?: TemperatureSensorHealth): string =>
+    health ? healthMessages[health] : 'Temperatursensorstatus wird ermittelt';
+
 export const getTemperatureSensorMessage = (sensor?: TemperatureSensorRealtimeState): string =>
-    sensor ? healthMessages[sensor.health] : 'Temperatursensorstatus wird ermittelt';
+    getTemperatureSensorHealthMessage(sensor?.health);
 
 export const isTemperatureSensorReady = (sensor: TemperatureSensorRealtimeState | undefined, socketConnected: boolean | undefined): sensor is TemperatureSensorRealtimeState & {current: number} =>
     socketConnected === true && sensor?.health === 'OK' && typeof sensor.current === 'number' && Number.isFinite(sensor.current);

--- a/src/utils/warningDisplay.test.ts
+++ b/src/utils/warningDisplay.test.ts
@@ -1,0 +1,40 @@
+import {getActiveWarnings, getWarningHeaderText, getWarningMessage} from './warningDisplay';
+
+describe('warningDisplay', () => {
+    it('maps temperature sensor health to a user-facing warning', () => {
+        expect(getWarningMessage({
+            type: 'TEMPERATURE_SENSOR',
+            active: true,
+            details: {health: 'MISSING'},
+        })).toBe('Temperatursensor nicht verfügbar');
+    });
+
+    it('falls back safely for an unknown temperature health value', () => {
+        expect(getWarningMessage({
+            type: 'TEMPERATURE_SENSOR',
+            active: true,
+            details: {health: 'UNKNOWN_STATE'},
+        })).toBe('Temperatursensor prüfen');
+    });
+
+    it('supports future warning types without requiring a transport change', () => {
+        expect(getWarningMessage({type: 'WATER_SUPPLY', active: true}))
+            .toBe('Betriebswarnung: WATER_SUPPLY');
+    });
+
+    it('ignores inactive warnings', () => {
+        expect(getActiveWarnings([
+            {type: 'TEMPERATURE_SENSOR', active: false, details: {health: 'MISSING'}},
+        ])).toEqual([]);
+        expect(getWarningHeaderText([
+            {type: 'TEMPERATURE_SENSOR', active: false, details: {health: 'MISSING'}},
+        ])).toBeUndefined();
+    });
+
+    it('summarizes multiple active warnings in one header message', () => {
+        expect(getWarningHeaderText([
+            {type: 'TEMPERATURE_SENSOR', active: true, details: {health: 'STALE'}},
+            {type: 'WATER_SUPPLY', active: true},
+        ])).toBe('⚠ 2 Warnungen: Temperaturmessung nicht aktuell · Betriebswarnung: WATER_SUPPLY');
+    });
+});

--- a/src/utils/warningDisplay.ts
+++ b/src/utils/warningDisplay.ts
@@ -1,0 +1,33 @@
+import {TemperatureSensorHealth} from '../model/RealtimeControllerState';
+import {Warning} from '../model/Warning';
+import {getTemperatureSensorHealthMessage} from './temperatureSensor';
+
+const knownTemperatureHealth = (value: unknown): value is TemperatureSensorHealth =>
+    value === 'OK'
+    || value === 'MISSING'
+    || value === 'STALE'
+    || value === 'INVALID_READING'
+    || value === 'MULTIPLE_SENSORS_FOUND'
+    || value === 'NOT_CONFIGURED';
+
+export const getWarningMessage = (warning: Warning): string => {
+    if (warning.type === 'TEMPERATURE_SENSOR') {
+        const health = warning.details?.health;
+        return knownTemperatureHealth(health)
+            ? getTemperatureSensorHealthMessage(health)
+            : 'Temperatursensor prüfen';
+    }
+    return `Betriebswarnung: ${warning.type}`;
+};
+
+export const getActiveWarnings = (warnings?: Warning[]): Warning[] =>
+    (warnings ?? []).filter((warning) => warning.active === true);
+
+export const getWarningHeaderText = (warnings?: Warning[]): string | undefined => {
+    const activeWarnings = getActiveWarnings(warnings);
+    if (activeWarnings.length === 0) return undefined;
+
+    const messages = activeWarnings.map(getWarningMessage);
+    if (messages.length === 1) return `⚠ ${messages[0]}`;
+    return `⚠ ${messages.length} Warnungen: ${messages.join(' · ')}`;
+};


### PR DESCRIPTION
## Zusammenfassung

- konsumiert das neue Socket.IO-Event `warning-state-changed` über die bestehende zentrale Verbindung
- führt einen generischen globalen Warning-State getrennt von Alarmen und Production-State ein
- unterstützt `TEMPERATURE_SENSOR` mit `details.health` als erste Warnung
- zeigt Warnungen im Desktop-Header orange, während Alarme weiterhin rot und höher priorisiert bleiben
- zeigt globale Warnungen auch in der mobilen Produktionsansicht
- behält `temperature-sensor-state-changed` als technischen Sensorzustand und als Kompatibilitäts-Fallback für ältere Controller-Versionen bei
- bestehende Startsperre und Sensor-Safety bleiben am technischen Sensorzustand (`health === OK` + gültiger Wert) gekoppelt
- ungültige Temperaturwerte bleiben `-- °C`; numerisch `0 °C` bleibt ein gültiger Messwert
- verwirft nicht gelatchte Warning-Snapshots bei Socket-Disconnect und wartet auf einen frischen Snapshot nach Reconnect

## Priorität

1. Alarm (`alarm-state-changed`) – rot / `role=alert`
2. Warning (`warning-state-changed`) – orange / `role=status`
3. normale Statusmeldungen

## Tests

Ergänzt wurden Tests für:

- Warning reducer / Replacement-Snapshots / Deduplizierung / Details-Änderung / Disconnect
- Warning-Textauflösung
- Socket-Registrierung und Weiterleitung von `warning-state-changed`
- Socket→Redux-Mapping
- Header-Priorität Alarm vor Warning
- getrennte Alarm-/Warning-Severity im StatusDisplay

Das Backend muss für die neue primäre Integration den vereinbarten Snapshot senden:

```json
{
  "warnings": [
    {
      "type": "TEMPERATURE_SENSOR",
      "active": true,
      "details": {"health": "MISSING"}
    }
  ]
}
```

Bis dahin bleibt die bestehende technische Sensorwarnung als Fallback aktiv.