### PR TITLE
Fix optional mobile brewing status type

### DIFF
--- a/src/containers/Mobile/MobileStatusView/MobileProductionView.tsx
+++ b/src/containers/Mobile/MobileStatusView/MobileProductionView.tsx
@@ -15,7 +15,7 @@ import {getWarningHeaderText} from '../../../utils/warningDisplay';
 
 interface MobileProductionViewProps {
     temperature: number;
-    brewingStatus: BrewingStatus;
+    brewingStatus?: BrewingStatus;
     confirm: (confirmState: ConfirmStates) => void;
     isConfirmPending: boolean;
     confirmError?: string;


### PR DESCRIPTION
Behebt den TypeScript-Buildfehler nach #244. `productionReducer.brewingStatus` ist korrekt als `BrewingStatus | undefined` modelliert; die mobile View hatte den Prop noch zwingend als `BrewingStatus` deklariert. Die View und die verwendeten Selector-Funktionen unterstützen den nicht initialisierten Zustand bereits, daher wird der Prop-Typ auf optional angepasst.