### PR TITLE
Gärungsverlauf, Aktionen und Sensoren integrieren (#249)

### DIFF
--- a/docs/codex/compatibility/compatibility-checklist.md
+++ b/docs/codex/compatibility/compatibility-checklist.md
@@ -44,3 +44,11 @@ When a compatibility-relevant change is requested, Codex must:
 - [x] Keeps `brew-session-running` as the sole trigger for BrewSession restoration and polling.
 - [x] Introduces no BeerDataStore endpoint or DTO change; BeerDataStore #40 and Braumeister #146 are prerequisites.
 - [ ] Verify two-client resume/discard and reconnect races on the deployed Raspberry Pi.
+
+## Fermentation additions checked for #249
+
+- [x] Existing `FinishedBrew.id` and `eBrewState` remain authoritative; no second beer/status model.
+- [x] Celsius, degrees Plato, ISO-8601 timestamps, and sensor-window seconds are explicit.
+- [x] Writes are backend-confirmed and followed by reload; no optimistic completion/assignment.
+- [x] Hardware communicates with BeerDataStore, not this UI.
+- [ ] Verify exact routes, aggregate DTO, action strings, and errors against BeerDataStore #42.

--- a/docs/codex/compatibility/cross-repo-contracts.md
+++ b/docs/codex/compatibility/cross-repo-contracts.md
@@ -250,3 +250,7 @@ The controller additionally provides `GET /Safety/Heater` and `POST /Safety/Heat
 ## Brew recovery contract (BeerDataStore #40 / Braumeister #146 / Brauhaus2 #246)
 
 The additive recovery contract uses the existing Socket.IO namespace/path and event `brew-recovery-state-changed`, plus control routes `POST /BrewRecovery/Resume` and `DELETE /BrewRecovery`. Resume receives the existing `BrewingData` shape. Saved `duration`, `elapsedTime`, and `remainingTime` are seconds; volume is liters and efficiency is percent. `brew-session-running` remains the only confirmation of a running workflow and must clear stale recovery before the established `GET /BrewSession` restoration. No database API changes are introduced. Raspberry Pi multi-client/reconnect deployment **Needs verification**.
+
+## Fermentation: Brauhaus2 #249 / BeerDataStore #42
+
+BeerDataStore is the source of truth for fermentation measurements, actions, devices, assignments, sensor readings, and completion timestamps. Brauhaus2 is display and interaction only; hardware does not call Brauhaus2. The additive contract is rooted at `fermentation/*`, keyed by existing `FinishedBrew.id`, and does not alter the finished-beer lifecycle. Exact route/DTO deployment and errors **Needs verification** with Boris26/BeerDataStore#42.

--- a/docs/codex/data-flow.md
+++ b/docs/codex/data-flow.md
@@ -112,3 +112,7 @@ Heater-safety reset is intentionally not a Settings-page action. Settings expose
 3. The controller broadcasts recovery false to all clients. Its separate `brew-session-running` lifecycle signal clears stale recovery locally, then the established restore flow reads `GET /BrewSession`, reconstructs selectedBeer/beerToBrew, and starts the single exhaust-mapped poll.
 4. Discard first requires an explicit destructive confirmation and then sends one serialized `DELETE /BrewRecovery`; local success closes the initiator while the socket false snapshot synchronizes peers. Failures preserve the snapshot and dialog.
 5. Each accepted local command increments a recovery request generation. A changed socket snapshot, `brew-session-running`, or successful local discard advances it again, so a delayed HTTP success/failure from an older generation is ignored. An identical socket snapshot is reducer-idempotent and does not cancel the active intent.
+
+## Fermentation data (#249)
+
+Finished-beer detail/dashboard → Redux action → fermentation epic → `FermentationRepository` → BeerDataStore. Successful measurement, completion, or assignment commands trigger a fresh aggregate read; reducers never optimistically claim domain success. Redux contains current API/UI state only. Sensor hardware communicates with BeerDataStore, never Brauhaus2. BeerDataStore supplies assignments; only ambiguous `unassigned` devices require UI interaction.

--- a/docs/codex/domain-model.md
+++ b/docs/codex/domain-model.md
@@ -70,3 +70,7 @@ Needs verification: backend/database canonical casing for malt `ebc` vs recipe m
 ## Brew recovery
 
 `BrewRecoveryState` belongs to `productionReducer`, alongside controller lifecycle state. It contains the authoritative `available` flag and optional `BrewRecoveryEnvelope`, plus UI command flags (`resumePending`, `discardPending`), a controlled error, and a monotonically advancing local `requestGeneration`. The generation prevents a delayed REST result from changing state after a newer socket lifecycle snapshot. The envelope reuses `BrewSession` rather than duplicating its scaling contract and contains a deliberately small saved-status projection (`process`, `currentStep`, `waiting`, `heating`) plus ISO `updatedAt`. Recovery timing values are immutable snapshot seconds; the UI does not advance them locally.
+
+## Fermentation records (#249)
+
+`FinishedBrew` remains the beer/batch identity and status model; no parallel beer entity or status machine is introduced. Measurements, generic actions, BeerDataStore-registered devices/assignments, and sensor measurements reference `FinishedBrew.id`. BeerDataStore owns records and actual timestamps. Brauhaus2 displays them and sends explicit user commands. Sensor availability never implies that fermentation ended. Displayed alcohol and attenuation are approximate and never trigger status changes.

--- a/docs/codex/interfaces.md
+++ b/docs/codex/interfaces.md
@@ -147,3 +147,9 @@ The Settings UI intentionally exposes none of the controller infrastructure fiel
 The existing default-namespace Socket.IO connection also consumes `brew-recovery-state-changed`. Its replacement payload is `{ available: false, recovery: null }` or `{ available: true, recovery: { version, brewSession, status, updatedAt } }`. `brewSession` uses the existing `beerId`, liter-valued `plannedVolume`, and percent-valued `plannedBrewhouseEfficiency`; recovery status contains only the saved process/current-step/waiting/heating snapshot required for display. Durations are controller-owned seconds.
 
 The control command endpoints are `POST /BrewRecovery/Resume` with normal `BrewingData`, and `DELETE /BrewRecovery`. HTTP success acknowledges a command only. Only the existing `brew-session-running` event confirms that the process runs and triggers `GET /BrewSession` plus the existing status polling restoration.
+
+## Fermentation contract (Brauhaus2 #249 / BeerDataStore #42)
+
+BeerDataStore is the sole persistent source of truth. Brauhaus2 keeps only request and display state. The UI uses additive `GET fermentation/finishedbeers/{finishedBeerId}`, `POST fermentation/measurements`, `POST fermentation/actions/{actionId}/complete`, `GET fermentation/devices`, `GET fermentation/sensor-measurements?finishedBeerId={id}`, and `PUT fermentation/devices/{deviceId}/assignment` routes. Deployment with these exact routes and DTOs **Needs verification** against BeerDataStore #42.
+
+Temperatures are Celsius, Plato values are degrees Plato, timestamps are ISO-8601, and `windowSeconds` is seconds. Server `bubbleRatePerMinute` wins; otherwise the UI derives `bubbleCount * 60 / windowSeconds`. Action states are `PLANNED`, `ACTIVE`, and `COMPLETED`. Error envelopes, online threshold, and inclusion of globally unassigned devices in the aggregate **Needs verification**.

--- a/src/actions/fermentation.actions.ts
+++ b/src/actions/fermentation.actions.ts
@@ -1,0 +1,22 @@
+import {CreateFermentationMeasurement, FermentationDetails} from '../model/Fermentation';
+
+export enum FermentationActionTypes {
+  LOAD = 'Fermentation.LOAD', LOAD_SUCCESS = 'Fermentation.LOAD_SUCCESS', LOAD_FAILURE = 'Fermentation.LOAD_FAILURE',
+  CREATE_MEASUREMENT = 'Fermentation.CREATE_MEASUREMENT', CREATE_MEASUREMENT_SUCCESS = 'Fermentation.CREATE_MEASUREMENT_SUCCESS', CREATE_MEASUREMENT_FAILURE = 'Fermentation.CREATE_MEASUREMENT_FAILURE',
+  COMPLETE_ACTION = 'Fermentation.COMPLETE_ACTION', COMPLETE_ACTION_SUCCESS = 'Fermentation.COMPLETE_ACTION_SUCCESS', COMPLETE_ACTION_FAILURE = 'Fermentation.COMPLETE_ACTION_FAILURE',
+  ASSIGN_DEVICE = 'Fermentation.ASSIGN_DEVICE', ASSIGN_DEVICE_SUCCESS = 'Fermentation.ASSIGN_DEVICE_SUCCESS', ASSIGN_DEVICE_FAILURE = 'Fermentation.ASSIGN_DEVICE_FAILURE',
+}
+export const FermentationActions = {
+  load: (brewId: string) => ({type: FermentationActionTypes.LOAD, payload: {brewId}}),
+  loadSuccess: (brewId: string, details: FermentationDetails) => ({type: FermentationActionTypes.LOAD_SUCCESS, payload: {brewId, details}}),
+  loadFailure: (brewId: string, error: string) => ({type: FermentationActionTypes.LOAD_FAILURE, payload: {brewId, error}}),
+  createMeasurement: (measurement: CreateFermentationMeasurement) => ({type: FermentationActionTypes.CREATE_MEASUREMENT, payload: {measurement}}),
+  createMeasurementSuccess: (brewId: string) => ({type: FermentationActionTypes.CREATE_MEASUREMENT_SUCCESS, payload: {brewId}}),
+  createMeasurementFailure: (brewId: string, error: string) => ({type: FermentationActionTypes.CREATE_MEASUREMENT_FAILURE, payload: {brewId, error}}),
+  completeAction: (brewId: string, actionId: string) => ({type: FermentationActionTypes.COMPLETE_ACTION, payload: {brewId, actionId}}),
+  completeActionSuccess: (brewId: string, actionId: string) => ({type: FermentationActionTypes.COMPLETE_ACTION_SUCCESS, payload: {brewId, actionId}}),
+  completeActionFailure: (brewId: string, actionId: string, error: string) => ({type: FermentationActionTypes.COMPLETE_ACTION_FAILURE, payload: {brewId, actionId, error}}),
+  assignDevice: (deviceId: string, brewId: string) => ({type: FermentationActionTypes.ASSIGN_DEVICE, payload: {deviceId, brewId}}),
+  assignDeviceSuccess: (deviceId: string, brewId: string) => ({type: FermentationActionTypes.ASSIGN_DEVICE_SUCCESS, payload: {deviceId, brewId}}),
+  assignDeviceFailure: (deviceId: string, brewId: string, error: string) => ({type: FermentationActionTypes.ASSIGN_DEVICE_FAILURE, payload: {deviceId, brewId, error}}),
+};

--- a/src/containers/Dashboard/DashboardPage.connect.ts
+++ b/src/containers/Dashboard/DashboardPage.connect.ts
@@ -1,11 +1,13 @@
 import { connect } from 'react-redux';
 import { BeerActions } from '../../actions/actions';
-import { BeerDataReducerState, ProductionReducerState } from '../../reducers/rootReducer';
+import { BeerDataReducerState, FermentationState, ProductionReducerState } from '../../reducers/rootReducer';
 import {DashboardPage} from './DashboardPage';
+import {FermentationActions} from '../../actions/fermentation.actions';
 
 interface DashboardRootState {
   beerDataReducer: BeerDataReducerState;
   productionReducer: ProductionReducerState;
+  fermentationReducer: FermentationState;
 }
 
 const mapStateToProps = (state: DashboardRootState) => ({
@@ -17,11 +19,13 @@ const mapStateToProps = (state: DashboardRootState) => ({
   isBackendAvailable: state.productionReducer.isBackenAvailable,
   realtimeState: state.productionReducer.realtimeState,
   socketConnected: state.productionReducer.socketConnection.connected,
+  fermentationByBrewId: state.fermentationReducer.byBrewId,
 });
 
-const mapDispatchToProps = (dispatch: (action: BeerActions.AllBeerActions) => void) => ({
+const mapDispatchToProps = (dispatch: (action: any) => void) => ({
   getBeers: (isFetching: boolean) => dispatch(BeerActions.getBeers(isFetching)),
   getFinishedBrews: (isFetching: boolean) => dispatch(BeerActions.getFinishedBeers(isFetching)),
+  loadFermentation: (id: string) => dispatch(FermentationActions.load(id)),
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(DashboardPage);

--- a/src/containers/Dashboard/DashboardPage.css
+++ b/src/containers/Dashboard/DashboardPage.css
@@ -21,6 +21,7 @@
 .dashboard-active-row:last-child { border-bottom: 0; }
 .dashboard-active-row h3 { font-size: var(--font-size-normal); }
 .dashboard-active-row p { margin: 2px 0 0; color: var(--color-text-secondary); font-size: var(--font-size-small); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.dashboard-active-row .dashboard-next-action { margin-top: var(--spacing-xs); white-space: normal; }.dashboard-next-action.is-due { color: var(--color-warning); }.dashboard-next-action.is-overdue { color: var(--color-error); }
 .dashboard-state-dot { width: .55rem; height: .55rem; border-radius: 50%; background: var(--color-success); }
 .dashboard-state-dot.is-maturation { background: var(--color-info); }
 .dashboard-badge { border-radius: var(--border-radius-pill); padding: .16rem .55rem; background: var(--color-success-subtle); color: var(--color-success); font-size: .78rem; font-weight: 700; white-space: nowrap; }

--- a/src/containers/Dashboard/DashboardPage.tsx
+++ b/src/containers/Dashboard/DashboardPage.tsx
@@ -16,6 +16,8 @@ import './DashboardPage.css';
 import {RealtimeControllerState} from '../../model/RealtimeControllerState';
 import {getAgitatorActive, getHeatingActive} from '../Production/utils/productionStatus';
 import {formatTemperature} from '../../utils/temperatureSensor';
+import {FermentationDetails} from '../../model/Fermentation';
+import {actionDueLabel, latestByDate} from '../../utils/fermentation';
 
 interface DashboardPageProps {
   beers?: Beer[];
@@ -28,6 +30,8 @@ interface DashboardPageProps {
   socketConnected?: boolean;
   getBeers: (isFetching: boolean) => void;
   getFinishedBrews: (isFetching: boolean) => void;
+  fermentationByBrewId?: Record<string, FermentationDetails>;
+  loadFermentation?: (id: string) => void;
 }
 
 const formatSeconds = (value: unknown): string => {
@@ -39,6 +43,13 @@ export class DashboardPage extends React.Component<DashboardPageProps> {
   componentDidMount(): void {
     if (this.props.beers === undefined) this.props.getBeers(true);
     if (this.props.finishedBrews === undefined) this.props.getFinishedBrews(true);
+    (this.props.finishedBrews ?? []).filter(b => b.active && b.state !== eBrewState.FINISHED).forEach(b => this.props.loadFermentation?.(b.id));
+  }
+
+  componentDidUpdate(previous: DashboardPageProps): void {
+    if (previous.finishedBrews !== this.props.finishedBrews) {
+      (this.props.finishedBrews ?? []).filter(b => b.active && b.state !== eBrewState.FINISHED).forEach(b => this.props.loadFermentation?.(b.id));
+    }
   }
 
   private renderProductionStatus(): React.ReactNode {
@@ -100,7 +111,7 @@ export class DashboardPage extends React.Component<DashboardPageProps> {
       <header className="dashboard-title-row"><div><h1 id="dashboard-title">Dashboard</h1><p>Brauhaus auf einen Blick</p></div>{this.props.isFetching && <span className="dashboard-loading">Dashboard-Daten werden geladen …</span>}</header>
       <section className="dashboard-kpi-grid" aria-label="Dashboard Kennzahlen">{cards.map((card) => <article className="dashboard-card dashboard-kpi-card" key={card.label}><span className="dashboard-kpi-icon" aria-hidden="true">{card.icon}</span><span className="dashboard-kpi-label">{card.label}</span><strong className="dashboard-kpi-value">{card.value}</strong><span className="dashboard-kpi-detail">{card.detail}</span></article>)}</section>
       <div className="dashboard-content-grid">
-        <section className="dashboard-card dashboard-main-card dashboard-active-card" aria-labelledby="dashboard-active-title"><div className="dashboard-section-header"><LocalDrinkIcon aria-hidden="true" /><h2 id="dashboard-active-title">Aktive Biere</h2></div>{activeRows.length === 0 ? <p className="dashboard-empty">Keine Biere in Hauptgärung oder Reifung.</p> : <div className="dashboard-scroll-list">{activeRows.map((row) => <article className="dashboard-active-row" key={row.id}><span className={`dashboard-state-dot ${row.state === eBrewState.MATURATION ? 'is-maturation' : ''}`} /><div><h3>{row.name}</h3><p>{row.litersLabel} · {row.originalWortLabel} · {row.residualExtractLabel}</p></div><span className={`dashboard-badge ${row.state === eBrewState.MATURATION ? 'is-maturation' : ''}`}>{row.stateLabel}</span><strong className="dashboard-day">{row.daysSinceStartLabel === '-' ? '–' : `Tag ${row.daysSinceStartLabel.replace(' Tage', '')}`}</strong></article>)}</div>}</section>
+        <section className="dashboard-card dashboard-main-card dashboard-active-card" aria-labelledby="dashboard-active-title"><div className="dashboard-section-header"><LocalDrinkIcon aria-hidden="true" /><h2 id="dashboard-active-title">Aktive Gärungen</h2></div>{activeRows.length === 0 ? <p className="dashboard-empty">Keine Biere in Hauptgärung oder Reifung.</p> : <div className="dashboard-scroll-list">{activeRows.map((row) => { const detail = this.props.fermentationByBrewId?.[row.id]; const measurement = latestByDate(detail?.measurements ?? [], m => m.measuredAt); const next = [...(detail?.actions ?? [])].filter(a => a.state === 'PLANNED').sort((a,b) => Date.parse(a.scheduledAt) - Date.parse(b.scheduledAt))[0]; const due = next && actionDueLabel(next); return <article className="dashboard-active-row" key={row.id}><span className={`dashboard-state-dot ${row.state === eBrewState.MATURATION ? 'is-maturation' : ''}`} /><div><h3>{row.name}</h3><p>{row.stateLabel} · {measurement ? `${measurement.temperature ?? '–'} °C · ${measurement.plato ?? '–'} °P` : row.residualExtractLabel}</p>{next && <p className={`dashboard-next-action is-${due?.severity}`}><strong>{due?.label}:</strong> {[next.amount, next.unit, next.ingredientName, next.type?.toLowerCase()].filter(Boolean).join(' ')}</p>}</div><span className={`dashboard-badge ${row.state === eBrewState.MATURATION ? 'is-maturation' : ''}`}>{row.stateLabel}</span><strong className="dashboard-day">{row.daysSinceStartLabel === '-' ? '–' : `Tag ${row.daysSinceStartLabel.replace(' Tage', '')}`}</strong></article>;})}</div>}</section>
         {this.renderProductionStatus()}
         <section className="dashboard-card dashboard-main-card dashboard-history-card" aria-labelledby="dashboard-history-title"><div className="dashboard-section-header"><AssessmentIcon aria-hidden="true" /><h2 id="dashboard-history-title">Brauhistorie nach Rezept</h2></div><div className="dashboard-history-summary"><span><strong>{kpis.brewCount}</strong>Sude</span><span><strong>{formatDashboardQuantity(kpis.totalLiters)} l</strong>gebraut</span><span><strong>{kpis.brewCount ? formatDashboardQuantity(kpis.totalLiters / kpis.brewCount) : '–'} l</strong>Ø pro Sud</span><span><strong>{history.length}</strong>verwendet</span></div>{history.length === 0 ? <p className="dashboard-empty">Keine verknüpfte Brauhistorie verfügbar.</p> : <div className="dashboard-scroll-list dashboard-history-list">{history.map((row) => <div className="dashboard-history-row" key={row.recipeId}><strong>{row.recipeName}</strong><span>{row.brewCount} {row.brewCount === 1 ? 'Sud' : 'Sude'}</span><span>{formatDashboardQuantity(row.liters)} l</span><div className="dashboard-history-track"><span style={{ width: `${row.brewCount / maxHistoryBrews * 100}%` }} /></div></div>)}</div>}</section>
         <section className="dashboard-card dashboard-compact-card" aria-labelledby="dashboard-consumption-title"><div className="dashboard-section-header"><Inventory2OutlinedIcon aria-hidden="true" /><h2 id="dashboard-consumption-title">Gesamtverbrauch</h2></div>{consumption.linkedBrewCount ? <><div className="dashboard-consumption-grid"><div><span>Malz</span><strong>{formatDashboardQuantity(consumption.maltQuantity)}</strong><small>Rezeptmenge*</small></div><div><span>Hopfen</span><strong>{formatDashboardQuantity(consumption.hopQuantity)}</strong><small>Rezeptmenge*</small></div><div><span>Hefe</span><strong>{consumption.yeastUses}</strong><small>Sud-Einsätze</small></div></div><p className="dashboard-footnote">* Die gespeicherten Mengen haben keine verlässliche Einheit.</p></> : <p className="dashboard-empty">Keine verknüpften Rezeptdaten verfügbar.</p>}</section>

--- a/src/containers/MainView/FinishBrewsBeers/FermentationDetails.css
+++ b/src/containers/MainView/FinishBrewsBeers/FermentationDetails.css
@@ -1,0 +1,15 @@
+.fermentation-details { display: grid; gap: var(--spacing-md); color: var(--color-text); }
+.fermentation-details h3, .fermentation-details h4, .fermentation-details h5, .fermentation-details p { margin-top: 0; }
+.fermentation-phase { color: var(--color-text-secondary); font-weight: 700; }
+.fermentation-card { padding: var(--spacing-md); border: 1px solid var(--color-border); border-radius: var(--border-radius-large); background: var(--color-panel-bg); }
+.fermentation-heading, .fermentation-device, .fermentation-list li { display: flex; justify-content: space-between; gap: var(--spacing-sm); align-items: center; }
+.fermentation-card button { border: 0; border-radius: var(--border-radius-small); padding: .45rem .8rem; color: var(--color-button-text); background: var(--color-primary); font-weight: 700; }
+.fermentation-card button:disabled { opacity: .55; }
+.fermentation-latest { display: grid; grid-template-columns: 1fr auto auto; gap: var(--spacing-sm) var(--spacing-lg); padding: var(--spacing-md); margin-bottom: var(--spacing-md); background: var(--color-panel-contrast); border-radius: var(--border-radius-medium); }
+.fermentation-latest span, .fermentation-latest small { grid-column: 1 / -1; color: var(--color-text-secondary); }.fermentation-latest strong { font-size: 1.4rem; }
+.fermentation-form { display: grid; grid-template-columns: repeat(2, 1fr); gap: var(--spacing-sm); padding: var(--spacing-md); margin-bottom: var(--spacing-md); border: 1px solid var(--color-accent-border); border-radius: var(--border-radius-medium); }
+.fermentation-form label { display: grid; gap: var(--spacing-xs); }.fermentation-form input, .fermentation-form textarea { padding: .5rem; color: var(--color-text); background: var(--color-input-bg); border: 1px solid var(--color-border); border-radius: var(--border-radius-small); }.fermentation-form div, .fermentation-form p { grid-column: 1 / -1; }
+.fermentation-list { list-style: none; padding: 0; }.fermentation-list li { flex-wrap: wrap; padding: var(--spacing-sm) 0; border-bottom: 1px solid var(--color-border-soft); }.fermentation-list time { min-width: 9rem; color: var(--color-text-secondary); }.fermentation-list li.is-overdue time { color: var(--color-error); font-weight: 700; }.fermentation-list li.is-due { background: var(--color-warning-subtle); }
+.fermentation-metrics, .fermentation-sensor-values { display: grid; grid-template-columns: repeat(2, 1fr); gap: var(--spacing-xs) var(--spacing-md); }.fermentation-metrics div, .fermentation-sensor-values div { display: flex; justify-content: space-between; }.fermentation-metrics dd, .fermentation-sensor-values dd { margin: 0; font-weight: 700; }
+.fermentation-device { padding: var(--spacing-sm); background: var(--color-panel-contrast); border-radius: var(--border-radius-medium); }.is-online { color: var(--color-success); }.is-offline, .fermentation-error { color: var(--color-error); }.fermentation-notice { color: var(--color-warning); }
+@media (max-width: 600px) { .fermentation-form, .fermentation-metrics, .fermentation-sensor-values { grid-template-columns: 1fr; }.fermentation-latest { grid-template-columns: 1fr 1fr; } }

--- a/src/containers/MainView/FinishBrewsBeers/FinishedBrewDetails.test.tsx
+++ b/src/containers/MainView/FinishBrewsBeers/FinishedBrewDetails.test.tsx
@@ -1,0 +1,27 @@
+import {fireEvent, render, screen} from '@testing-library/react';
+import {FinishedBrewDetailsView} from './FinishedBrewDetails';
+import {eBrewState} from '../../../enums/eBrewState';
+
+const brew: any = {id: 'brew-1', name: 'West Coast IPA', startDate: '2026-09-01', liters: 20, originalwort: 13.2, residual_extract: null, note: '', active: true, state: eBrewState.FERMENTATION};
+const base: any = {brew, details: {measurements: [], actions: [], devices: [], sensorMeasurements: []}, activeBrews: [brew], loading: false, saving: false, completing: [], assigning: [], load: jest.fn(), save: jest.fn(), complete: jest.fn(), assign: jest.fn()};
+
+describe('fermentation details', () => {
+  it('shows the empty state and validates at least one manual value', () => {
+    render(<FinishedBrewDetailsView {...base} />);
+    expect(screen.getByText('Keine Messwerte vorhanden.')).toBeInTheDocument(); expect(screen.getByText('Kein Sensor zugeordnet.')).toBeInTheDocument();
+    fireEvent.click(screen.getByText('Neue Messung')); fireEvent.click(screen.getByText('Speichern'));
+    expect(screen.getByText('Mindestens Temperatur oder Plato ist erforderlich.')).toBeInTheDocument(); expect(base.save).not.toHaveBeenCalled();
+  });
+  it('submits temperature-only data with the selected finished beer and editable date', () => {
+    const save = jest.fn(); render(<FinishedBrewDetailsView {...base} save={save} />); fireEvent.click(screen.getByText('Neue Messung'));
+    fireEvent.change(screen.getByLabelText('Datum / Uhrzeit'), {target: {value: '2026-09-04T18:30'}}); fireEvent.change(screen.getByLabelText('Temperatur °C'), {target: {value: '18.3'}}); fireEvent.click(screen.getByText('Speichern'));
+    expect(save).toHaveBeenCalledWith(expect.objectContaining({finishedBeerId: 'brew-1', temperature: 18.3, plato: undefined, measuredAt: expect.stringContaining('2026-09-04')}));
+  });
+  it('renders measurements, generic actions, sensor values and assignment choices', () => {
+    const complete = jest.fn(); const assign = jest.fn();
+    const details: any = {measurements: [{id: 'm', finishedBeerId: 'brew-1', measuredAt: '2026-09-04T18:00:00Z', plato: 4.2}], actions: [{id: 'a', finishedBeerId: 'brew-1', scheduledAt: '2026-09-04', state: 'PLANNED', type: 'HINZUFÜGEN', ingredientName: 'Citra', amount: 80, unit: 'g'}], devices: [{id: 'd', name: 'FERM-01', lastSeenAt: '2026-09-04T17:55:00Z'}], sensorMeasurements: [{id: 's', deviceId: 'd', measuredAt: '2026-09-04T18:00:00Z', beerTemperature: 18.3, ambientTemperature: 17.6, bubbleCount: 17, windowSeconds: 300}]};
+    render(<FinishedBrewDetailsView {...base} details={details} complete={complete} assign={assign} />);
+    expect(screen.getByText(/4,2 °P/)).toBeInTheDocument(); expect(screen.getByText('FERM-01')).toBeInTheDocument(); expect(screen.getByText(/3,4 Blubbs\/min/)).toBeInTheDocument();
+    fireEvent.click(screen.getByText('Erledigt')); expect(complete).toHaveBeenCalledWith('brew-1', 'a'); fireEvent.click(screen.getByText('West Coast IPA')); expect(assign).toHaveBeenCalledWith('d', 'brew-1');
+  });
+});

--- a/src/containers/MainView/FinishBrewsBeers/FinishedBrewDetails.tsx
+++ b/src/containers/MainView/FinishBrewsBeers/FinishedBrewDetails.tsx
@@ -1,58 +1,48 @@
-import React, { Component } from 'react';
-import { FinishedBrew } from "../../../model/FinishedBrew";
+import React, {useEffect, useMemo, useState} from 'react';
+import {connect} from 'react-redux';
+import {FinishedBrew} from '../../../model/FinishedBrew';
+import {BrewStateGerman, eBrewState} from '../../../enums/eBrewState';
+import {FermentationActions} from '../../../actions/fermentation.actions';
+import {CreateFermentationMeasurement, FermentationDetails} from '../../../model/Fermentation';
+import {approximateAlcohol, attenuation, bubbleRate, fermentationDay, isDeviceOnline, latestByDate, missingPlatoDays, temperatureDelta, actionDueLabel} from '../../../utils/fermentation';
 import BrewProcessChart from './BrewProcessChart';
+import './FermentationDetails.css';
 
-interface FinishedBrewDetailsProps {
-  brew: FinishedBrew;
-}
+interface Props { brew: FinishedBrew; details?: FermentationDetails; activeBrews: FinishedBrew[]; loading: boolean; saving: boolean; completing: string[]; assigning: string[]; error?: string; load: (id: string) => void; save: (value: CreateFermentationMeasurement) => void; complete: (brewId: string, actionId: string) => void; assign: (deviceId: string, brewId: string) => void; }
+const number = (value?: number | null, unit = '') => typeof value === 'number' ? `${value.toLocaleString('de-DE', {maximumFractionDigits: 1})}${unit}` : '–';
+const date = (value?: string) => value ? new Intl.DateTimeFormat('de-DE', {dateStyle: 'short', timeStyle: 'short'}).format(new Date(value)) : '–';
+const actionText = (action: any) => [action.amount, action.unit, action.ingredientName, action.type?.toLowerCase()].filter(Boolean).join(' ');
 
-class FinishedBrewDetails extends Component<FinishedBrewDetailsProps> {
-  render() {
-    const { brew } = this.props;
-    if (!brew) return <div>Keine Daten verfügbar.</div>;
-
-    let groupedData: any = undefined;
-    if (brew.brewValues) {
-      try {
-        const parsed = typeof brew.brewValues === 'string' ? JSON.parse(brew.brewValues) : brew.brewValues;
-        groupedData = parsed.groupedData;
-      } catch (e) {
-        groupedData = undefined;
-      }
-    }
-
-    return (
-      <div className="finished-brew-details">
-        <h3>Brau-Durchgang Details</h3>
-        <table>
-          <tbody>
-            <tr>
-              <td><b>Name:</b></td>
-              <td>{brew.name}</td>
-            </tr>
-            <tr>
-              <td><b>Notiz:</b></td>
-              <td>{brew.note || '-'}</td>
-            </tr>
-            <tr>
-              <td><b>Restextrakt:</b></td>
-              <td>{brew.residual_extract ?? '-'}</td>
-            </tr>
-            {/* Weitere Felder nach Bedarf ergänzen */}
-          </tbody>
-        </table>
-        {/* Diagramm anzeigen, falls Daten vorhanden */}
-        {groupedData && (
-          <>
-            <h4 style={{ marginTop: 30 }}>Temperaturverlauf</h4>
-            <div style={{ marginBottom: 32 }}>
-              <BrewProcessChart groupedData={groupedData} />
-            </div>
-          </>
-        )}
-      </div>
-    );
-  }
-}
-
-export default FinishedBrewDetails;
+export const FinishedBrewDetailsView: React.FC<Props> = props => {
+  const [formOpen, setFormOpen] = useState(false);
+  const [measuredAt, setMeasuredAt] = useState(() => new Date().toISOString().slice(0, 16));
+  const [temperature, setTemperature] = useState(''); const [plato, setPlato] = useState(''); const [note, setNote] = useState(''); const [validation, setValidation] = useState('');
+  useEffect(() => { props.load(props.brew.id); }, [props.brew.id]); // eslint-disable-line react-hooks/exhaustive-deps
+  useEffect(() => { if (formOpen && !props.saving && !props.error) { setFormOpen(false); setTemperature(''); setPlato(''); setNote(''); } }, [props.saving]); // eslint-disable-line react-hooks/exhaustive-deps
+  const details = props.details ?? {measurements: [], actions: [], devices: [], sensorMeasurements: []};
+  const measurements = useMemo(() => [...details.measurements].sort((a, b) => Date.parse(b.measuredAt) - Date.parse(a.measuredAt)), [details.measurements]);
+  const latest = measurements[0]; const sensor = latestByDate(details.sensorMeasurements, x => x.measuredAt);
+  const delta = temperatureDelta(sensor); const bubbles = bubbleRate(sensor); const noPlato = missingPlatoDays(measurements);
+  const save = () => { if (!temperature && !plato) { setValidation('Mindestens Temperatur oder Plato ist erforderlich.'); return; } setValidation(''); props.save({finishedBeerId: props.brew.id, measuredAt: new Date(measuredAt).toISOString(), temperature: temperature === '' ? undefined : Number(temperature), plato: plato === '' ? undefined : Number(plato), note}); };
+  let groupedData: any; try { groupedData = props.brew.brewValues && JSON.parse(props.brew.brewValues as string).groupedData; } catch (_) { groupedData = undefined; }
+  const residual = latest?.plato ?? props.brew.residual_extract; const attenuationValue = typeof residual === 'number' ? attenuation(props.brew.originalwort, residual) : undefined; const alcohol = typeof residual === 'number' ? approximateAlcohol(props.brew.originalwort, residual) : undefined;
+  return <div className="finished-brew-details fermentation-details">
+    <h3>{props.brew.name}</h3><p className="fermentation-phase">{BrewStateGerman[props.brew.state]}{fermentationDay(details.phaseStartedAt || String(props.brew.startDate)) ? ` · Tag ${fermentationDay(details.phaseStartedAt || String(props.brew.startDate))}` : ''}</p>
+    <section className="fermentation-card"><div className="fermentation-heading"><h4>Gärungsverlauf</h4><button onClick={() => setFormOpen(true)}>Neue Messung</button></div>
+      {props.loading && <p>Daten werden geladen …</p>}{props.error && <p className="fermentation-error">{props.error}</p>}
+      <div className="fermentation-latest"><span>Letzte Messung</span><strong>{number(latest?.temperature, ' °C')}</strong><strong>{number(latest?.plato, ' °P')}</strong><small>{date(latest?.measuredAt)}</small></div>
+      {noPlato !== undefined && noPlato >= 3 && <p className="fermentation-notice">Seit {noPlato} Tagen keine Plato-Messung.</p>}
+      {formOpen && <div className="fermentation-form" role="dialog" aria-label="Neue Gärungsmessung"><label>Datum / Uhrzeit<input type="datetime-local" value={measuredAt} onChange={e => setMeasuredAt(e.target.value)} /></label><label>Temperatur °C<input type="number" step="0.1" value={temperature} onChange={e => setTemperature(e.target.value)} /></label><label>Plato °P<input type="number" step="0.1" value={plato} onChange={e => setPlato(e.target.value)} /></label><label>Notiz<textarea value={note} onChange={e => setNote(e.target.value)} /></label>{validation && <p className="fermentation-error">{validation}</p>}<div><button onClick={() => setFormOpen(false)} disabled={props.saving}>Abbrechen</button><button onClick={save} disabled={props.saving}>{props.saving ? 'Speichert …' : 'Speichern'}</button></div></div>}
+      <h5>Manuelle Messungen</h5>{measurements.length === 0 ? <p>Keine Messwerte vorhanden.</p> : <ul className="fermentation-list">{measurements.map(m => <li key={m.id}><time>{date(m.measuredAt)}</time><strong>{[number(m.temperature, ' °C'), number(m.plato, ' °P')].join(' · ')}</strong>{m.note && <span>{m.note}</span>}</li>)}</ul>}
+      {typeof residual === 'number' && <dl className="fermentation-metrics"><div><dt>Stammwürze</dt><dd>{number(props.brew.originalwort, ' °P')}</dd></div><div><dt>Restextrakt</dt><dd>{number(residual, ' °P')}</dd></div><div><dt>Scheinbarer Vergärungsgrad</dt><dd>ca. {number(attenuationValue, ' %')}</dd></div><div><dt>Alkohol</dt><dd>ca. {number(alcohol, ' % vol')}</dd></div></dl>}
+    </section>
+    <section className="fermentation-card"><h4>Gärsensor</h4>{details.devices.length === 0 ? <p>Kein Sensor zugeordnet.</p> : details.devices.map(device => <div key={device.id} className="fermentation-device"><strong>{device.name}</strong><span className={isDeviceOnline(device.lastSeenAt) ? 'is-online' : 'is-offline'}>{isDeviceOnline(device.lastSeenAt) ? '● Online' : `Keine aktuellen Daten · zuletzt ${date(device.lastSeenAt || undefined)}`}</span>{!device.assignedFinishedBeerId && <div><p>Welches Bier wird überwacht?</p>{props.activeBrews.map(brew => <button key={brew.id} disabled={props.assigning.includes(device.id)} onClick={() => props.assign(device.id, brew.id)}>{brew.name}</button>)}</div>}</div>)}
+      {sensor && <dl className="fermentation-sensor-values"><div><dt>Bier</dt><dd>{number(sensor.beerTemperature, ' °C')}</dd></div><div><dt>Umgebung</dt><dd>{number(sensor.ambientTemperature, ' °C')}</dd></div><div><dt>Δ Temperatur</dt><dd>{typeof delta === 'number' && delta >= 0 ? '+' : ''}{number(delta, ' °C')}</dd></div><div><dt>Aktivität</dt><dd>{number(bubbles, ' Blubbs/min')}</dd></div></dl>}
+    </section>
+    <section className="fermentation-card"><h4>Gärungsaktionen</h4>{details.actions.length === 0 ? <p>Keine Aktionen geplant.</p> : <ul className="fermentation-list">{[...details.actions].sort((a,b) => Date.parse(a.scheduledAt)-Date.parse(b.scheduledAt)).map(action => { const due = actionDueLabel(action); return <li key={action.id} className={`is-${due.severity}`}><time>{action.state === 'COMPLETED' ? `Erledigt ${date(action.completedAt || undefined)}` : due.label}</time><strong>{actionText(action)}</strong>{action.state === 'PLANNED' && <button disabled={props.completing.includes(action.id)} onClick={() => props.complete(props.brew.id, action.id)}>{props.completing.includes(action.id) ? 'Wird gespeichert …' : 'Erledigt'}</button>}{action.state === 'ACTIVE' && <span>Aktiv{action.removeAt ? ` · Entfernen: ${date(action.removeAt)}` : ''}</span>}</li>;})}</ul>}</section>
+    {groupedData && <section className="fermentation-card"><h4>Temperaturverlauf des Brauprozesses</h4><BrewProcessChart groupedData={groupedData} /></section>}
+  </div>;
+};
+const mapState = (state: any, own: {brew: FinishedBrew}) => ({details: state.fermentationReducer.byBrewId[own.brew.id], activeBrews: (state.beerDataReducer.finishedBrews || []).filter((b: FinishedBrew) => b.active && b.state !== eBrewState.FINISHED), loading: state.fermentationReducer.loadingIds.includes(own.brew.id), saving: state.fermentationReducer.savingMeasurementIds.includes(own.brew.id), completing: state.fermentationReducer.completingActionIds, assigning: state.fermentationReducer.assigningDeviceIds, error: state.fermentationReducer.errors[own.brew.id]});
+const mapDispatch = (dispatch: any) => ({load: (id: string) => dispatch(FermentationActions.load(id)), save: (value: CreateFermentationMeasurement) => dispatch(FermentationActions.createMeasurement(value)), complete: (brewId: string, actionId: string) => dispatch(FermentationActions.completeAction(brewId, actionId)), assign: (deviceId: string, brewId: string) => dispatch(FermentationActions.assignDevice(deviceId, brewId))});
+export default connect(mapState, mapDispatch)(FinishedBrewDetailsView);

--- a/src/epics/fermentationEpics.ts
+++ b/src/epics/fermentationEpics.ts
@@ -1,0 +1,52 @@
+import {ofType} from 'redux-observable';
+import {from, of} from 'rxjs';
+import {catchError, exhaustMap, groupBy, map, mergeMap, switchMap} from 'rxjs/operators';
+import {FermentationActions, FermentationActionTypes} from '../actions/fermentation.actions';
+import {FermentationRepository} from '../repositorys/FermentationRepository';
+
+export const loadFermentationEpic = (action$: any) => action$.pipe(
+  ofType(FermentationActionTypes.LOAD),
+  groupBy((action: any) => action.payload.brewId),
+  mergeMap((group$: any) => group$.pipe(switchMap((action: any) =>
+    from(FermentationRepository.getDetails(action.payload.brewId)).pipe(
+      map(details => FermentationActions.loadSuccess(action.payload.brewId, details)),
+      catchError(error => of(FermentationActions.loadFailure(action.payload.brewId, error.message)))
+    )
+  )))
+);
+
+export const createMeasurementEpic = (action$: any) => action$.pipe(
+  ofType(FermentationActionTypes.CREATE_MEASUREMENT),
+  groupBy((action: any) => action.payload.measurement.finishedBeerId),
+  mergeMap((group$: any) => group$.pipe(exhaustMap((action: any) => {
+    const brewId = action.payload.measurement.finishedBeerId;
+    return from(FermentationRepository.createMeasurement(action.payload.measurement)).pipe(
+      mergeMap(() => of(FermentationActions.createMeasurementSuccess(brewId), FermentationActions.load(brewId))),
+      catchError(error => of(FermentationActions.createMeasurementFailure(brewId, error.message)))
+    );
+  })))
+);
+
+export const completeFermentationActionEpic = (action$: any) => action$.pipe(
+  ofType(FermentationActionTypes.COMPLETE_ACTION),
+  groupBy((action: any) => action.payload.actionId),
+  mergeMap((group$: any) => group$.pipe(exhaustMap((action: any) =>
+    from(FermentationRepository.completeAction(action.payload.actionId)).pipe(
+      mergeMap(() => of(FermentationActions.completeActionSuccess(action.payload.brewId, action.payload.actionId), FermentationActions.load(action.payload.brewId))),
+      catchError(error => of(FermentationActions.completeActionFailure(action.payload.brewId, action.payload.actionId, error.message)))
+    )
+  )))
+);
+
+export const assignDeviceEpic = (action$: any) => action$.pipe(
+  ofType(FermentationActionTypes.ASSIGN_DEVICE),
+  groupBy((action: any) => action.payload.deviceId),
+  mergeMap((group$: any) => group$.pipe(exhaustMap((action: any) =>
+    from(FermentationRepository.assignDevice(action.payload.deviceId, action.payload.brewId)).pipe(
+      mergeMap(() => of(FermentationActions.assignDeviceSuccess(action.payload.deviceId, action.payload.brewId), FermentationActions.load(action.payload.brewId))),
+      catchError(error => of(FermentationActions.assignDeviceFailure(action.payload.deviceId, action.payload.brewId, error.message)))
+    )
+  )))
+);
+
+export const fermentationEpics = [loadFermentationEpic, createMeasurementEpic, completeFermentationActionEpic, assignDeviceEpic];

--- a/src/model/Fermentation.ts
+++ b/src/model/Fermentation.ts
@@ -1,0 +1,54 @@
+export type FermentationActionState = 'PLANNED' | 'ACTIVE' | 'COMPLETED';
+
+export interface FermentationMeasurement {
+  id: string;
+  finishedBeerId: string;
+  measuredAt: string;
+  temperature?: number | null;
+  plato?: number | null;
+  note?: string;
+}
+
+export type CreateFermentationMeasurement = Omit<FermentationMeasurement, 'id'>;
+
+export interface FermentationAction {
+  id: string;
+  finishedBeerId: string;
+  type: string;
+  ingredientName?: string;
+  amount?: number;
+  unit?: string;
+  scheduledAt: string;
+  state: FermentationActionState;
+  completedAt?: string | null;
+  removeAt?: string | null;
+}
+
+export interface FermentationDevice {
+  id: string;
+  name: string;
+  status?: 'ONLINE' | 'OFFLINE' | string;
+  lastSeenAt?: string | null;
+  assignedFinishedBeerId?: string | null;
+}
+
+export interface SensorMeasurement {
+  id: string;
+  deviceId: string;
+  finishedBeerId?: string;
+  measuredAt: string;
+  beerTemperature?: number | null;
+  ambientTemperature?: number | null;
+  temperatureDelta?: number | null;
+  bubbleRatePerMinute?: number | null;
+  bubbleCount?: number | null;
+  windowSeconds?: number | null;
+}
+
+export interface FermentationDetails {
+  measurements: FermentationMeasurement[];
+  actions: FermentationAction[];
+  devices: FermentationDevice[];
+  sensorMeasurements: SensorMeasurement[];
+  phaseStartedAt?: string;
+}

--- a/src/reducers/fermentationReducer.test.ts
+++ b/src/reducers/fermentationReducer.test.ts
@@ -1,0 +1,15 @@
+import {FermentationActions} from '../actions/fermentation.actions';
+import {fermentationReducer, initialFermentationState} from './fermentationReducer';
+
+describe('fermentationReducer', () => {
+  it('does not optimistically add measurements', () => {
+    const state = fermentationReducer(initialFermentationState, FermentationActions.createMeasurement({finishedBeerId: 'b', measuredAt: '', plato: 4}));
+    expect(state.savingMeasurementIds).toEqual(['b']); expect(state.byBrewId.b).toBeUndefined();
+  });
+  it('does not optimistically complete actions or assignments and exposes failures', () => {
+    const completing = fermentationReducer(initialFermentationState, FermentationActions.completeAction('b', 'a'));
+    expect(completing.completingActionIds).toEqual(['a']); expect(completing.byBrewId.b).toBeUndefined();
+    const failed = fermentationReducer(completing, FermentationActions.completeActionFailure('b', 'a', 'HTTP 500'));
+    expect(failed.completingActionIds).toEqual([]); expect(failed.errors.b).toBe('HTTP 500');
+  });
+});

--- a/src/reducers/fermentationReducer.ts
+++ b/src/reducers/fermentationReducer.ts
@@ -1,0 +1,25 @@
+import {FermentationActionTypes} from '../actions/fermentation.actions';
+import {FermentationDetails} from '../model/Fermentation';
+
+export interface FermentationState { byBrewId: Record<string, FermentationDetails>; loadingIds: string[]; savingMeasurementIds: string[]; completingActionIds: string[]; assigningDeviceIds: string[]; errors: Record<string, string>; }
+export const initialFermentationState: FermentationState = {byBrewId: {}, loadingIds: [], savingMeasurementIds: [], completingActionIds: [], assigningDeviceIds: [], errors: {}};
+const add = (xs: string[], id: string) => xs.includes(id) ? xs : [...xs, id];
+const remove = (xs: string[], id: string) => xs.filter(value => value !== id);
+export const fermentationReducer = (state = initialFermentationState, action: any): FermentationState => {
+  const p = action.payload || {};
+  switch (action.type) {
+    case FermentationActionTypes.LOAD: return {...state, loadingIds: add(state.loadingIds, p.brewId), errors: {...state.errors, [p.brewId]: ''}};
+    case FermentationActionTypes.LOAD_SUCCESS: return {...state, loadingIds: remove(state.loadingIds, p.brewId), byBrewId: {...state.byBrewId, [p.brewId]: p.details}};
+    case FermentationActionTypes.LOAD_FAILURE: return {...state, loadingIds: remove(state.loadingIds, p.brewId), errors: {...state.errors, [p.brewId]: p.error}};
+    case FermentationActionTypes.CREATE_MEASUREMENT: return {...state, savingMeasurementIds: add(state.savingMeasurementIds, p.measurement.finishedBeerId), errors: {...state.errors, [p.measurement.finishedBeerId]: ''}};
+    case FermentationActionTypes.CREATE_MEASUREMENT_SUCCESS: return {...state, savingMeasurementIds: remove(state.savingMeasurementIds, p.brewId)};
+    case FermentationActionTypes.CREATE_MEASUREMENT_FAILURE: return {...state, savingMeasurementIds: remove(state.savingMeasurementIds, p.brewId), errors: {...state.errors, [p.brewId]: p.error}};
+    case FermentationActionTypes.COMPLETE_ACTION: return {...state, completingActionIds: add(state.completingActionIds, p.actionId)};
+    case FermentationActionTypes.COMPLETE_ACTION_SUCCESS: return {...state, completingActionIds: remove(state.completingActionIds, p.actionId)};
+    case FermentationActionTypes.COMPLETE_ACTION_FAILURE: return {...state, completingActionIds: remove(state.completingActionIds, p.actionId), errors: {...state.errors, [p.brewId]: p.error}};
+    case FermentationActionTypes.ASSIGN_DEVICE: return {...state, assigningDeviceIds: add(state.assigningDeviceIds, p.deviceId)};
+    case FermentationActionTypes.ASSIGN_DEVICE_SUCCESS: return {...state, assigningDeviceIds: remove(state.assigningDeviceIds, p.deviceId)};
+    case FermentationActionTypes.ASSIGN_DEVICE_FAILURE: return {...state, assigningDeviceIds: remove(state.assigningDeviceIds, p.deviceId), errors: {...state.errors, [p.brewId]: p.error}};
+    default: return state;
+  }
+};

--- a/src/reducers/rootReducer.ts
+++ b/src/reducers/rootReducer.ts
@@ -7,6 +7,7 @@ import {maltsReducer, MaltsReducerState, initialMaltsState} from './maltsReducer
 import {yeastReducer, YeastReducerState, initialYeastState} from './yeastReducer';
 import {additionalIngredientsReducer, AdditionalIngredientsReducerState, initialAdditionalIngredientsState} from './additionalIngredientsReducer';
 import {initialWarningState, warningReducer, WarningReducerState} from './warningReducer';
+import {fermentationReducer, FermentationState, initialFermentationState} from './fermentationReducer';
 
 export const rootReducer = combineReducers({
     applicationReducer: applicationReducer,
@@ -16,7 +17,8 @@ export const rootReducer = combineReducers({
     hopsReducer: hopsReducer,
     maltsReducer: maltsReducer,
     yeastReducer: yeastReducer,
-    additionalIngredientsReducer: additionalIngredientsReducer
+    additionalIngredientsReducer: additionalIngredientsReducer,
+    fermentationReducer
 
 });
 
@@ -29,6 +31,9 @@ export interface RootState {
     maltsReducer: MaltsReducerState;
     yeastReducer: YeastReducerState;
     additionalIngredientsReducer: AdditionalIngredientsReducerState;
+    fermentationReducer: FermentationState;
 }
 export type { ApplicationReducerState, BeerDataReducerState, ProductionReducerState, WarningReducerState, HopsReducerState, MaltsReducerState, YeastReducerState, AdditionalIngredientsReducerState };
 export { initialApplicationState, initialBeerState, initialProductionState, initialWarningState, initialHopsState, initialMaltsState, initialYeastState, initialAdditionalIngredientsState};
+export type {FermentationState};
+export {initialFermentationState};

--- a/src/repositorys/FermentationRepository.ts
+++ b/src/repositorys/FermentationRepository.ts
@@ -1,0 +1,21 @@
+import {BaseRepository} from './BaseRepository';
+import {CreateFermentationMeasurement, FermentationAction, FermentationDetails, FermentationDevice, FermentationMeasurement, SensorMeasurement} from '../model/Fermentation';
+
+export class FermentationRepository extends BaseRepository {
+  static getDetails(finishedBeerId: string): Promise<FermentationDetails> {
+    return this.get(`fermentation/finishedbeers/${encodeURIComponent(finishedBeerId)}`);
+  }
+  static getDevices(): Promise<FermentationDevice[]> { return this.get('fermentation/devices'); }
+  static getSensorMeasurements(finishedBeerId: string): Promise<SensorMeasurement[]> {
+    return this.get(`fermentation/sensor-measurements?finishedBeerId=${encodeURIComponent(finishedBeerId)}`);
+  }
+  static createMeasurement(value: CreateFermentationMeasurement): Promise<FermentationMeasurement> {
+    return this.post('fermentation/measurements', value);
+  }
+  static completeAction(id: string): Promise<FermentationAction> {
+    return this.post(`fermentation/actions/${encodeURIComponent(id)}/complete`, {});
+  }
+  static assignDevice(deviceId: string, finishedBeerId: string): Promise<FermentationDevice> {
+    return this.put(`fermentation/devices/${encodeURIComponent(deviceId)}/assignment`, {finishedBeerId});
+  }
+}

--- a/src/store.ts
+++ b/src/store.ts
@@ -9,10 +9,11 @@ import { hopsEpic} from "./epics/hopsEpic";
 import { maltsEpic} from "./epics/maltsEpic";
 import {yeastEpic} from "./epics/yeastEpic";
 import {additionalIngredientsEpic} from "./epics/additionalIngredientsEpic";
+import {fermentationEpics} from './epics/fermentationEpics';
 
 const epicMiddleware = createEpicMiddleware<any, any, RootState>();
 
-const rootEpic = combineEpics(...beerEpics, ...productionEpics, ...hopsEpic, ...maltsEpic, ...yeastEpic, ...additionalIngredientsEpic);
+const rootEpic = combineEpics(...beerEpics, ...productionEpics, ...hopsEpic, ...maltsEpic, ...yeastEpic, ...additionalIngredientsEpic, ...fermentationEpics);
 
 // Erstellen Sie den Store mit der Middleware
 const store = configureStore({

--- a/src/utils/fermentation.test.ts
+++ b/src/utils/fermentation.test.ts
@@ -1,0 +1,21 @@
+import {actionDueLabel, approximateAlcohol, attenuation, bubbleRate, isDeviceOnline, missingPlatoDays, temperatureDelta} from './fermentation';
+
+describe('fermentation domain helpers', () => {
+  it('uses server bubble rate and otherwise derives bubbles per minute centrally', () => {
+    expect(bubbleRate({id: '1', deviceId: 'd', measuredAt: '', bubbleRatePerMinute: 4})).toBe(4);
+    expect(bubbleRate({id: '1', deviceId: 'd', measuredAt: '', bubbleCount: 17, windowSeconds: 300})).toBeCloseTo(3.4);
+  });
+  it('derives temperature delta only where needed', () => expect(temperatureDelta({id: '1', deviceId: 'd', measuredAt: '', beerTemperature: 18.3, ambientTemperature: 17.6})).toBeCloseTo(.7));
+  it('classifies future, today and overdue actions', () => {
+    const action: any = {scheduledAt: '2026-09-04T18:00:00Z'};
+    expect(actionDueLabel(action, new Date('2026-09-04T08:00:00Z'))).toMatchObject({label: 'Heute', severity: 'due'});
+    expect(actionDueLabel({...action, scheduledAt: '2026-09-03'}, new Date('2026-09-04'))).toMatchObject({severity: 'overdue'});
+    expect(actionDueLabel({...action, scheduledAt: '2026-09-07'}, new Date('2026-09-04'))).toMatchObject({label: 'In 3 Tagen', severity: 'future'});
+  });
+  it('handles missing Plato, online state and approximate metrics', () => {
+    expect(missingPlatoDays([{id: '1', finishedBeerId: 'b', measuredAt: '2026-09-01T00:00:00Z', plato: 4}], Date.parse('2026-09-04T00:00:00Z'))).toBe(3);
+    expect(isDeviceOnline('2026-09-04T11:50:00Z', Date.parse('2026-09-04T12:00:00Z'))).toBe(true);
+    expect(attenuation(13.2, 3)).toBeCloseTo(77.27);
+    expect(approximateAlcohol(13.2, 3)).toBeCloseTo(5.406);
+  });
+});

--- a/src/utils/fermentation.ts
+++ b/src/utils/fermentation.ts
@@ -1,0 +1,36 @@
+import {FermentationAction, FermentationMeasurement, SensorMeasurement} from '../model/Fermentation';
+
+export const latestByDate = <T>(values: T[], getDate: (value: T) => string): T | undefined =>
+  [...values].sort((a, b) => Date.parse(getDate(b)) - Date.parse(getDate(a)))[0];
+export const bubbleRate = (value?: SensorMeasurement): number | undefined => {
+  if (!value) return undefined;
+  if (typeof value.bubbleRatePerMinute === 'number') return value.bubbleRatePerMinute;
+  return typeof value.bubbleCount === 'number' && typeof value.windowSeconds === 'number' && value.windowSeconds > 0
+    ? value.bubbleCount * 60 / value.windowSeconds : undefined;
+};
+export const temperatureDelta = (value?: SensorMeasurement): number | undefined => {
+  if (!value) return undefined;
+  if (typeof value.temperatureDelta === 'number') return value.temperatureDelta;
+  return typeof value.beerTemperature === 'number' && typeof value.ambientTemperature === 'number' ? value.beerTemperature - value.ambientTemperature : undefined;
+};
+export const isDeviceOnline = (lastSeenAt?: string | null, now = Date.now(), staleMinutes = 15): boolean =>
+  Boolean(lastSeenAt && now - Date.parse(lastSeenAt) <= staleMinutes * 60_000);
+export const fermentationDay = (startedAt?: string, now = Date.now()): number | undefined => {
+  const start = startedAt ? Date.parse(startedAt) : NaN;
+  return Number.isFinite(start) ? Math.max(1, Math.floor((now - start) / 86_400_000) + 1) : undefined;
+};
+export const actionDueLabel = (action: FermentationAction, now = new Date()): {label: string; severity: 'future' | 'due' | 'overdue'} => {
+  const today = new Date(now.getFullYear(), now.getMonth(), now.getDate()).getTime();
+  const dueDate = new Date(action.scheduledAt); const due = new Date(dueDate.getFullYear(), dueDate.getMonth(), dueDate.getDate()).getTime();
+  const days = Math.round((due - today) / 86_400_000);
+  if (days < 0) return {label: `${Math.abs(days)} Tag${days === -1 ? '' : 'e'} überfällig`, severity: 'overdue'};
+  if (days === 0) return {label: 'Heute', severity: 'due'};
+  if (days === 1) return {label: 'Morgen', severity: 'future'};
+  return {label: `In ${days} Tagen`, severity: 'future'};
+};
+export const missingPlatoDays = (values: FermentationMeasurement[], now = Date.now()): number | undefined => {
+  const latest = latestByDate(values.filter(v => typeof v.plato === 'number'), v => v.measuredAt);
+  return latest ? Math.floor((now - Date.parse(latest.measuredAt)) / 86_400_000) : undefined;
+};
+export const attenuation = (original: number, residual: number) => original > 0 ? (original - residual) / original * 100 : undefined;
+export const approximateAlcohol = (original: number, residual: number) => (original - residual) * 0.53;


### PR DESCRIPTION
### Motivation
- Umsetzung von Issue `#249`: Gärungsverlauf, Gärungsaktionen und Gärsensoren im Frontend integrieren und BeerDataStore (#42) als Source of Truth nutzen.
- Keine zweite Bierverwaltung oder Persistenz in Redux; UI bleibt Darstellungs- und Interaktionsschicht und lädt Daten aus BeerDataStore-API-Repository-Endpoints.

### Description
- Neue Domain-/API-Modelle und Repository: `src/model/Fermentation.ts` und `src/repositorys/FermentationRepository.ts` für Measurements, Actions, Devices, Assignments und SensorMeasurements sowie Backend-Route-Kapselung (`fermentation/*`).
- Redux + Epics: `src/actions/fermentation.actions.ts`, `src/reducers/fermentationReducer.ts`, `src/epics/fermentationEpics.ts` und Registrierung der `fermentationEpics` im Store, inklusive Loading/Pending/Failure-Zuständen und kein optimistisches Domain-Update.
- UI-Integration: Erweiterte `FinishedBrew`-Detailansicht in `src/containers/MainView/FinishBrewsBeers/FinishedBrewDetails.tsx` (neues Formular für manuelle Messungen, Messhistorie, Sensoranzeige, Aktionen, Assignment-Buttons) und kompakte Darstellung aktiver Gärungen auf dem Dashboard in `src/containers/Dashboard/DashboardPage.tsx`.
- Hilfsfunktionen und Berechnungen: zentrale Utilities in `src/utils/fermentation.ts` (z.B. `bubbleRate`, `temperatureDelta`, `actionDueLabel`, `missingPlatoDays`, `attenuation`, `approximateAlcohol`) und zugehörige Tests `src/utils/fermentation.test.ts`.
- Tests und Komponenten-Tests: neue Tests für Reducer und Detail-View in `src/reducers/fermentationReducer.test.ts` und `src/containers/MainView/FinishBrewsBeers/FinishedBrewDetails.test.tsx`.
- Dokumentation: Ergänzungen in `docs/codex/*` (Interfaces, Domain-Model, Data-Flow, Compatibility) die BeerDataStore `fermentation/*`-Contract, Units und Verifizierungs-Punkte beschreiben.

### Testing
- Ergänzte Unit-Tests: `src/utils/fermentation.test.ts`, `src/reducers/fermentationReducer.test.ts` und `src/containers/MainView/FinishBrewsBeers/FinishedBrewDetails.test.tsx` wurden hinzugefügt (behavioral/validation tests for measurements, actions, sensor values and assignment flows).
- Repo checks: `git diff --check` und `git status` liefen lokal und wurden bestanden; Änderungen sind committed (Commit: "Integrate fermentation tracking into finished beers").
- Type checking / test execution: `npx tsc --noEmit` und `CI=true npm test` konnten nicht vollständig erfolgreich durchlaufen, weil `npm ci` / Abhängigkeitsinstallation an der konfigurierten Registry mit `403 Forbidden` scheiterte und `react-scripts` sowie Types fehlten; deshalb konnten die Tests und vollständige TypeScript-Checks in dieser Umgebung nicht ausgeführt werden.
- Verhalten der asynchronen Flows: Epics wurden so implementiert, dass nach erfolgreichen Writes (`createMeasurement`, `completeAction`, `assignDevice`) ein frisches Laden (`load`) des Backend-Aggregats erfolgt; reducer-Tests prüfen das Ausbleiben optimistischer fachlicher Bestätigungen und das korrekte Pending/Error-Handling.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a9a65baad74832f8f74707485b2aeee)