### PR TITLE
Fix discard recovery epic test setup

### DIFF
--- a/src/epics/productionEpics.test.ts
+++ b/src/epics/productionEpics.test.ts
@@ -291,7 +291,7 @@ describe('brew recovery command epics', () => {
 
     const discardDeferred = createDeferred<void>(); mockedProductionRepository.discardBrewRecovery.mockReturnValue(discardDeferred.promise);
     const discardActions = new Subject<any>(); const discarded: any[] = [];
-    const discardSub = discardBrewRecoveryEpic$(discardActions).subscribe((a: any) => discarded.push(a));
+    const discardSub = discardBrewRecoveryEpic$(discardActions, new BehaviorSubject(recoveryState([recoverableBeer()]))).subscribe((a: any) => discarded.push(a));
     discardActions.next(ProductionActions.discardBrewRecovery()); discardActions.next(ProductionActions.discardBrewRecovery());
     expect(mockedProductionRepository.discardBrewRecovery).toHaveBeenCalledTimes(1);
     discardDeferred.reject(new Error('offline')); await flushPromises();


### PR DESCRIPTION
### Motivation
- Fix a TypeScript test compilation error (`TS2554`) by supplying the required Redux state observable to `discardBrewRecoveryEpic$` in `src/epics/productionEpics.test.ts` so the epic test can exercise serialization and failure behavior correctly.

### Description
- Update the failing test to call `discardBrewRecoveryEpic$` with the missing second argument: `new BehaviorSubject(recoveryState([recoverableBeer()]))`, so the epic receives the expected `(action$, state$)` signature.

### Testing
- Ran `git diff --check` which reported no whitespace issues and showed the single-line test change; success. 
- Attempted `CI=true npm test -- --runInBand --watchAll=false src/epics/productionEpics.test.ts`, but automated test execution could not complete in this environment because project dependencies / `react-scripts` are not available (npm registry access produced a 403), so the Jest run failed to start.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a9a70398ca0832f9e14658cc638282b)