### PR TITLE
Fix duplicate finished brews and simplify finalization

### DIFF
--- a/docs/codex/known-risks.md
+++ b/docs/codex/known-risks.md
@@ -7,7 +7,8 @@
 - Recipe list default selection depends on the last item returned by `GET beers`. Backend ordering changes affect default preview.
 - Hop reminders assume recipe hop `time` is minutes before end of boil and status `currentStep.elapsedTime` is seconds within cooking phase.
 - `FinishedBrew` creation after production finish stores default numeric values (`liters`, `originalwort`, `residual_extract`) as `0`; real measurement ownership is unclear. Needs verification.
-- Finished-brew create and update have distinct confirmed semantics: create uses `POST finishedbeer` without a client ID, while full-record update uses `PUT finishedbeer` with the existing ID.
+- Finished-brew create and update have distinct semantics: create uses `POST finishedbeer` with a UI-generated optional UUID that is reused for retries; full-record update uses `PUT finishedbeer` with the existing ID. Legacy clients may still omit the create ID, in which case BeerDataStore generates one and that individual legacy request is not retry-idempotent.
+- A stable PI/control brew-run ID does not exist. Two independent UI clients completing the same physical brew can therefore still create different FinishedBrew UUIDs; cross-client deduplication is Needs verification and must not use `beer_id` alone because one recipe can be brewed repeatedly.
 - Status normalization supports legacy fields; removing backend legacy fields is safe only if structured fields are complete.
 - The app mixes Material UI v4 and MUI v5 dependencies.
 - `build-deploy`/`deploy` assume SSH access to `boris@192.168.178.72:/srv/sites/braumeister`.

--- a/src/containers/MainView/FinishBrewsBeers/FinishedBrewsTable.connect.ts
+++ b/src/containers/MainView/FinishBrewsBeers/FinishedBrewsTable.connect.ts
@@ -3,6 +3,7 @@ import {FinishedBrew, FinishedBrewCreatePayload} from "../../../model/FinishedBr
 import {finishedBrewsTestData} from "../../../model/finishedBrewsTestData";
 import {BeerActions} from "../../../actions/actions";
 import {FinishedBrewsTable} from './FinishedBrewsTable';
+import {withFinishedBrewCreateId} from '../../../utils/finishedBrewCreateId';
 
 const mapStateToProps = (state: any) => ({
     brews: state.beerDataReducer.finishedBrews || finishedBrewsTestData,
@@ -19,7 +20,7 @@ const mapDispatchToProps = (dispatch: any) => ({
         dispatch(BeerActions.updateActiveBeer(brew));
     },
     onCreate: (brew: FinishedBrewCreatePayload) => {
-        dispatch(BeerActions.addFinishedBrew(brew));
+        dispatch(BeerActions.addFinishedBrew(withFinishedBrewCreateId(brew)));
     },
     exportPdf: (brews: FinishedBrew[]) => {
         dispatch(BeerActions.generateFinishedBrewsPdf(brews));

--- a/src/containers/MainView/FinishBrewsBeers/FinishedBrewsTable.tsx
+++ b/src/containers/MainView/FinishBrewsBeers/FinishedBrewsTable.tsx
@@ -15,6 +15,7 @@ import { eBrewState, BrewStateGerman } from '../../../enums/eBrewState';
 import Panel from '../../Panel/Panel';
 import FinishedBrewDetails from './FinishedBrewDetails';
 import {completeFinishedBrew, mergeFinishedBrewChanges} from '../../../utils/finishedBrewChanges';
+import {createFinishedBrewId} from '../../../utils/finishedBrewCreateId';
 import ModalDialog, {DialogType} from '../../../components/ModalDialog/ModalDialog';
 
 
@@ -255,7 +256,7 @@ export class FinishedBrewsTable extends React.Component<FinishedBrewsTableProps,
                 <button
                     className="finish-btn"
                     style={{ marginLeft: '2rem', height: '2.2rem', display: 'flex', alignItems: 'center' }}
-                    onClick={() => this.setState({ newRowActive: true, newRowData: {} })}
+                    onClick={() => this.setState({ newRowActive: true, newRowData: {id: createFinishedBrewId()} })}
                     title="Neuen Eintrag hinzufügen"
                     aria-label="Neuen Eintrag hinzufügen"
                 >

--- a/src/containers/MainView/FinishBrewsBeers/FinishedBrewsTable.tsx
+++ b/src/containers/MainView/FinishBrewsBeers/FinishedBrewsTable.tsx
@@ -483,7 +483,7 @@ export class FinishedBrewsTable extends React.Component<FinishedBrewsTableProps,
                         className="table-edit-field"
                         disabled={!isActive}
                     >
-                        {Object.values(eBrewState).map(state => (
+                        {Object.values(eBrewState).filter(state => state !== eBrewState.FINISHED).map(state => (
                             <option key={state} value={state}>{BrewStateGerman[state]}</option>
                         ))}
                     </select>

--- a/src/containers/Production/Production.connect.ts
+++ b/src/containers/Production/Production.connect.ts
@@ -7,6 +7,7 @@ import {FinishedBrewCreatePayload} from "../../model/FinishedBrew";
 import {RootState} from "../../reducers/rootReducer";
 import {Production} from './Production';
 import {ConfirmStates} from '../../enums/eConfirmStates';
+import {withFinishedBrewCreateId} from '../../utils/finishedBrewCreateId';
 
 const mapDispatchToProps = (dispatch: Dispatch) => ({
     toggleAgitator: (agitatorState: MashAgitatorStates) => {
@@ -22,7 +23,7 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
         dispatch(ProductionActions.sendBrewingData(brewingData))
     },
     addFinishedBrew: (finishedBrew: FinishedBrewCreatePayload) => {
-        dispatch(BeerActions.addFinishedBrew(finishedBrew))
+        dispatch(BeerActions.addFinishedBrew(withFinishedBrewCreateId(finishedBrew)))
     },
     nextProcedureStep: () => {
         dispatch(ProductionActions.nextProcedureStep())

--- a/src/model/FinishedBrew.ts
+++ b/src/model/FinishedBrew.ts
@@ -15,4 +15,10 @@ export interface FinishedBrew {
     brewValues?: string;
 }
 
-export type FinishedBrewCreatePayload = Omit<FinishedBrew, 'id'>;
+/**
+ * Create payload for a finished-brew record.
+ *
+ * `id` is optional for backwards compatibility, but Brauhaus2 assigns one before
+ * dispatching the create action so retries can reuse the same create-operation ID.
+ */
+export type FinishedBrewCreatePayload = Omit<FinishedBrew, 'id'> & { id?: string };

--- a/src/utils/finishedBrewCreateId.test.ts
+++ b/src/utils/finishedBrewCreateId.test.ts
@@ -1,0 +1,30 @@
+import {eBrewState} from '../enums/eBrewState';
+import {FinishedBrewCreatePayload} from '../model/FinishedBrew';
+import {withFinishedBrewCreateId} from './finishedBrewCreateId';
+
+const payload = (): FinishedBrewCreatePayload => ({
+    name: 'Testbier',
+    startDate: '2026-09-05',
+    liters: 20,
+    originalwort: 12,
+    residual_extract: 4,
+    note: '',
+    active: true,
+    beer_id: 'recipe-id',
+    state: eBrewState.FERMENTATION,
+});
+
+describe('withFinishedBrewCreateId', () => {
+    it('adds a UUID to a new create payload', () => {
+        const identified = withFinishedBrewCreateId(payload());
+
+        expect(identified.id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i);
+    });
+
+    it('preserves an existing create ID for retries', () => {
+        const first = withFinishedBrewCreateId(payload());
+        const retry = withFinishedBrewCreateId(first);
+
+        expect(retry.id).toBe(first.id);
+    });
+});

--- a/src/utils/finishedBrewCreateId.ts
+++ b/src/utils/finishedBrewCreateId.ts
@@ -1,0 +1,26 @@
+import {FinishedBrewCreatePayload} from '../model/FinishedBrew';
+
+export type IdentifiedFinishedBrewCreatePayload = FinishedBrewCreatePayload & {id: string};
+
+export const createFinishedBrewId = (): string => {
+    if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+        return crypto.randomUUID();
+    }
+
+    return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, character => {
+        const random = Math.floor(Math.random() * 16);
+        const value = character === 'x' ? random : (random & 0x3) | 0x8;
+        return value.toString(16);
+    });
+};
+
+/**
+ * Adds an idempotency ID exactly once. Existing IDs are preserved so retries of
+ * the same create payload hit the BeerDataStore with the same operation key.
+ */
+export const withFinishedBrewCreateId = (
+    payload: FinishedBrewCreatePayload,
+): IdentifiedFinishedBrewCreatePayload => ({
+    ...payload,
+    id: payload.id || createFinishedBrewId(),
+});


### PR DESCRIPTION
## Problem
A FinishedBrew can be created twice when the original `POST /finishedbeer` is committed by BeerDataStore but the UI does not receive the response and retries. The retry currently has no stable create identity. The finished-brews table also exposes the terminal `FINISHED` state both in the status select and via the dedicated `Endgültig fertigstellen` action.

## Changes
- Generate a UUID before dispatching every FinishedBrew create.
- Preserve that UUID in Redux pending payloads so production retries reuse the same ID.
- Preserve the UUID for manual new-row retries as well.
- Keep `FinishedBrewCreatePayload.id` optional for backward compatibility.
- Remove `FINISHED` from the status select of existing active brews; terminal completion now goes through the dedicated finalization button, which sets `state=FINISHED`, `active=false`, and `endDate`.
- Add unit coverage for create-ID generation/reuse.
- Document the remaining cross-client limitation: without a stable controller brew-run ID, two independent UI clients can still represent the same physical run with different UUIDs. `beer_id` must not be used as a uniqueness key because recipes can be brewed repeatedly.

## Coordinated backend change
Requires the companion BeerDataStore PR from branch `fix/idempotent-finished-brew`, where `POST /finishedbeer` accepts the optional client UUID and treats repeated requests with the same UUID idempotently.

## Root-cause note
Changing an existing row to finished is a `PUT /finishedbeer`, not a create operation. The duplicate-row failure is therefore in the earlier create/retry path, not in the final `PUT` itself.