### PR TITLE
Fix stale ingredient resolution on dialog reopen

### DIFF
--- a/src/containers/DatabaseOverview/RecipeImportDialog.test.tsx
+++ b/src/containers/DatabaseOverview/RecipeImportDialog.test.tsx
@@ -213,6 +213,25 @@ describe('RecipeImportDialog', () => {
         expect(screen.getByText('Manuell gewählt')).toBeInTheDocument();
     });
 
+    it('does not attach a cancelled resolution response to a newly opened dialog', async () => {
+        const onCancel = jest.fn();
+        const result = resolutionResult([{ingredientType: 'MALT', sourceName: 'Altes Malz', candidates: []}]);
+        const {rerender} = render(<RecipeImportDialog open onCancel={onCancel} onImport={jest.fn()} result={result} />);
+
+        expect(screen.getByText('Rezept importieren')).toBeInTheDocument();
+        expect(screen.queryByText('Altes Malz')).not.toBeInTheDocument();
+        selectFormat('Brauhaus');
+        selectFile(jsonFile('{"name":"Neu"}'));
+        await waitFor(() => expect(screen.getByRole('button', {name: 'Importieren'})).toBeEnabled());
+
+        rerender(<RecipeImportDialog open={false} onCancel={onCancel} onImport={jest.fn()} result={result} />);
+        rerender(<RecipeImportDialog open onCancel={onCancel} onImport={jest.fn()} result={result} />);
+
+        expect(screen.getByText('Rezept importieren')).toBeInTheDocument();
+        expect(screen.queryByText('Altes Malz')).not.toBeInTheDocument();
+        expect(screen.getByRole('button', {name: 'Importieren'})).toBeDisabled();
+    });
+
     it('blocks a second retry while the first request is pending', async () => {
         const {onImport} = await startResolution([{ingredientType: 'HOP', sourceName: 'Hallertau', candidates: [{ingredientId: 'h-1', name: 'Hallertauer', matchType: 'FUZZY'}]}]);
         const retry = await screen.findByRole('button', {name: 'Import abschließen'});

--- a/src/containers/DatabaseOverview/RecipeImportDialog.tsx
+++ b/src/containers/DatabaseOverview/RecipeImportDialog.tsx
@@ -64,6 +64,7 @@ export const RecipeImportDialog: React.FC<RecipeImportDialogProps> = ({open, loa
     const [idempotencyKey, setIdempotencyKey] = React.useState('');
     const [parseError, setParseError] = React.useState('');
     const [submitted, setSubmitted] = React.useState(false);
+    const [activeResolution, setActiveResolution] = React.useState<RecipeImportResult>();
     const [mappings, setMappings] = React.useState<Record<string, string | number>>({});
     const [mappingStates, setMappingStates] = React.useState<Record<string, 'suggested' | 'manual' | 'created'>>({});
     const [creating, setCreating] = React.useState<string>();
@@ -73,11 +74,11 @@ export const RecipeImportDialog: React.FC<RecipeImportDialogProps> = ({open, loa
 
     const reset = React.useCallback(() => {
         setFormat(''); setFileName(''); setRecipe(undefined); setIdempotencyKey(''); setParseError('');
-        setSubmitted(false); setMappings({}); setMappingStates({}); setCreating(undefined); setCreateValues({name: '', description: ''}); setCreateError('');
+        setSubmitted(false); setActiveResolution(undefined); setMappings({}); setMappingStates({}); setCreating(undefined); setCreateValues({name: '', description: ''}); setCreateError('');
     }, []);
     React.useEffect(() => { if (open && !wasOpen.current) reset(); wasOpen.current = open; }, [open, reset]);
     React.useEffect(() => {
-        if (!result?.resolutionRequired) return;
+        if (!result?.resolutionRequired || !recipe || !idempotencyKey) return;
         const initialMappings: Record<string, string | number> = {};
         const initialStates: Record<string, 'suggested'> = {};
         (result.ingredients ?? []).forEach(item => {
@@ -89,6 +90,7 @@ export const RecipeImportDialog: React.FC<RecipeImportDialogProps> = ({open, loa
         });
         setMappings(initialMappings);
         setMappingStates(initialStates);
+        setActiveResolution(result);
         setSubmitted(false);
         setCreating(undefined);
     }, [result]); // A new backend response starts a new resolution; ordinary renders retain user choices.
@@ -97,7 +99,7 @@ export const RecipeImportDialog: React.FC<RecipeImportDialogProps> = ({open, loa
 
     const resetAndCancel = () => { reset(); onCancel(); };
     const readFile = async (file?: File) => {
-        setFileName(file?.name || ''); setRecipe(undefined); setIdempotencyKey(''); setParseError(''); setSubmitted(false); setMappings({}); setMappingStates({});
+        setFileName(file?.name || ''); setRecipe(undefined); setIdempotencyKey(''); setParseError(''); setSubmitted(false); setActiveResolution(undefined); setMappings({}); setMappingStates({});
         if (!file) return;
         try {
             const parsed: unknown = JSON.parse(await file.text());
@@ -105,7 +107,9 @@ export const RecipeImportDialog: React.FC<RecipeImportDialogProps> = ({open, loa
             setRecipe(parsed as JsonObject); setIdempotencyKey(createImportIdempotencyKey());
         } catch (_error) { setParseError('Die ausgewählte Datei enthält kein gültiges JSON.'); }
     };
-    const unresolved = result?.resolutionRequired ? (result.ingredients ?? []) : [];
+    // A cancelled resolution may still be present in Redux when the dialog is opened
+    // again. Only a response received for the source held by this dialog becomes active.
+    const unresolved = activeResolution?.ingredients ?? [];
     const retry = () => {
         if (!format || !recipe || !idempotencyKey || unresolved.some(item => !isValidIngredientId(mappings[keyFor(item)]))) return;
         const ingredientMappings: IngredientMappingRequest[] = unresolved.map(item => ({ingredientType: item.ingredientType, sourceName: item.sourceName, ingredientId: mappings[keyFor(item)]}));


### PR DESCRIPTION
### Motivation
- Prevent a previously received backend resolution that remained in Redux from being incorrectly attached to a newly opened import dialog or a different source file so the dialog always shows the resolution for its current source document only.

### Description
- Scope resolution responses to the current dialog session by introducing a local `activeResolution` state and only activating backend `result` when this dialog holds a parsed `recipe` and an `idempotencyKey`.
- Clear the active resolution on dialog reset and when a new file is selected so stale responses are not reused unintentionally.
- Add a unit test that verifies a cancelled/residual resolution response in Redux is not attached to a newly opened dialog (`src/containers/DatabaseOverview/RecipeImportDialog.test.tsx`).
- Files changed: `src/containers/DatabaseOverview/RecipeImportDialog.tsx`, `src/containers/DatabaseOverview/RecipeImportDialog.test.tsx`.

### Testing
- Ran `git diff --check` and repository lint/diff checks successfully, and committed the change as `Fix stale ingredient resolution on dialog reopen`.
- Added a Jest test covering the cancelled-resolution reopen case but running the full Jest suites locally could not be completed because `npm ci --legacy-peer-deps` failed in this environment due to an HTTP 403 from the npm registry, so automated test execution was not available here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6aa2cb4c5264832fb58caf498d3c1bfd)