### PR TITLE
Add independent fermentation gateway realtime channel

### DIFF
--- a/docs/codex/compatibility/cross-repo-contracts.md
+++ b/docs/codex/compatibility/cross-repo-contracts.md
@@ -262,3 +262,7 @@ The UI normal lifecycle is `FERMENTATION -> MATURATION | FINISHED`, `MATURATION 
 ### BeerDataStore normalized recipe ingredients and Import V2 resolution
 
 The UI now requires the hard-cut normalized BeerDataStore recipe contract: ingredient uses identify master data only by `id`; hop/additional timing is `additionTime`; recipe additional notes are `note`; and recipe uses have no `actionId`. Runtime `FermentationAction.actionId` remains unchanged. Import resolution is stateless: `resolutionRequired` responses are not inserted into recipe state, and the retry resends the unchanged source document and idempotency key with explicit `{ingredientType, sourceName, ingredientId}` mappings. Deployment against the matching BeerDataStore refactor is required.
+
+## UI ↔ FermentationSensorGateway live integration status (Brauhaus2)
+
+Brauhaus2 additively consumes the gateway's native RFC WebSocket through Caddy at `/api/fermentation/ui`; it must not use the existing BrewmasterController Socket.IO client for this endpoint. Snapshot/status DTOs and the six documented status strings are preserved without deriving assignment or fermentation decisions in the UI. BeerDataStore remains the REST source of truth and exposes no UI WebSocket. Local CRA development rewrites this public path to `http://localhost:5001/fermentation/ui` with WebSocket upgrade support. Production Caddy route and gateway deployment are **Needs verification**.

--- a/docs/codex/data-flow.md
+++ b/docs/codex/data-flow.md
@@ -118,3 +118,11 @@ Heater-safety reset is intentionally not a Settings-page action. Settings expose
 Finished-beer detail/dashboard → Redux action → fermentation epic → `FermentationRepository` → BeerDataStore. A load combines recipe actions and the unified measurement history from their per-finished-beer routes with the existing device/sensor reads. Beer temperature, ambient temperature, and Plato flow exclusively from `/measurements` into one Redux history; the UI does not merge temperatures from `/sensor-measurements`. The sensor route remains loaded for sensor-specific blubb data. Successful measurement, completion, or assignment commands reload backend truth; reducers never optimistically claim domain success. Sensor hardware communicates with BeerDataStore, never Brauhaus2.
 
 The compact finished-beer detail links to `/finished-brews/{finishedBeerId}/measurements`. The route resolves the existing `FinishedBrew.id`, restores the finished-brew list only for direct entry, and reuses `FinishedBrewDetails` in measurement mode. That shared component remains the single owner of the fermentation aggregate load, so opening the analysis view does not introduce a second measurement-loading path or endpoint.
+
+## Fermentation gateway live status
+
+1. At app-shell startup, the UI independently opens the native same-origin WebSocket `/api/fermentation/ui` while retaining the existing BrewmasterController Socket.IO connection.
+2. A gateway snapshot completely replaces `fermentationReducer.sensorsByDeviceUid`; a status-change message replaces only the entry identified by `deviceUid`.
+3. Redux derives a persistent header warning for gateway disconnect, assignment, sensor connectivity, or BeerDataStore integration errors. Identical state does not create toasts or dialogs.
+4. A meaningful sensor status change may trigger at most one reload of an already visible fermentation aggregate. That reload uses existing BeerDataStore REST methods; assignments and measurements never come from the gateway message.
+5. Disconnect uses bounded backoff (2, 5, 10, 20, then at most 30 seconds), reset after open. App unmount closes only this gateway socket.

--- a/docs/codex/interfaces.md
+++ b/docs/codex/interfaces.md
@@ -163,3 +163,9 @@ Dry-hop and fermentation-phase additional-ingredient DTOs use one Recipe Action 
 `FinishedBrew.fermentationStartedAt` is the optional, timezone-bearing canonical basis for `TIME_OFFSET`; it is not inferred from `startDate`. The normal production-completion workflow sets it to the current ISO-8601 instant, while legacy/manual records may leave it absent. Complete PUT payloads preserve the value unchanged.
 
 Runtime actions retain the API field `actionId` (never silently renamed to `id`) and contain `sourceType`, `name`, `amount`, `unit`, the generic trigger/contact fields, `status`, `due`, `completedAt`, `skippedAt`, `contactEndsAt`, and `latestPlato`. `contactEndsAt` and `due` are backend-owned projections. Only the separately retained device/sensor route deployment and exact error envelopes remain **Needs verification**.
+
+## UI ↔ FermentationSensorGateway WebSocket
+
+The browser opens a native RFC WebSocket (not Socket.IO) at same-origin `/api/fermentation/ui`, using `ws://` for an HTTP page and `wss://` for an HTTPS page. Caddy owns production routing. The initial `FERMENTATION_GATEWAY_SNAPSHOT` carries `sensors[]`; `FERMENTATION_SENSOR_STATUS_CHANGED` carries one `sensor`. A sensor is keyed by `deviceUid`, has optional `deviceName` and `beerId`, an ISO-8601 `updatedAt`, and one of `REGISTERED | ASSIGNED | UNASSIGNED | DISCONNECTED | BACKEND_UNAVAILABLE | BACKEND_ERROR`. Unknown messages are ignored. The UI must not infer assignments from optional `beerId`.
+
+This additive live-status contract does not change BeerDataStore REST DTOs or controller Socket.IO. Caddy routing and deployed gateway support are **Needs verification** outside this repository.

--- a/docs/codex/system-overview.md
+++ b/docs/codex/system-overview.md
@@ -54,3 +54,9 @@ No `.env`-based URL configuration was found in inspected source. Changing deploy
 5. Production view maps the selected recipe into `BrewingData`, sends it to control, starts brewing, then polls status immediately and every ten seconds until terminal state while timed-step displays advance from a local wall-clock projection.
 6. Runtime status updates drive progress display, confirm dialogs, timeline grouping, hop-addition reminders, finish dialog, and saved finished-brew records.
 7. Finished brew completion stores collected status samples as JSON in `FinishedBrew.brewValues`.
+
+## Fermentation gateway realtime channel (Brauhaus2)
+
+The UI owns two independent realtime connections. During brewing, the existing default-namespace Socket.IO connection communicates with BrewmasterController and remains unchanged. During fermentation, a separate native RFC WebSocket connects to FermentationSensorGateway at the same-origin public path `/api/fermentation/ui`; either service may be offline without controlling the other connection.
+
+BeerDataStore remains the REST source of truth for fermentation devices, assignments, measurements, and recipe actions. It has no UI WebSocket. FermentationSensorGateway publishes only live integration/connectivity status and does not provide measurements as UI truth or perform UI-side fermentation assessment.

--- a/src/actions/fermentation.actions.ts
+++ b/src/actions/fermentation.actions.ts
@@ -1,4 +1,4 @@
-import {CreateFermentationMeasurement, FermentationDetails} from '../model/Fermentation';
+import {CreateFermentationMeasurement, FermentationDetails, FermentationGatewaySensorStatus} from '../model/Fermentation';
 
 export enum FermentationActionTypes {
   LOAD = 'Fermentation.LOAD', LOAD_SUCCESS = 'Fermentation.LOAD_SUCCESS', LOAD_FAILURE = 'Fermentation.LOAD_FAILURE',
@@ -6,6 +6,8 @@ export enum FermentationActionTypes {
   COMPLETE_ACTION = 'Fermentation.COMPLETE_ACTION', COMPLETE_ACTION_SUCCESS = 'Fermentation.COMPLETE_ACTION_SUCCESS', COMPLETE_ACTION_FAILURE = 'Fermentation.COMPLETE_ACTION_FAILURE',
   SKIP_ACTION = 'Fermentation.SKIP_ACTION', SKIP_ACTION_SUCCESS = 'Fermentation.SKIP_ACTION_SUCCESS', SKIP_ACTION_FAILURE = 'Fermentation.SKIP_ACTION_FAILURE',
   ASSIGN_DEVICE = 'Fermentation.ASSIGN_DEVICE', ASSIGN_DEVICE_SUCCESS = 'Fermentation.ASSIGN_DEVICE_SUCCESS', ASSIGN_DEVICE_FAILURE = 'Fermentation.ASSIGN_DEVICE_FAILURE',
+  GATEWAY_CONNECT = 'Fermentation.GATEWAY_CONNECT', GATEWAY_DISCONNECT = 'Fermentation.GATEWAY_DISCONNECT', GATEWAY_CONNECTION_CHANGED = 'Fermentation.GATEWAY_CONNECTION_CHANGED',
+  GATEWAY_SNAPSHOT_RECEIVED = 'Fermentation.GATEWAY_SNAPSHOT_RECEIVED', GATEWAY_SENSOR_STATUS_CHANGED = 'Fermentation.GATEWAY_SENSOR_STATUS_CHANGED',
 }
 export const FermentationActions = {
   load: (brewId: string) => ({type: FermentationActionTypes.LOAD, payload: {brewId}}),
@@ -23,4 +25,9 @@ export const FermentationActions = {
   assignDevice: (deviceId: string, brewId: string) => ({type: FermentationActionTypes.ASSIGN_DEVICE, payload: {deviceId, brewId}}),
   assignDeviceSuccess: (deviceId: string, brewId: string) => ({type: FermentationActionTypes.ASSIGN_DEVICE_SUCCESS, payload: {deviceId, brewId}}),
   assignDeviceFailure: (deviceId: string, brewId: string, error: string) => ({type: FermentationActionTypes.ASSIGN_DEVICE_FAILURE, payload: {deviceId, brewId, error}}),
+  gatewayConnect: () => ({type: FermentationActionTypes.GATEWAY_CONNECT}),
+  gatewayDisconnect: () => ({type: FermentationActionTypes.GATEWAY_DISCONNECT}),
+  gatewayConnectionChanged: (connected: boolean) => ({type: FermentationActionTypes.GATEWAY_CONNECTION_CHANGED, payload: {connected}}),
+  gatewaySnapshotReceived: (sensors: FermentationGatewaySensorStatus[]) => ({type: FermentationActionTypes.GATEWAY_SNAPSHOT_RECEIVED, payload: {sensors}}),
+  gatewaySensorStatusChanged: (sensor: FermentationGatewaySensorStatus) => ({type: FermentationActionTypes.GATEWAY_SENSOR_STATUS_CHANGED, payload: {sensor}}),
 };

--- a/src/containers/MainView/Header/Header.connect.ts
+++ b/src/containers/MainView/Header/Header.connect.ts
@@ -14,6 +14,8 @@ const mapStateToProps = (state: RootState) => ({
     socketConnected: state.productionReducer.socketConnection.connected,
     warnings: state.warningReducer.warnings,
     warningsReceived: state.warningReducer.warningsReceived,
+    fermentationGatewayConnected: state.fermentationReducer.gatewayConnected,
+    fermentationGatewaySensors: state.fermentationReducer.sensorsByDeviceUid,
 });
 
 const mapDispatchToProps = (dispatch: any) => ({

--- a/src/containers/MainView/Header/Header.test.tsx
+++ b/src/containers/MainView/Header/Header.test.tsx
@@ -100,6 +100,15 @@ describe('Header navigation', () => {
         expect(screen.queryByText('Bereit')).not.toBeInTheDocument();
     });
 
+    it('shows and clears the persistent fermentation gateway assignment warning', () => {
+        const props = {setViewState: jest.fn(), currentView: Views.FINISHED_BREWS, removeAllMessages: jest.fn(), backendStatus: true, messages: [], fermentationGatewayConnected: true};
+        const unassigned = {deviceUid: 'sensor-1', deviceName: 'FERM-123', status: 'UNASSIGNED' as const, updatedAt: '2026-09-11T07:23:11Z'};
+        const {rerender} = render(<Header {...props} fermentationGatewaySensors={{'sensor-1': unassigned}} />);
+        expect(screen.getByRole('status')).toHaveTextContent('Gärsensor FERM-123 ist keinem Bier zugeordnet.');
+        rerender(<Header {...props} fermentationGatewaySensors={{'sensor-1': {...unassigned, status: 'ASSIGNED' as const}}} />);
+        expect(screen.queryByText(/ist keinem Bier zugeordnet/)).not.toBeInTheDocument();
+    });
+
     it('keeps alarms above warnings when both are active', () => {
         render(
             <Header

--- a/src/containers/MainView/Header/Header.tsx
+++ b/src/containers/MainView/Header/Header.tsx
@@ -17,6 +17,8 @@ import {getAlarmSnapshot} from '../../Production/utils/productionStatus';
 import {getTemperatureSensorMessage} from '../../../utils/temperatureSensor';
 import {Warning} from '../../../model/Warning';
 import {getWarningHeaderText} from '../../../utils/warningDisplay';
+import {FermentationGatewaySensorStatus} from '../../../model/Fermentation';
+import {getFermentationGatewayWarning} from '../../../utils/fermentationGatewayStatus';
 
 
 
@@ -31,6 +33,8 @@ interface HeaderProps {
     socketConnected?: boolean;
     warnings?: Warning[];
     warningsReceived?: boolean;
+    fermentationGatewayConnected?: boolean;
+    fermentationGatewaySensors?: Record<string, FermentationGatewaySensorStatus>;
 }
 
 interface HeaderState {
@@ -124,12 +128,16 @@ export class Header extends React.Component<HeaderProps, HeaderState> {
            ? getWarningHeaderText(this.props.warnings)
            : undefined;
        const temperatureSensor = this.props.realtimeState?.temperatureSensor;
+       const fermentationGatewayWarning = this.props.fermentationGatewayConnected === undefined ? undefined : getFermentationGatewayWarning(
+           this.props.fermentationGatewayConnected,
+           this.props.fermentationGatewaySensors || {},
+       );
        // Keep the technical sensor state as a compatibility fallback until all
        // controller versions provide warning-state-changed snapshots.
        const sensorWarning = !warningText && (!this.props.socketConnected || temperatureSensor?.health !== 'OK')
            ? `⚠ Temperatursensor: ${getTemperatureSensorMessage(temperatureSensor)}`
            : undefined;
-       const priorityMessage = alarmText ?? warningText ?? sensorWarning;
+       const priorityMessage = alarmText ?? warningText ?? fermentationGatewayWarning ?? sensorWarning;
        const prioritySeverity = alarmText ? 'alarm' : priorityMessage ? 'warning' : undefined;
        const uiMode = getUiMode();
        const navigationViews = getNavigationViews(uiMode);

--- a/src/containers/index.connect.ts
+++ b/src/containers/index.connect.ts
@@ -2,6 +2,7 @@ import {connect} from "react-redux";
 import {Views} from '../enums/eViews';
 import {ProductionActions} from "../actions/actions";
 import {Index} from './index';
+import {FermentationActions} from '../actions/fermentation.actions';
 
 const mapStateToProps = (state: any) => ({
     viewState: state.applicationReducer.view as Views,
@@ -20,7 +21,9 @@ const mapDispatchToProps = (dispatch: any) => ({
     },
     webSocketDisconnect: () => {
         dispatch(ProductionActions.webSocketDisconnect());
-    }
+    },
+    fermentationGatewayConnect: () => dispatch(FermentationActions.gatewayConnect()),
+    fermentationGatewayDisconnect: () => dispatch(FermentationActions.gatewayDisconnect()),
 
 
 

--- a/src/containers/index.tsx
+++ b/src/containers/index.tsx
@@ -22,19 +22,23 @@ interface indexMainProps {
     checkIsBackenAvailable : () => void;
     webSocketConnect: () => void;
     webSocketDisconnect: () => void;
+    fermentationGatewayConnect: () => void;
+    fermentationGatewayDisconnect: () => void;
     socketConnected: boolean;
     socketId?: string;
 }
 
 export class Index extends React.Component<indexMainProps> {
     componentDidMount() {
-        const {checkIsBackenAvailable, webSocketConnect} = this.props;
+        const {checkIsBackenAvailable, webSocketConnect, fermentationGatewayConnect} = this.props;
         checkIsBackenAvailable();
         webSocketConnect();
+        fermentationGatewayConnect();
     }
 
     componentWillUnmount() {
         this.props.webSocketDisconnect();
+        this.props.fermentationGatewayDisconnect();
     }
 
     componentDidUpdate(prevProps: Readonly<indexMainProps>, prevState: Readonly<{}>, snapshot?: any) {

--- a/src/epics/fermentationEpics.ts
+++ b/src/epics/fermentationEpics.ts
@@ -1,8 +1,14 @@
 import {ofType} from 'redux-observable';
-import {from, of} from 'rxjs';
+import {EMPTY, from, Observable, of} from 'rxjs';
 import {catchError, exhaustMap, groupBy, map, mergeMap, switchMap} from 'rxjs/operators';
 import {FermentationActions, FermentationActionTypes} from '../actions/fermentation.actions';
 import {FermentationRepository} from '../repositorys/FermentationRepository';
+import {FermentationGatewayWebSocketController, FermentationGatewayMessage} from '../utils/FermentationGatewayWebSocketController';
+import {RootState} from '../reducers/rootReducer';
+import {Views} from '../enums/eViews';
+import {getFinishedBeerIdFromPath} from '../utils/viewRoutes';
+
+let gatewayController: FermentationGatewayWebSocketController | null = null;
 
 export const loadFermentationEpic = (action$: any) => action$.pipe(
   ofType(FermentationActionTypes.LOAD),
@@ -60,4 +66,45 @@ export const assignDeviceEpic = (action$: any) => action$.pipe(
   )))
 );
 
-export const fermentationEpics = [loadFermentationEpic, createMeasurementEpic, completeFermentationActionEpic, skipFermentationActionEpic, assignDeviceEpic];
+const gatewayMessageAction = (message: FermentationGatewayMessage) => message.type === 'FERMENTATION_GATEWAY_SNAPSHOT'
+  ? FermentationActions.gatewaySnapshotReceived(message.sensors)
+  : FermentationActions.gatewaySensorStatusChanged(message.sensor);
+
+export const fermentationGatewayWebSocketEpic = (action$: any) => action$.pipe(
+  ofType(FermentationActionTypes.GATEWAY_CONNECT, FermentationActionTypes.GATEWAY_DISCONNECT),
+  switchMap((action: any) => {
+    if (action.type === FermentationActionTypes.GATEWAY_DISCONNECT) {
+      gatewayController?.disconnect();
+      gatewayController = null;
+      return EMPTY;
+    }
+    return new Observable<any>(observer => {
+      gatewayController ??= new FermentationGatewayWebSocketController(
+        message => observer.next(gatewayMessageAction(message)),
+        connected => observer.next(FermentationActions.gatewayConnectionChanged(connected)),
+      );
+      gatewayController.connect();
+      return () => {
+        gatewayController?.disconnect();
+        gatewayController = null;
+      };
+    });
+  }),
+);
+
+/** Refresh only the already visible fermentation aggregate; the gateway never becomes its data source. */
+export const refreshFermentationAfterGatewayStatusEpic = (action$: any, state$: {value: RootState}) => action$.pipe(
+  ofType(FermentationActionTypes.GATEWAY_SENSOR_STATUS_CHANGED),
+  mergeMap((action: any) => {
+    if (!['REGISTERED', 'ASSIGNED', 'UNASSIGNED', 'DISCONNECTED'].includes(action.payload.sensor.status)) return EMPTY;
+    const state = state$.value;
+    const loadedIds = Object.keys(state.fermentationReducer.byBrewId);
+    const pathId = state.applicationReducer.view === Views.MEASUREMENT_DATA && typeof window !== 'undefined'
+      ? getFinishedBeerIdFromPath(window.location.pathname)
+      : undefined;
+    const brewId = pathId && loadedIds.includes(pathId) ? pathId : loadedIds.length === 1 ? loadedIds[0] : undefined;
+    return brewId ? of(FermentationActions.load(brewId)) : EMPTY;
+  }),
+);
+
+export const fermentationEpics = [loadFermentationEpic, createMeasurementEpic, completeFermentationActionEpic, skipFermentationActionEpic, assignDeviceEpic, fermentationGatewayWebSocketEpic, refreshFermentationAfterGatewayStatusEpic];

--- a/src/model/Fermentation.ts
+++ b/src/model/Fermentation.ts
@@ -85,6 +85,17 @@ export interface FermentationDevice {
   assignedFinishedBeerId?: string | null;
 }
 
+export type FermentationGatewaySensorState = 'REGISTERED' | 'ASSIGNED' | 'UNASSIGNED' | 'DISCONNECTED' | 'BACKEND_UNAVAILABLE' | 'BACKEND_ERROR';
+
+/** Runtime integration state from FermentationSensorGateway; BeerDataStore remains authoritative for assignments and measurements. */
+export interface FermentationGatewaySensorStatus {
+  deviceUid: string;
+  deviceName?: string;
+  status: FermentationGatewaySensorState;
+  updatedAt: string;
+  beerId?: string;
+}
+
 export interface SensorMeasurement {
   id: string;
   deviceId: string;

--- a/src/reducers/fermentationReducer.test.ts
+++ b/src/reducers/fermentationReducer.test.ts
@@ -2,6 +2,16 @@ import {FermentationActions} from '../actions/fermentation.actions';
 import {fermentationReducer, initialFermentationState} from './fermentationReducer';
 
 describe('fermentationReducer', () => {
+  it('replaces a gateway snapshot and updates exactly one sensor status', () => {
+    const first = {deviceUid: 'one', deviceName: 'FERM-1', status: 'UNASSIGNED' as const, updatedAt: '2026-09-11T07:23:11Z'};
+    const second = {deviceUid: 'two', deviceName: 'FERM-2', status: 'REGISTERED' as const, updatedAt: '2026-09-11T07:23:11Z'};
+    const snapshot = fermentationReducer(initialFermentationState, FermentationActions.gatewaySnapshotReceived([first, second]));
+    expect(snapshot.sensorsByDeviceUid).toEqual({one: first, two: second});
+    const assigned = {...first, status: 'ASSIGNED' as const};
+    const changed = fermentationReducer(snapshot, FermentationActions.gatewaySensorStatusChanged(assigned));
+    expect(changed.sensorsByDeviceUid).toEqual({one: assigned, two: second});
+    expect(changed.sensorsByDeviceUid.two).toBe(snapshot.sensorsByDeviceUid.two);
+  });
   it('does not optimistically add measurements', () => {
     const state = fermentationReducer(initialFermentationState, FermentationActions.createMeasurement({finishedBeerId: 'b', measuredAt: '', plato: 4}));
     expect(state.savingMeasurementIds).toEqual(['b']); expect(state.byBrewId.b).toBeUndefined();

--- a/src/reducers/fermentationReducer.ts
+++ b/src/reducers/fermentationReducer.ts
@@ -1,8 +1,8 @@
 import {FermentationActionTypes} from '../actions/fermentation.actions';
-import {FermentationDetails} from '../model/Fermentation';
+import {FermentationDetails, FermentationGatewaySensorStatus} from '../model/Fermentation';
 
-export interface FermentationState { byBrewId: Record<string, FermentationDetails>; loadingIds: string[]; savingMeasurementIds: string[]; completingActionIds: string[]; skippingActionIds: string[]; assigningDeviceIds: string[]; errors: Record<string, string>; }
-export const initialFermentationState: FermentationState = {byBrewId: {}, loadingIds: [], savingMeasurementIds: [], completingActionIds: [], skippingActionIds: [], assigningDeviceIds: [], errors: {}};
+export interface FermentationState { byBrewId: Record<string, FermentationDetails>; loadingIds: string[]; savingMeasurementIds: string[]; completingActionIds: string[]; skippingActionIds: string[]; assigningDeviceIds: string[]; errors: Record<string, string>; gatewayConnected: boolean; sensorsByDeviceUid: Record<string, FermentationGatewaySensorStatus>; }
+export const initialFermentationState: FermentationState = {byBrewId: {}, loadingIds: [], savingMeasurementIds: [], completingActionIds: [], skippingActionIds: [], assigningDeviceIds: [], errors: {}, gatewayConnected: false, sensorsByDeviceUid: {}};
 const add = (xs: string[], id: string) => xs.includes(id) ? xs : [...xs, id];
 const remove = (xs: string[], id: string) => xs.filter(value => value !== id);
 export const fermentationReducer = (state = initialFermentationState, action: any): FermentationState => {
@@ -23,6 +23,9 @@ export const fermentationReducer = (state = initialFermentationState, action: an
     case FermentationActionTypes.ASSIGN_DEVICE: return {...state, assigningDeviceIds: add(state.assigningDeviceIds, p.deviceId)};
     case FermentationActionTypes.ASSIGN_DEVICE_SUCCESS: return {...state, assigningDeviceIds: remove(state.assigningDeviceIds, p.deviceId)};
     case FermentationActionTypes.ASSIGN_DEVICE_FAILURE: return {...state, assigningDeviceIds: remove(state.assigningDeviceIds, p.deviceId), errors: {...state.errors, [p.brewId]: p.error}};
+    case FermentationActionTypes.GATEWAY_CONNECTION_CHANGED: return {...state, gatewayConnected: p.connected};
+    case FermentationActionTypes.GATEWAY_SNAPSHOT_RECEIVED: return {...state, sensorsByDeviceUid: Object.fromEntries((p.sensors || []).map((sensor: FermentationGatewaySensorStatus) => [sensor.deviceUid, sensor]))};
+    case FermentationActionTypes.GATEWAY_SENSOR_STATUS_CHANGED: return p.sensor?.deviceUid ? {...state, sensorsByDeviceUid: {...state.sensorsByDeviceUid, [p.sensor.deviceUid]: p.sensor}} : state;
     default: return state;
   }
 };

--- a/src/setupProxy.js
+++ b/src/setupProxy.js
@@ -4,6 +4,21 @@ const target = "https://braumeister.boris-mahne.de";
 
 module.exports = function setupProxy(app) {
     app.use(
+        createProxyMiddleware("/api/fermentation/ui", {
+            target: "http://localhost:5001",
+            changeOrigin: true,
+            ws: true,
+            pathRewrite: {"^/api/fermentation/ui": "/fermentation/ui"},
+            onError(aError, aRequest) {
+                console.error(
+                    `Development fermentation gateway proxy failed for ${aRequest.method} ${aRequest.url}:`,
+                    aError.message
+                );
+            },
+        })
+    );
+
+    app.use(
         "/api",
         createProxyMiddleware({
             target,

--- a/src/setupProxy.test.js
+++ b/src/setupProxy.test.js
@@ -8,20 +8,35 @@ jest.mock('http-proxy-middleware', () => ({
 const setupProxy = require('./setupProxy');
 
 describe('development API proxy', () => {
+    beforeEach(() => jest.clearAllMocks());
     it('forwards the complete /api namespace without rewriting paths or filtering methods', () => {
         const app = { use: jest.fn() };
 
         setupProxy(app);
 
         expect(app.use).toHaveBeenCalledWith('/api', mockProxyMiddleware);
-        expect(mockCreateProxyMiddleware).toHaveBeenCalledWith(expect.objectContaining({
-            target: 'https://192.168.178.72',
+        expect(mockCreateProxyMiddleware).toHaveBeenNthCalledWith(2, expect.objectContaining({
+            target: 'https://braumeister.boris-mahne.de',
             changeOrigin: true,
             secure: false,
         }));
 
-        const proxyOptions = mockCreateProxyMiddleware.mock.calls[0][0];
+        const proxyOptions = mockCreateProxyMiddleware.mock.calls[1][0];
         expect(proxyOptions).not.toHaveProperty('pathRewrite');
         expect(proxyOptions).not.toHaveProperty('method');
+    });
+
+    it('routes the native fermentation websocket to the local gateway with a rewritten path', () => {
+        const app = { use: jest.fn() };
+
+        setupProxy(app);
+
+        expect(app.use).toHaveBeenNthCalledWith(1, mockProxyMiddleware);
+        expect(mockCreateProxyMiddleware).toHaveBeenNthCalledWith(1, '/api/fermentation/ui', expect.objectContaining({
+            target: 'http://localhost:5001',
+            changeOrigin: true,
+            ws: true,
+            pathRewrite: {'^/api/fermentation/ui': '/fermentation/ui'},
+        }));
     });
 });

--- a/src/utils/FermentationGatewayWebSocketController.test.ts
+++ b/src/utils/FermentationGatewayWebSocketController.test.ts
@@ -1,0 +1,50 @@
+import {buildFermentationGatewayWebSocketUrl, FermentationGatewayWebSocketController, parseFermentationGatewayMessage} from './FermentationGatewayWebSocketController';
+
+class MockWebSocket {
+  static instances: MockWebSocket[] = [];
+  onopen: (() => void) | null = null;
+  onclose: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+  onmessage: ((event: {data: string}) => void) | null = null;
+  close = jest.fn(() => this.onclose?.());
+  constructor(public url: string) { MockWebSocket.instances.push(this); }
+}
+
+describe('FermentationGatewayWebSocketController', () => {
+  beforeEach(() => { jest.useFakeTimers(); MockWebSocket.instances = []; (global as any).WebSocket = MockWebSocket; });
+  afterEach(() => jest.useRealTimers());
+
+  it('builds same-origin ws and wss URLs without a LAN address', () => {
+    expect(buildFermentationGatewayWebSocketUrl({protocol: 'http:', host: 'localhost:3000'} as Location)).toBe('ws://localhost:3000/api/fermentation/ui');
+    expect(buildFermentationGatewayWebSocketUrl({protocol: 'https:', host: 'brauhaus.example'} as Location)).toBe('wss://brauhaus.example/api/fermentation/ui');
+    expect(buildFermentationGatewayWebSocketUrl({protocol: 'https:', host: 'brauhaus.example'} as Location)).not.toMatch(/192\.168\./);
+  });
+
+  it('parses snapshots and status changes and ignores unknown messages', () => {
+    expect(parseFermentationGatewayMessage(JSON.stringify({type: 'FERMENTATION_GATEWAY_SNAPSHOT', sensors: []}))).toEqual({type: 'FERMENTATION_GATEWAY_SNAPSHOT', sensors: []});
+    expect(parseFermentationGatewayMessage(JSON.stringify({type: 'FERMENTATION_SENSOR_STATUS_CHANGED', sensor: {deviceUid: 'a', status: 'ASSIGNED'}}))?.type).toBe('FERMENTATION_SENSOR_STATUS_CHANGED');
+    expect(parseFermentationGatewayMessage('{"type":"UNKNOWN"}')).toBeUndefined();
+    expect(parseFermentationGatewayMessage('invalid')).toBeUndefined();
+  });
+
+  it('reconnects and resets backoff after a successful connection', () => {
+    const states: boolean[] = [];
+    const controller = new FermentationGatewayWebSocketController(jest.fn(), connected => states.push(connected), 'ws://host/api/fermentation/ui');
+    controller.connect();
+    expect(MockWebSocket.instances).toHaveLength(1);
+    MockWebSocket.instances[0].onclose?.();
+    jest.advanceTimersByTime(1999);
+    expect(MockWebSocket.instances).toHaveLength(1);
+    jest.advanceTimersByTime(1);
+    expect(MockWebSocket.instances).toHaveLength(2);
+    MockWebSocket.instances[1].onclose?.();
+    jest.advanceTimersByTime(5000);
+    expect(MockWebSocket.instances).toHaveLength(3);
+    MockWebSocket.instances[2].onopen?.();
+    MockWebSocket.instances[2].onclose?.();
+    jest.advanceTimersByTime(2000);
+    expect(MockWebSocket.instances).toHaveLength(4);
+    expect(states).toContain(true);
+    controller.disconnect();
+  });
+});

--- a/src/utils/FermentationGatewayWebSocketController.ts
+++ b/src/utils/FermentationGatewayWebSocketController.ts
@@ -1,0 +1,83 @@
+import {FermentationGatewaySensorStatus} from '../model/Fermentation';
+
+export type FermentationGatewayMessage =
+  | {type: 'FERMENTATION_GATEWAY_SNAPSHOT'; sensors: FermentationGatewaySensorStatus[]}
+  | {type: 'FERMENTATION_SENSOR_STATUS_CHANGED'; sensor: FermentationGatewaySensorStatus};
+
+export const buildFermentationGatewayWebSocketUrl = (location: Pick<Location, 'protocol' | 'host'> = window.location): string =>
+  `${location.protocol === 'https:' ? 'wss:' : 'ws:'}//${location.host}/api/fermentation/ui`;
+
+export const parseFermentationGatewayMessage = (data: unknown): FermentationGatewayMessage | undefined => {
+  try {
+    const value = typeof data === 'string' ? JSON.parse(data) : data;
+    if (value?.type === 'FERMENTATION_GATEWAY_SNAPSHOT' && Array.isArray(value.sensors)) return value;
+    if (value?.type === 'FERMENTATION_SENSOR_STATUS_CHANGED' && value.sensor?.deviceUid) return value;
+  } catch (_) {
+    // Malformed and unknown gateway messages are deliberately non-fatal.
+  }
+  return undefined;
+};
+
+const reconnectDelays = [2000, 5000, 10000, 20000, 30000];
+
+export class FermentationGatewayWebSocketController {
+  private socket?: WebSocket;
+  private reconnectTimer?: ReturnType<typeof setTimeout>;
+  private reconnectAttempt = 0;
+  private stopped = true;
+
+  constructor(
+    private readonly onMessage: (message: FermentationGatewayMessage) => void,
+    private readonly onConnectionChanged: (connected: boolean) => void,
+    private readonly url = buildFermentationGatewayWebSocketUrl(),
+  ) {}
+
+  connect(): void {
+    this.stopped = false;
+    if (this.socket || this.reconnectTimer) return;
+    this.openSocket();
+  }
+
+  disconnect(): void {
+    this.stopped = true;
+    if (this.reconnectTimer) clearTimeout(this.reconnectTimer);
+    this.reconnectTimer = undefined;
+    const socket = this.socket;
+    this.socket = undefined;
+    socket?.close();
+    this.onConnectionChanged(false);
+  }
+
+  private openSocket(): void {
+    if (this.stopped || this.socket) return;
+    const socket = new WebSocket(this.url);
+    this.socket = socket;
+    socket.onopen = () => {
+      if (this.socket !== socket) return;
+      this.reconnectAttempt = 0;
+      this.onConnectionChanged(true);
+    };
+    socket.onmessage = event => {
+      const message = parseFermentationGatewayMessage(event.data);
+      if (message) this.onMessage(message);
+      else if (process.env.NODE_ENV === 'development') console.debug('Unbekannte Nachricht vom Gärsensor-Gateway ignoriert.');
+    };
+    socket.onerror = () => socket.close();
+    socket.onclose = () => {
+      if (this.socket !== socket) return;
+      this.socket = undefined;
+      this.onConnectionChanged(false);
+      if (!this.stopped) this.scheduleReconnect();
+    };
+  }
+
+  private scheduleReconnect(): void {
+    if (this.reconnectTimer || this.stopped) return;
+    const delay = reconnectDelays[Math.min(this.reconnectAttempt, reconnectDelays.length - 1)];
+    this.reconnectAttempt += 1;
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = undefined;
+      this.openSocket();
+    }, delay);
+  }
+}

--- a/src/utils/fermentationGatewayStatus.test.ts
+++ b/src/utils/fermentationGatewayStatus.test.ts
@@ -1,0 +1,19 @@
+import {getFermentationGatewayWarning} from './fermentationGatewayStatus';
+import {FermentationGatewaySensorStatus} from '../model/Fermentation';
+
+const sensor = (status: FermentationGatewaySensorStatus['status'], deviceName = 'FERM-123'): FermentationGatewaySensorStatus => ({
+  deviceUid: 'device-1', deviceName, status, updatedAt: '2026-09-11T07:25:11Z',
+});
+
+it('shows UNASSIGNED and DISCONNECTED gateway warnings', () => {
+  expect(getFermentationGatewayWarning(true, {'device-1': sensor('UNASSIGNED')})).toBe('Gärsensor FERM-123 ist keinem Bier zugeordnet.');
+  expect(getFermentationGatewayWarning(true, {'device-1': sensor('DISCONNECTED')})).toBe('Gärsensor FERM-123 ist nicht verbunden.');
+});
+
+it('removes the UNASSIGNED warning as soon as the sensor is ASSIGNED', () => {
+  expect(getFermentationGatewayWarning(true, {'device-1': sensor('ASSIGNED')})).toBeUndefined();
+});
+
+it('shows a disconnected gateway without producing repeated messages', () => {
+  expect(getFermentationGatewayWarning(false, {})).toBe('Gärsensor-Gateway nicht erreichbar.');
+});

--- a/src/utils/fermentationGatewayStatus.ts
+++ b/src/utils/fermentationGatewayStatus.ts
@@ -1,0 +1,16 @@
+import {FermentationGatewaySensorStatus} from '../model/Fermentation';
+
+export const getFermentationGatewayWarning = (
+  connected: boolean,
+  sensorsByDeviceUid: Record<string, FermentationGatewaySensorStatus>,
+): string | undefined => {
+  if (!connected) return 'Gärsensor-Gateway nicht erreichbar.';
+  const sensors = Object.values(sensorsByDeviceUid);
+  if (sensors.some(sensor => sensor.status === 'BACKEND_UNAVAILABLE')) return 'Gärsensor-Gateway kann BeerDataStore nicht erreichen.';
+  if (sensors.some(sensor => sensor.status === 'BACKEND_ERROR')) return 'Fehler bei der Verarbeitung von Gärsensordaten.';
+  const disconnected = sensors.find(sensor => sensor.status === 'DISCONNECTED');
+  if (disconnected) return `Gärsensor ${disconnected.deviceName || disconnected.deviceUid} ist nicht verbunden.`;
+  const unassigned = sensors.find(sensor => sensor.status === 'UNASSIGNED');
+  if (unassigned) return `Gärsensor ${unassigned.deviceName || unassigned.deviceUid} ist keinem Bier zugeordnet.`;
+  return undefined;
+};


### PR DESCRIPTION
### Motivation

- Provide a second, independent realtime channel for fermentation status because the existing controller Socket.IO connection can be offline during fermentation. 
- Use the native browser `WebSocket` API for the FermentationSensorGateway (RFC WebSocket), and keep the existing `socket.io-client` controller socket unchanged. 
- Surface non-intrusive persistent warnings in the existing header area and integrate per-device gateway status into the existing fermentation Redux domain while keeping BeerDataStore as the REST source of truth. 
- Enable working WebSocket behavior in CRA development by proxying `/api/fermentation/ui` to a local gateway on port `5001` with websocket upgrade support.

### Description

- Added a native WebSocket controller `FermentationGatewayWebSocketController` with URL builder `buildFermentationGatewayWebSocketUrl`, JSON parsing `parseFermentationGatewayMessage`, bounded reconnect backoff (2s, 5s, 10s, 20s, 30s) and clean shutdown semantics. (`src/utils/FermentationGatewayWebSocketController.ts`) 
- Introduced gateway message types and mapped them into new fermentation actions: `GATEWAY_CONNECT`, `GATEWAY_DISCONNECT`, `GATEWAY_CONNECTION_CHANGED`, `GATEWAY_SNAPSHOT_RECEIVED`, and `GATEWAY_SENSOR_STATUS_CHANGED`. (`src/actions/fermentation.actions.ts`) 
- Extended fermentation reducer state with `gatewayConnected: boolean` and `sensorsByDeviceUid: Record<string, FermentationGatewaySensorStatus>` and implemented snapshot replace + single-sensor updates. (`src/reducers/fermentationReducer.ts`) 
- Integrated lifecycle into epics: `fermentationGatewayWebSocketEpic` manages the controller lifecycle independent of the existing controller socket, and `refreshFermentationAfterGatewayStatusEpic` triggers at most one targeted reload of a visible fermentation aggregate for meaningful status changes. (`src/epics/fermentationEpics.ts`) 
- Wire header/status: compute a compact, persistent fermentation gateway warning (gateway disconnect, `UNASSIGNED`, `DISCONNECTED`, `BACKEND_UNAVAILABLE`, `BACKEND_ERROR`) and integrate it into the existing header priority message flow without toasts/modals. (`src/utils/fermentationGatewayStatus.ts`, `src/containers/MainView/Header/Header.tsx`, `src/containers/MainView/Header/Header.connect.ts`) 
- Start/stop gateway connection from app shell: dispatch `FermentationActions.gatewayConnect()` on app start and `...gatewayDisconnect()` on unmount; keep this independent from production controller socket startup. (`src/containers/index.tsx`, `src/containers/index.connect.ts`) 
- Development proxy: added a CRA dev-proxy mapping for the native gateway route with `ws: true` and a path rewrite to `/fermentation/ui` on the local gateway (`http://localhost:5001`) while leaving existing `/api` and `/socket.io` proxies unchanged. (`src/setupProxy.js`, tests updated: `src/setupProxy.test.js`) 
- Documented the feature and cross-repo contract in Codex docs: `docs/codex/system-overview.md`, `docs/codex/interfaces.md`, `docs/codex/data-flow.md`, and `docs/codex/compatibility/cross-repo-contracts.md`. 
- Added unit tests that exercise URL-building, message parsing, reconnect/backoff, gateway-status-to-warning translation, and reducer snapshot/patch behavior: `src/utils/FermentationGatewayWebSocketController.test.ts`, `src/utils/fermentationGatewayStatus.test.ts`, `src/reducers/fermentationReducer.test.ts` (extended). 

### Testing

- Ran `node --check src/setupProxy.js` and `node --check src/setupProxy.test.js` to validate the added proxy code and proxy test harness; both checks passed. 
- Ran `git diff --check` and project diffs to ensure no stray whitespace/check errors; passed. 
- Performed TypeScript checks with `tsc --noEmit --ignoreDeprecations 6.0` as a lightweight validation; the command executed but a full project compile requires node_modules and project dependencies. 
- Attempted dependency install and unit test runs: `npm ci` failed due to existing peer-dependency conflicts in this repository (Material UI v4 vs React 18 dev deps), and `npm ci --legacy-peer-deps` could not complete in the available environment; for the same reason the CRA/Jest runner (`react-scripts test`) was not available and the new Jest tests could not be executed in this environment. 
- Added unit tests (listed above) that exercise key behaviors (URL scheme `ws://` vs `wss://`, no hard-coded LAN IPs, snapshot replace, single-sensor update, unknown messages ignored, header warning mapping, reconnect/backoff and reset on open), but automated execution of those tests was blocked by dependency-install issues in the environment. 

Notes and manual verification items: Caddy routing and production WebSocket upgrade for `/api/fermentation/ui` must be validated on deployment; exercise reconnect behavior with a running gateway on `localhost:5001` during CRA development; visually verify header behavior with simultaneous controller and gateway warnings.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6aa3b081eee8832fb7c7ea86a3bb7298)