### PR TITLE
Fix TypeScript compilation in container tests

### DIFF
--- a/src/containers/DatabaseOverview/RecipeImportDialog.test.tsx
+++ b/src/containers/DatabaseOverview/RecipeImportDialog.test.tsx
@@ -80,7 +80,7 @@ describe('RecipeImportDialog', () => {
     it('retains the key for another send of the same request and creates a new key for a new file', async () => {
         (createImportIdempotencyKey as jest.Mock).mockReturnValueOnce('key-a').mockReturnValueOnce('key-b');
         const onImport = jest.fn();
-        render(<RecipeImportDialog open backendError="Netzwerkfehler" onCancel={jest.fn()} onImport={onImport} />);
+        const {rerender} = render(<RecipeImportDialog open backendError="Netzwerkfehler" onCancel={jest.fn()} onImport={onImport} />);
         selectFormat('Brauhaus');
         selectFile(jsonFile('{"name":"first"}'));
         await waitFor(() => expect(screen.getByRole('button', {name: 'Importieren'})).toBeEnabled());

--- a/src/containers/index.test.tsx
+++ b/src/containers/index.test.tsx
@@ -33,6 +33,8 @@ const renderIndex = (brewingStatus: BrewingStatus, viewState = Views.VERSION, li
             checkIsBackenAvailable={jest.fn()}
             webSocketConnect={lifecycle.connect}
             webSocketDisconnect={lifecycle.disconnect}
+            fermentationGatewayConnect={jest.fn()}
+            fermentationGatewayDisconnect={jest.fn()}
             socketConnected={false}
         />
     );


### PR DESCRIPTION
### Motivation

- Resolve TypeScript/Jest test compilation errors caused by an unused `rerender` reference and missing required `Index` props so tests compile under `tsc`/Jest.

### Description

- Capture React Testing Library's `rerender` helper in `src/containers/DatabaseOverview/RecipeImportDialog.test.tsx` so the retry flow uses the rendered helper instead of an undefined `rerender` reference. 
- Provide the required `fermentationGatewayConnect` and `fermentationGatewayDisconnect` callbacks when rendering `Index` in `src/containers/index.test.tsx` so the component receives all required `indexMainProps`.

### Testing

- Ran `git diff --check` and committed the change successfully (`Fix TypeScript test compilation errors`).
- Attempted to run the relevant Jest tests with `CI=true npm test -- --runInBand --watchAll=false src/containers/DatabaseOverview/RecipeImportDialog.test.tsx src/containers/index.test.tsx`, but running the test runner failed because `react-scripts` was not available in `node_modules` / the environment blocked installing it (npm 403 on registry), so the tests could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6aa3b8b8d4b4832f9e1fb06dd2c93b9a)