### PR TITLE
Gäraktivität als Linienverlauf darstellen

### DIFF
--- a/src/containers/MainView/FinishBrewsBeers/BubbleActivityChart.test.tsx
+++ b/src/containers/MainView/FinishBrewsBeers/BubbleActivityChart.test.tsx
@@ -1,6 +1,15 @@
 import {render, screen} from '@testing-library/react';
 import {BubbleActivityChart, buildBubbleActivityChartData} from './BubbleActivityChart';
 
+jest.mock('recharts', () => {
+  const React = require('react');
+  const Container = ({children}: {children?: React.ReactNode}) => <div>{children}</div>;
+  return {
+    ResponsiveContainer: Container, LineChart: Container, CartesianGrid: () => null, XAxis: () => null, YAxis: () => null, Tooltip: () => null,
+    Line: (props: Record<string, unknown>) => <div data-testid="bubble-activity-line" data-type={String(props.type)} data-dot={JSON.stringify(props.dot)} data-connect-nulls={String(props.connectNulls)} data-animation={String(props.isAnimationActive)} />,
+  };
+});
+
 const activity: any[] = [
   {deviceId: 'new', sequence: 3, bubbleCount: 7, windowSeconds: 60, windowEndedAt: '2026-09-11T10:04:00Z'},
   {deviceId: 'old', sequence: 1, bubbleCount: 8, windowSeconds: 60, windowEndedAt: '2026-09-11T10:00:00Z'},
@@ -11,16 +20,20 @@ const activity: any[] = [
 describe('bubble activity chart', () => {
   it('normalizes windows, preserves zero and chronological gaps, and combines devices', () => {
     const data = buildBubbleActivityChartData(activity);
-    expect(data.map(point => [point.timestamp, point.bubblesPerMinute])).toEqual([
+    expect(data.filter(point => point.bubblesPerMinute !== null).map(point => [point.timestamp, point.bubblesPerMinute])).toEqual([
       [Date.parse('2026-09-11T10:00:00Z'), 8], [Date.parse('2026-09-11T10:01:00Z'), 0], [Date.parse('2026-09-11T10:04:00Z'), 7],
     ]);
     expect(data.some(point => point.timestamp === Date.parse('2026-09-11T10:02:00Z'))).toBe(false);
+    expect(data.filter(point => point.bubblesPerMinute === null)).toHaveLength(1);
     expect(data[0]).not.toHaveProperty('sequence'); expect(data[0]).not.toHaveProperty('deviceId');
   });
   it('normalizes a 30 second window and exposes only a technical label', () => {
     expect(buildBubbleActivityChartData([{...activity[0], bubbleCount: 4, windowSeconds: 30}])[0].bubblesPerMinute).toBe(8);
     render(<BubbleActivityChart activity={activity} />);
     expect(screen.getByRole('img', {name: /Gäraktivität in Blubbs pro Minute/})).toBeInTheDocument();
+    expect(screen.getByTestId('bubble-activity-line')).toHaveAttribute('data-type', 'linear');
+    expect(screen.getByTestId('bubble-activity-line')).toHaveAttribute('data-connect-nulls', 'false');
+    expect(screen.getByTestId('bubble-activity-line')).toHaveAttribute('data-animation', 'false');
     expect(screen.queryByText(/starke|schwache|beendet|verlangsamt|Device|sequence/i)).not.toBeInTheDocument();
   });
 });

--- a/src/containers/MainView/FinishBrewsBeers/BubbleActivityChart.tsx
+++ b/src/containers/MainView/FinishBrewsBeers/BubbleActivityChart.tsx
@@ -1,20 +1,22 @@
 import React from 'react';
-import {Bar, BarChart, CartesianGrid, ResponsiveContainer, Tooltip, XAxis, YAxis} from 'recharts';
+import {CartesianGrid, Line, LineChart, ResponsiveContainer, Tooltip, XAxis, YAxis} from 'recharts';
 import {BubbleActivity} from '../../../model/Fermentation';
 import {COLOR_CHART_BLUE} from '../../../colors';
 
 export interface BubbleActivityChartPoint {
   timestamp: number;
-  bubblesPerMinute: number;
-  bubbleCount: number;
-  windowSeconds: number;
+  bubblesPerMinute: number | null;
+  bubbleCount?: number;
+  windowSeconds?: number;
 }
+
+type BubbleActivityMeasurementPoint = Required<BubbleActivityChartPoint>;
 
 const localDateTime = (value: number): string => new Intl.DateTimeFormat('de-DE', {
   dateStyle: 'short', timeStyle: 'short',
 }).format(new Date(value));
 
-export const buildBubbleActivityChartData = (activity: BubbleActivity[]): BubbleActivityChartPoint[] => activity
+const normalizedBubbleActivity = (activity: BubbleActivity[]): BubbleActivityMeasurementPoint[] => activity
   .filter(value => Number.isFinite(Date.parse(value.windowEndedAt)) && Number.isFinite(value.bubbleCount) && Number.isFinite(value.windowSeconds) && value.windowSeconds > 0)
   .map(value => ({
     timestamp: Date.parse(value.windowEndedAt),
@@ -24,20 +26,28 @@ export const buildBubbleActivityChartData = (activity: BubbleActivity[]): Bubble
   }))
   .sort((left, right) => left.timestamp - right.timestamp);
 
+export const buildBubbleActivityChartData = (activity: BubbleActivity[]): BubbleActivityChartPoint[] => normalizedBubbleActivity(activity)
+  .flatMap((point, index, points) => {
+    const previous = points[index - 1];
+    if (!previous || point.timestamp - previous.timestamp <= Math.max(previous.windowSeconds, point.windowSeconds) * 1000) return [point];
+
+    return [{timestamp: previous.timestamp + (point.timestamp - previous.timestamp) / 2, bubblesPerMinute: null}, point];
+  });
+
 export class BubbleActivityChart extends React.PureComponent<{activity: BubbleActivity[]}> {
   render() {
     const data = buildBubbleActivityChartData(this.props.activity);
     return <div className="fermentation-bubble-chart" role="img" aria-label="Zeitlicher Verlauf der Gäraktivität in Blubbs pro Minute">
-      <ResponsiveContainer width="100%" height="100%"><BarChart data={data} margin={{top: 8, right: 12, bottom: 8, left: 4}}>
+      <ResponsiveContainer width="100%" height="100%"><LineChart data={data} margin={{top: 8, right: 12, bottom: 8, left: 4}}>
         <CartesianGrid strokeDasharray="3 3" opacity={0.25} />
         <XAxis dataKey="timestamp" type="number" scale="time" domain={['dataMin', 'dataMax']} minTickGap={30} tickFormatter={localDateTime} />
         <YAxis width={72} label={{value: 'Blubbs/min', angle: -90, position: 'insideLeft'}} allowDecimals />
         <Tooltip labelFormatter={value => localDateTime(Number(value))} formatter={(value, _name, item) => [
-          `${Number(value).toLocaleString('de-DE', {maximumFractionDigits: 2})} Blubbs/min · ${item.payload.bubbleCount.toLocaleString('de-DE')} Blubbs in ${item.payload.windowSeconds.toLocaleString('de-DE')} s`,
+          `${Number(value).toLocaleString('de-DE', {maximumFractionDigits: 2})} Blubbs/min${item.payload.bubbleCount !== undefined && item.payload.windowSeconds !== undefined ? ` · ${item.payload.bubbleCount.toLocaleString('de-DE')} Blubbs in ${item.payload.windowSeconds.toLocaleString('de-DE')} s` : ''}`,
           'Gäraktivität',
         ]} />
-        <Bar dataKey="bubblesPerMinute" name="Gäraktivität" fill={COLOR_CHART_BLUE} isAnimationActive={false} />
-      </BarChart></ResponsiveContainer>
+        <Line dataKey="bubblesPerMinute" name="Gäraktivität" type="linear" stroke={COLOR_CHART_BLUE} strokeWidth={2} dot={data.length <= 48 ? {r: 2} : false} activeDot={{r: 4}} connectNulls={false} isAnimationActive={false} />
+      </LineChart></ResponsiveContainer>
     </div>;
   }
 }


### PR DESCRIPTION
### Motivation
- Die Gäraktivität ist ein zeitlicher Verlauf und soll als Linie statt als Balken visualisiert werden, um die Entwicklung von Blubbs/min besser darzustellen.
- Dabei dürfen Normalisierung, Tooltip-Inhalt, lokale Zeitachse und die bestehenden Auswahlzeiträume unverändert bleiben und es dürfen keine Datenlücken künstlich aufgefüllt oder geglättet werden.

### Description
- Ersetzt `BarChart`/`Bar` durch `LineChart`/`Line` in `BubbleActivityChart.tsx` und passt Importe an (`Line`, `LineChart`, `CartesianGrid`, `ResponsiveContainer`, `Tooltip`, `XAxis`, `YAxis`).
- Beibehaltung der Normalisierung `bubbleCount * 60 / windowSeconds` und Erhalt echter `bubbleCount = 0`-Werte; die Datenaufbereitung (`buildBubbleActivityChartData`) wurde ergänzt, um bei erkennbaren zeitlichen Lücken einen `null`-Punkt einzufügen statt fehlende Messungen als `0` zu ergänzen.
- Line-spezifische Darstellungseinstellungen: `connectNulls={false}`, Animation deaktiviert (`isAnimationActive={false}`), dezente Punktmarker nur bei kleinen Datensätzen (`dot={...}`), und Tooltip-Text so angepasst, dass Zeitpunkt und Blubbs/min weiterhin angezeigt werden und optional die Rohwerte `bubbleCount` und `windowSeconds` gezeigt werden.
- Komponententests aktualisiert: Tests mocken `recharts` zur Überprüfung der Line-Konfiguration, prüfen Normalisierung, echte Nullwerte und dass Lücken als `null`-Unterbrechungen behandelt werden (keine künstliche 0-Einträge) und dass die Linie statt Balken gerendert wird.

### Testing
- `git diff --check` wurde ausgeführt und zeigte keine Überprüfungsfehler.
- `npx tsc --noEmit` wurde ausgeführt, zeigte projektweite TypeScript-/tsconfig-Deprecation-Meldungen (TypeScript-6/tsconfig-Optionen) und konnte daher keine saubere Validierung liefern.
- `npm test -- --watchAll=false src/containers/MainView/FinishBrewsBeers/BubbleActivityChart.test.tsx` wurde versucht, konnte aber lokal nicht ausgeführt werden, da Projektabhängigkeiten nicht installiert werden konnten (`npm ci` scheiterte wegen Registry-Zugriffsfehlern), daher konnten die Tests nicht tatsächlich durch CI hier ausgeführt werden.
- `npx eslint ...` wurde aufgrund der lokalen Umgebung und abweichender globaler ESLint-Konfiguration nicht voll ausgeführt; die neuen/geänderten Dateien sind jedoch so formatiert, dass sie die Komponentenregeln befolgen.

Hinweis: Die Änderung beschränkt sich auf die UI-Komponente für die Gäraktivität und die zugehörigen Tests; es wurden keine Backend-, Redux- oder Datenmodell-Änderungen vorgenommen.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6aa3f243fa8c832f852f8347400d85c4)