### PR TITLE
Use LineChart for bubble activity and update tests to mock recharts

### DIFF
--- a/src/containers/MainView/FinishBrewsBeers/BubbleActivityChart.test.tsx
+++ b/src/containers/MainView/FinishBrewsBeers/BubbleActivityChart.test.tsx
@@ -1,6 +1,15 @@
 import {render, screen} from '@testing-library/react';
 import {BubbleActivityChart, buildBubbleActivityChartData} from './BubbleActivityChart';
 
+jest.mock('recharts', () => {
+  const React = require('react');
+  const Container = ({children}: {children?: React.ReactNode}) => <div>{children}</div>;
+  return {
+    ResponsiveContainer: Container, LineChart: Container, CartesianGrid: () => null, XAxis: () => null, YAxis: () => null, Tooltip: () => null,
+    Line: (props: Record<string, unknown>) => <div data-testid="bubble-activity-line" data-type={String(props.type)} data-dot={JSON.stringify(props.dot)} data-connect-nulls={String(props.connectNulls)} data-animation={String(props.isAnimationActive)} />,
+  };
+});
+
 const activity: any[] = [
   {deviceId: 'new', sequence: 3, bubbleCount: 7, windowSeconds: 60, windowEndedAt: '2026-09-11T10:04:00Z'},
   {deviceId: 'old', sequence: 1, bubbleCount: 8, windowSeconds: 60, windowEndedAt: '2026-09-11T10:00:00Z'},
@@ -15,12 +24,18 @@ describe('bubble activity chart', () => {
       [Date.parse('2026-09-11T10:00:00Z'), 8], [Date.parse('2026-09-11T10:01:00Z'), 0], [Date.parse('2026-09-11T10:04:00Z'), 7],
     ]);
     expect(data.some(point => point.timestamp === Date.parse('2026-09-11T10:02:00Z'))).toBe(false);
+    expect(data).toHaveLength(3);
+    expect(data.every(point => point.bubbleCount !== undefined && point.windowSeconds !== undefined)).toBe(true);
     expect(data[0]).not.toHaveProperty('sequence'); expect(data[0]).not.toHaveProperty('deviceId');
   });
   it('normalizes a 30 second window and exposes only a technical label', () => {
     expect(buildBubbleActivityChartData([{...activity[0], bubbleCount: 4, windowSeconds: 30}])[0].bubblesPerMinute).toBe(8);
     render(<BubbleActivityChart activity={activity} />);
     expect(screen.getByRole('img', {name: /Gäraktivität in Blubbs pro Minute/})).toBeInTheDocument();
+    expect(screen.getByTestId('bubble-activity-line')).toHaveAttribute('data-type', 'linear');
+    expect(screen.getByTestId('bubble-activity-line')).toHaveAttribute('data-dot', 'false');
+    expect(screen.getByTestId('bubble-activity-line')).toHaveAttribute('data-connect-nulls', 'true');
+    expect(screen.getByTestId('bubble-activity-line')).toHaveAttribute('data-animation', 'false');
     expect(screen.queryByText(/starke|schwache|beendet|verlangsamt|Device|sequence/i)).not.toBeInTheDocument();
   });
 });

--- a/src/containers/MainView/FinishBrewsBeers/BubbleActivityChart.tsx
+++ b/src/containers/MainView/FinishBrewsBeers/BubbleActivityChart.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {Bar, BarChart, CartesianGrid, ResponsiveContainer, Tooltip, XAxis, YAxis} from 'recharts';
+import {CartesianGrid, Line, LineChart, ResponsiveContainer, Tooltip, XAxis, YAxis} from 'recharts';
 import {BubbleActivity} from '../../../model/Fermentation';
 import {COLOR_CHART_BLUE} from '../../../colors';
 
@@ -28,7 +28,7 @@ export class BubbleActivityChart extends React.PureComponent<{activity: BubbleAc
   render() {
     const data = buildBubbleActivityChartData(this.props.activity);
     return <div className="fermentation-bubble-chart" role="img" aria-label="Zeitlicher Verlauf der Gäraktivität in Blubbs pro Minute">
-      <ResponsiveContainer width="100%" height="100%"><BarChart data={data} margin={{top: 8, right: 12, bottom: 8, left: 4}}>
+      <ResponsiveContainer width="100%" height="100%"><LineChart data={data} margin={{top: 8, right: 12, bottom: 8, left: 4}}>
         <CartesianGrid strokeDasharray="3 3" opacity={0.25} />
         <XAxis dataKey="timestamp" type="number" scale="time" domain={['dataMin', 'dataMax']} minTickGap={30} tickFormatter={localDateTime} />
         <YAxis width={72} label={{value: 'Blubbs/min', angle: -90, position: 'insideLeft'}} allowDecimals />
@@ -36,8 +36,8 @@ export class BubbleActivityChart extends React.PureComponent<{activity: BubbleAc
           `${Number(value).toLocaleString('de-DE', {maximumFractionDigits: 2})} Blubbs/min · ${item.payload.bubbleCount.toLocaleString('de-DE')} Blubbs in ${item.payload.windowSeconds.toLocaleString('de-DE')} s`,
           'Gäraktivität',
         ]} />
-        <Bar dataKey="bubblesPerMinute" name="Gäraktivität" fill={COLOR_CHART_BLUE} isAnimationActive={false} />
-      </BarChart></ResponsiveContainer>
+        <Line dataKey="bubblesPerMinute" name="Gäraktivität" type="linear" stroke={COLOR_CHART_BLUE} strokeWidth={2} dot={false} activeDot={{r: 4}} connectNulls isAnimationActive={false} />
+      </LineChart></ResponsiveContainer>
     </div>;
   }
 }


### PR DESCRIPTION
### Motivation

- Replace the bar visualization with a time-series line to better represent bubbles-per-minute as a continuous metric.
- Ensure the chart data is filtered and normalized so only valid numeric windows are plotted and technical details remain available for tooltips.
- Make tests robust by mocking `recharts` primitives so the chart's configuration can be asserted without rendering the full library.

### Description

- Swapped `BarChart`/`Bar` for `LineChart`/`Line` and updated imports accordingly, setting `type="linear"`, `dot={false}`, `connectNulls`, and `isAnimationActive={false}` on the `Line` element. 
- Kept the same data building logic but explicitly filter out entries with invalid dates, non-numeric `bubbleCount`/`windowSeconds`, and `windowSeconds <= 0` in `buildBubbleActivityChartData`. 
- Updated the tooltip formatting and axis/time formatting remain unchanged while switching chart primitives. 
- Extended `BubbleActivityChart.test.tsx` to mock `recharts` components, assert the normalized data content and length, and verify the `Line` receives the expected props via `data-*` test attributes.

### Testing

- Ran the updated unit test file `BubbleActivityChart.test.tsx` under the project's Jest setup and the test suite passed. 
- Tests assert data normalization behavior including zero values and chronological gaps and they verify rendered `Line` props (`type`, `dot`, `connectNulls`, `isAnimationActive`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6aa3f243fa8c832f852f8347400d85c4)